### PR TITLE
[refactor] game→:room FK 영속 의존 제거 — RoomReferencePort 도입 (ADR-0025 후속, #1413 분리)

### DIFF
--- a/backend/admin/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
@@ -114,7 +114,7 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
                         MINI_GAME.count()
                 ))
                 .from(MINI_GAME)
-                .join(MINI_GAME.roomSession, ROOM)
+                .join(ROOM).on(ROOM.id.eq(MINI_GAME.roomSessionId))
                 .where(ROOM.createdAt.between(startDate, endDate))
                 .groupBy(MINI_GAME.miniGameType)
                 .orderBy(MINI_GAME.count().desc())
@@ -130,7 +130,7 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
         // 1단계: player_id로 GROUP BY하여 집계 (JOIN 없이)
         final List<Tuple> aggregations = queryFactory
                 .select(
-                        MINI_GAME_RESULT.player.id,
+                        MINI_GAME_RESULT.playerId,
                         MINI_GAME_RESULT.score.min()
                 )
                 .from(MINI_GAME_RESULT)
@@ -138,8 +138,8 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
                         MINI_GAME_RESULT.miniGameType.eq(MiniGameType.RACING_GAME),
                         MINI_GAME_RESULT.createdAt.between(startDate, endDate)
                 )
-                .groupBy(MINI_GAME_RESULT.player.id)
-                .orderBy(MINI_GAME_RESULT.score.min().asc(), MINI_GAME_RESULT.player.id.asc())
+                .groupBy(MINI_GAME_RESULT.playerId)
+                .orderBy(MINI_GAME_RESULT.score.min().asc(), MINI_GAME_RESULT.playerId.asc())
                 .limit(limit)
                 .fetch();
 
@@ -149,7 +149,7 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
 
         // 2단계: player_id 목록으로 player_name 조회
         final List<Long> playerIds = aggregations.stream()
-                .map(tuple -> tuple.get(MINI_GAME_RESULT.player.id))
+                .map(tuple -> tuple.get(MINI_GAME_RESULT.playerId))
                 .toList();
 
         final Map<Long, String> playerNameMap = queryFactory
@@ -166,7 +166,7 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
         // 3단계: 집계 결과와 player_name 매핑
         return aggregations.stream()
                 .map(tuple -> new RacingGameTopPlayerResponse(
-                        playerNameMap.get(tuple.get(MINI_GAME_RESULT.player.id)),
+                        playerNameMap.get(tuple.get(MINI_GAME_RESULT.playerId)),
                         tuple.get(MINI_GAME_RESULT.score.min())
                 ))
                 .toList();
@@ -185,7 +185,7 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
                         MINI_GAME_RESULT.score.max()
                 ))
                 .from(MINI_GAME_RESULT)
-                .join(MINI_GAME_RESULT.player, PLAYER)
+                .join(PLAYER).on(PLAYER.id.eq(MINI_GAME_RESULT.playerId))
                 .where(
                         MINI_GAME_RESULT.miniGameType.eq(MiniGameType.BLOCK_STACKING),
                         MINI_GAME_RESULT.createdAt.between(startDate, endDate)

--- a/backend/admin/src/test/java/coffeeshout/dashboard/application/DashboardServiceTest.java
+++ b/backend/admin/src/test/java/coffeeshout/dashboard/application/DashboardServiceTest.java
@@ -364,9 +364,9 @@ class DashboardServiceTest extends AdminModuleServiceTest {
             // given
             final RoomEntity room = roomJpaRepository.save(new RoomEntity("IIII"));
 
-            miniGameJpaRepository.save(new MiniGameEntity(room, MiniGameType.CARD_GAME));
-            miniGameJpaRepository.save(new MiniGameEntity(room, MiniGameType.CARD_GAME));
-            miniGameJpaRepository.save(new MiniGameEntity(room, MiniGameType.CARD_GAME));
+            miniGameJpaRepository.save(new MiniGameEntity(room.getId(),MiniGameType.CARD_GAME));
+            miniGameJpaRepository.save(new MiniGameEntity(room.getId(),MiniGameType.CARD_GAME));
+            miniGameJpaRepository.save(new MiniGameEntity(room.getId(),MiniGameType.CARD_GAME));
 
             // when
             final List<GamePlayCountResponse> result = dashboardService.getGamePlayCounts();
@@ -384,7 +384,7 @@ class DashboardServiceTest extends AdminModuleServiceTest {
 
             // CARD_GAME 5회
             for (int i = 0; i < 5; i++) {
-                miniGameJpaRepository.save(new MiniGameEntity(room, MiniGameType.CARD_GAME));
+                miniGameJpaRepository.save(new MiniGameEntity(room.getId(),MiniGameType.CARD_GAME));
             }
 
             // when
@@ -402,9 +402,9 @@ class DashboardServiceTest extends AdminModuleServiceTest {
             final RoomEntity room1 = roomJpaRepository.save(new RoomEntity("KKKK"));
             final RoomEntity room2 = roomJpaRepository.save(new RoomEntity("LLLL"));
 
-            miniGameJpaRepository.save(new MiniGameEntity(room1, MiniGameType.CARD_GAME));
-            miniGameJpaRepository.save(new MiniGameEntity(room1, MiniGameType.CARD_GAME));
-            miniGameJpaRepository.save(new MiniGameEntity(room2, MiniGameType.CARD_GAME));
+            miniGameJpaRepository.save(new MiniGameEntity(room1.getId(),MiniGameType.CARD_GAME));
+            miniGameJpaRepository.save(new MiniGameEntity(room1.getId(),MiniGameType.CARD_GAME));
+            miniGameJpaRepository.save(new MiniGameEntity(room2.getId(),MiniGameType.CARD_GAME));
 
             // when
             final List<GamePlayCountResponse> result = dashboardService.getGamePlayCounts();
@@ -434,16 +434,16 @@ class DashboardServiceTest extends AdminModuleServiceTest {
             // given
             final RoomEntity room = roomJpaRepository.save(new RoomEntity("MMNN"));
             final MiniGameEntity miniGame = miniGameJpaRepository.save(
-                    new MiniGameEntity(room, MiniGameType.BLOCK_STACKING)
+                    new MiniGameEntity(room.getId(),MiniGameType.BLOCK_STACKING)
             );
 
             final PlayerEntity 철수 = playerJpaRepository.save(new PlayerEntity(room, "철수", PlayerType.HOST));
             final PlayerEntity 영희 = playerJpaRepository.save(new PlayerEntity(room, "영희", PlayerType.GUEST));
             final PlayerEntity 민수 = playerJpaRepository.save(new PlayerEntity(room, "민수", PlayerType.GUEST));
 
-            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 철수, 1, 30L));
-            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 영희, 2, 20L));
-            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 민수, 3, 10L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 철수.getId(), 1, 30L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 영희.getId(), 2, 20L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 민수.getId(), 3, 10L));
 
             // when
             final List<BlockStackingTopPlayerResponse> result = dashboardService.getBlockStackingTopPlayers();
@@ -472,14 +472,14 @@ class DashboardServiceTest extends AdminModuleServiceTest {
             // given
             final RoomEntity room = roomJpaRepository.save(new RoomEntity("TTUV"));
             final MiniGameEntity miniGame = miniGameJpaRepository.save(
-                    new MiniGameEntity(room, MiniGameType.BLOCK_STACKING)
+                    new MiniGameEntity(room.getId(),MiniGameType.BLOCK_STACKING)
             );
 
             for (int i = 1; i <= 10; i++) {
                 final PlayerEntity player = playerJpaRepository.save(
                         new PlayerEntity(room, "플레이어" + i, PlayerType.GUEST)
                 );
-                miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, player, i, (long) i * 10));
+                miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, player.getId(), i, (long) i * 10));
             }
 
             // when
@@ -497,17 +497,17 @@ class DashboardServiceTest extends AdminModuleServiceTest {
             // given
             final RoomEntity room = roomJpaRepository.save(new RoomEntity("WWXX"));
             final MiniGameEntity blockStackingGame = miniGameJpaRepository.save(
-                    new MiniGameEntity(room, MiniGameType.BLOCK_STACKING)
+                    new MiniGameEntity(room.getId(),MiniGameType.BLOCK_STACKING)
             );
             final MiniGameEntity racingGame = miniGameJpaRepository.save(
-                    new MiniGameEntity(room, MiniGameType.RACING_GAME)
+                    new MiniGameEntity(room.getId(),MiniGameType.RACING_GAME)
             );
 
             final PlayerEntity 철수 = playerJpaRepository.save(new PlayerEntity(room, "철수", PlayerType.HOST));
             final PlayerEntity 영희 = playerJpaRepository.save(new PlayerEntity(room, "영희", PlayerType.GUEST));
 
-            miniGameResultJpaRepository.save(new MiniGameResultEntity(blockStackingGame, 철수, 1, 20L));
-            miniGameResultJpaRepository.save(new MiniGameResultEntity(racingGame, 영희, 1, 5000L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(blockStackingGame, 철수.getId(), 1, 20L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(racingGame, 영희.getId(), 1, 5000L));
 
             // when
             final List<BlockStackingTopPlayerResponse> result = dashboardService.getBlockStackingTopPlayers();

--- a/backend/app/src/test/java/coffeeshout/arch/GameArchitectureTest.java
+++ b/backend/app/src/test/java/coffeeshout/arch/GameArchitectureTest.java
@@ -100,29 +100,8 @@ public class GameArchitectureTest {
                     "coffeeshout.blindtimer.."
             ).as("minigame orchestration은 개별 게임 패키지를 직접 참조할 수 없다 — MiniGameFactory SPI를 통해 디스패치해야 한다");
 
-    /**
-     * [의도된 예외] MiniGamePersistenceService(game 모듈)가 room.infra.persistence 타입을 직접 사용.
-     *
-     * MiniGameEntity/MiniGameResultEntity의 JPA @ManyToOne이 RoomEntity/PlayerEntity를 참조하므로
-     * game → room.infra 의존은 JPA FK 구조상 단기 해소가 어렵다.
-     * 이 의존이 규칙 위반처럼 보일 수 있으나 설계상 허용된 예외다.
-     *
-     * 해소 방향: MiniGameEntity의 FK를 ID 참조(@Column)로 변경하면 room.infra 의존을 제거할 수 있음.
-     */
-    /**
-     * minigame.application의 room.infra 의존 중 JPA FK 구조상 허용된 클래스 목록:
-     * - MiniGamePersistenceService: MiniGameEntity의 RoomEntity FK 생성 (PlayerEntity 생성 책임은
-     *   PlayerSnapshotRequiredEvent로 :room에 이관됨 — ADR-0025 PlayerEntity 영속 책임 분리)
-     * - MiniGameEntityRepository: RoomEntity FK 파라미터
-     *
-     * 나머지 application 클래스는 room.infra를 참조해서는 안 된다.
-     */
-    @ArchTest
-    static final ArchRule minigame_persistence_외에는_room_infra를_참조할_수_없다 = noClasses()
-            .that().resideInAPackage("coffeeshout.minigame.application..")
-            .and().haveSimpleNameNotContaining("PersistenceService")
-            .and().haveSimpleNameNotContaining("EntityRepository")
-            .should().dependOnClassesThat()
-            .resideInAPackage("coffeeshout.room.infra..")
-            .as("minigame.application 중 JPA 영속성 관련 클래스를 제외하고는 room.infra를 참조할 수 없다");
+    // [제거됨] minigame_persistence_외에는_room_infra를_참조할_수_없다
+    // ADR-0025 FK 영속 책임 분리 완료(MiniGameEntity/MiniGameResultEntity FK → ID 참조)로 :game → room.infra
+    // 의존이 사라졌다. game → :room 전체 금지는 RoomGameSeparationArchitectureTest.game은_room을_직접_참조할_수_없다가
+    // room.domain·room.application·room.infra를 모두 포괄해 강제하므로, 부분 집합이던 이 규칙은 제거한다.
 }

--- a/backend/app/src/test/java/coffeeshout/arch/RoomGameSeparationArchitectureTest.java
+++ b/backend/app/src/test/java/coffeeshout/arch/RoomGameSeparationArchitectureTest.java
@@ -54,10 +54,9 @@ public class RoomGameSeparationArchitectureTest {
             .as("room.application의 게임 패키지 참조는 game-api 이벤트 in-process 리스너 3곳만 허용한다 (ADR-0025)");
 
     /**
-     * [의도된 예외] MiniGamePersistenceService는 PlayerEntity 영속 필드(name, playerType, userId)를
-     * 채우기 위해 room.getPlayers()의 Player에 접근한다. Gamer는 playerType을 갖지 않아 대체 불가.
-     * GameArchitectureTest의 room.infra JPA FK 예외와 같은 계열이며, 해소 방향도 동일하다
-     * (FK를 ID 참조로 변경 시 함께 제거 가능).
+     * :game은 room.domain.player를 참조할 수 없다 — 플레이어 식별은 Gamer(:game-api)를 사용한다.
+     * (ADR-0025 FK 영속 책임 분리 완료로, PlayerEntity 영속을 위해 Player에 접근하던
+     * MiniGamePersistenceService 예외가 제거됐다 — 이제 RoomReferencePort.findPlayerRefs로 ID·userId만 받는다.)
      */
     @ArchTest
     static final ArchRule game은_room_domain_player를_참조할_수_없다 = noClasses()
@@ -70,33 +69,22 @@ public class RoomGameSeparationArchitectureTest {
                     "coffeeshout.speedtouch..",
                     "coffeeshout.blindtimer.."
             )
-            .and().haveSimpleNameNotContaining("PersistenceService")
             .should().dependOnClassesThat()
             .resideInAPackage("coffeeshout.room.domain.player..")
             .as("게임 모듈은 room.domain.player를 참조할 수 없다 — 플레이어 식별은 Gamer(:game-api)를 사용한다 (ADR-0025)");
 
     /**
-     * [ADR-0025 재유입 방지] :game 게임 서비스·도메인·플로우 계층은 Room 애그리거트
-     * (coffeeshout.room.domain..)를 직접 참조할 수 없다. 게임 식별은 JoinCode, 플레이어 식별은 Gamer를
-     * 사용하며, 게임 인스턴스 조회는 GameSession을 경유한다. "joinCode를 얻으려 Room을 왕복 조회"하던
-     * 패턴(RoomQueryService.getByJoinCode → room.getJoinCode())의 재도입을 차단한다.
+     * [ADR-0025 재유입 방지] :game(게임 서비스·도메인·플로우·영속·UI)은 :room(coffeeshout.room..) 전체를
+     * 직접 참조할 수 없다. 게임 식별은 JoinCode, 플레이어 식별은 Gamer를 쓰고, 게임 인스턴스 조회는
+     * GameSession을 경유하며, :room의 식별·상태·영속이 필요하면 RoomReferencePort(:game-api)를 통한다.
+     * "joinCode를 얻으려 Room을 왕복 조회"하던 패턴(RoomQueryService.getByJoinCode)의 재도입도 차단한다.
      *
-     * <p>현 상태를 동결(freeze)해 신규 위반을 막는다. 아래는 현재 정당한 :game → room.domain 참조다.
-     * <ul>
-     *   <li>MiniGamePersistenceService : 결과 영속 시 Room/RoomState/Player 접근 (JPA FK 예외 계열 —
-     *       ADR-0025 후속 작업에서 MiniGameEntity의 RoomEntity FK·PlayerEntity 영속 책임 분리 예정)</li>
-     * </ul>
-     *
-     * <p>이전에 정당 참조였던 다음 클래스는 ADR-0025 결정 4·6 개정으로 :room 의존이 제거됐다.
-     * <ul>
-     *   <li>MiniGameEventService       : 게임 시작을 {@code GameStartReadyEvent}(in-process 동기)로 분리 — 명단은 :room이 실어 전달</li>
-     *   <li>MiniGameSelectConsumer     : 호스트 검증을 GameSession으로 이관(권위 세션 사전 생성, Option B)</li>
-     *   <li>GameSessionInit/CleanupConsumer : 생명주기 이벤트를 :game-api(GameRoomCreated/RemovedEvent)로 이전</li>
-     *   <li>PlayerHands                : 공용 {@code GameErrorCode}(:game-api)로 교체</li>
-     * </ul>
+     * <p>FK 영속 책임 분리 완료로, 이전의 정당 참조(MiniGamePersistenceService·MiniGameResultSaveEventListener의
+     * RoomEntity/PlayerEntity/RoomState/RoomQueryService 직접 참조)가 모두 제거돼 더 이상 예외 클래스가 없다.
+     * room.domain뿐 아니라 room.application·room.infra까지 포함한 :room 전체로 금지 범위를 격상한다.
      */
     @ArchTest
-    static final ArchRule game은_room_domain을_직접_참조할_수_없다 = noClasses()
+    static final ArchRule game은_room을_직접_참조할_수_없다 = noClasses()
             .that().resideInAnyPackage(
                     "coffeeshout.minigame..",
                     "coffeeshout.cardgame..",
@@ -106,9 +94,8 @@ public class RoomGameSeparationArchitectureTest {
                     "coffeeshout.speedtouch..",
                     "coffeeshout.blindtimer.."
             )
-            .and().haveSimpleNameNotContaining("MiniGamePersistenceService")
             .should().dependOnClassesThat()
-            .resideInAPackage("coffeeshout.room.domain..")
-            .as("게임 모듈은 Room 애그리거트(coffeeshout.room.domain..)를 직접 참조할 수 없다 "
-                    + "— 식별은 JoinCode/Gamer, 게임 조회는 GameSession 경유 (ADR-0025)");
+            .resideInAPackage("coffeeshout.room..")
+            .as("게임 모듈은 :room(coffeeshout.room..)을 직접 참조할 수 없다 "
+                    + "— 식별은 JoinCode/Gamer, 게임 조회는 GameSession, room 참조는 RoomReferencePort(:game-api) 경유 (ADR-0025)");
 }

--- a/backend/game-api/src/main/java/coffeeshout/gamecommon/PlayerRef.java
+++ b/backend/game-api/src/main/java/coffeeshout/gamecommon/PlayerRef.java
@@ -1,0 +1,14 @@
+package coffeeshout.gamecommon;
+
+/**
+ * {@code :game}이 결과 영속에 필요로 하는 플레이어 참조의 최소 표현. {@code PlayerEntity} 구체 타입을
+ * {@code :game}에 노출하지 않기 위한 DTO다.
+ *
+ * <ul>
+ *   <li>{@code id} — {@code mini_game_result.player_id} FK 값</li>
+ *   <li>{@code name} — score 맵 키(Gamer 이름)와 매칭하는 플레이어 이름</li>
+ *   <li>{@code userId} — 회원이면 UserStats 갱신에 사용, 게스트면 {@code null}</li>
+ * </ul>
+ */
+public record PlayerRef(Long id, String name, Long userId) {
+}

--- a/backend/game-api/src/main/java/coffeeshout/gamecommon/RoomReferencePort.java
+++ b/backend/game-api/src/main/java/coffeeshout/gamecommon/RoomReferencePort.java
@@ -1,0 +1,36 @@
+package coffeeshout.gamecommon;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@code :game} 영속 계층이 {@code :room}의 식별·상태를 참조하기 위한 포트. {@code :room}이 구현하고
+ * {@code :game}이 소비한다(room → game-api 의존만으로 성립).
+ *
+ * <p>MiniGameEntity의 RoomEntity FK·MiniGameResultEntity의 PlayerEntity FK를 ID 참조로 분리하면서,
+ * 게임 측이 {@code RoomEntity}/{@code PlayerEntity} 구체 타입을 모른 채 필요한 식별자
+ * (roomSessionId·playerId·userId)만 받도록 한다(ADR-0025 FK 영속 책임 분리 후속).
+ *
+ * <p>{@code GameRoomCreatedEvent} 등과 같이 {@code :room}이 생산하고 {@code :game}이 소비하는
+ * {@code gamecommon} 계약 계열이다.
+ */
+public interface RoomReferencePort {
+
+    /**
+     * joinCode에 해당하는 현재(가장 최근 생성) RoomSession의 ID를 조회한다. "어느 세션이 현재인가"의
+     * 판정은 {@code :room}이 소유한다 — joinCode 하나에 세션이 시간순으로 여러 개 존재할 수 있으므로
+     * joinCode를 그대로 FK로 들 수 없고 현재 세션 ID로 환원해야 한다.
+     */
+    Optional<Long> findCurrentRoomSessionId(String joinCode);
+
+    /**
+     * 현재 RoomSession의 영속 상태를 PLAYING으로 전이한다. {@code RoomState} 열거는 {@code :room}
+     * 내부에 가둔다.
+     */
+    void markRoomPlaying(String joinCode);
+
+    /**
+     * roomSessionId에 속한 플레이어 중 이름이 일치하는 참조(id·name·userId)를 조회한다.
+     */
+    List<PlayerRef> findPlayerRefs(Long roomSessionId, List<String> playerNames);
+}

--- a/backend/game/build.gradle.kts
+++ b/backend/game/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(project(":web"))
     implementation(project(":websocket"))
     implementation(project(":game-api"))
-    implementation(project(":room"))
     implementation(project(":user"))
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -28,6 +27,8 @@ dependencies {
     testFixturesImplementation(project(":game-api"))
     testFixturesImplementation(project(":test-support"))
     testImplementation(project(":test-support"))
+    // :game 프로덕션은 :room을 모르지만(FK ID 참조로 분리), 테스트는 Room/Player 도메인 픽스처를 사용한다.
+    testImplementation(project(":room"))
     testImplementation(testFixtures(project(":room")))
     // 테스트 컨텍스트가 coffeeshout 전체를 스캔하며 :room·:user 빈이 ProfanityChecker 구현체를 요구한다
     testImplementation(project(":profanity"))

--- a/backend/game/src/main/java/coffeeshout/minigame/application/MiniGamePersistenceService.java
+++ b/backend/game/src/main/java/coffeeshout/minigame/application/MiniGamePersistenceService.java
@@ -1,16 +1,13 @@
 package coffeeshout.minigame.application;
 
 import coffeeshout.gamecommon.JoinCode;
+import coffeeshout.gamecommon.RoomReferencePort;
 import coffeeshout.global.lock.RedisLock;
+import coffeeshout.minigame.application.port.MiniGameEntityRepository;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.minigame.event.GameStartReadyEvent;
 import coffeeshout.minigame.event.PlayerSnapshotRequiredEvent;
-import coffeeshout.minigame.application.port.MiniGameEntityRepository;
 import coffeeshout.minigame.infra.persistence.MiniGameEntity;
-import coffeeshout.room.application.port.RoomEntityRepository;
-import coffeeshout.room.application.port.RoomStatusPort;
-import coffeeshout.room.domain.RoomState;
-import coffeeshout.room.infra.persistence.RoomEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -21,9 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MiniGamePersistenceService {
 
     private final GameSessionService gameSessionService;
-    private final RoomEntityRepository roomEntityRepository;
+    private final RoomReferencePort roomReferencePort;
     private final MiniGameEntityRepository miniGameEntityRepository;
-    private final RoomStatusPort roomStatusPort;
     private final ApplicationEventPublisher eventPublisher;
 
     @RedisLock(
@@ -37,9 +33,12 @@ public class MiniGamePersistenceService {
     public void saveGameEntities(GameStartReadyEvent event, MiniGameType miniGameType) {
         final JoinCode roomJoinCode = new JoinCode(event.joinCode());
 
-        final RoomEntity roomEntity = getRoomEntity(event.joinCode());
-        roomStatusPort.updateStatus(roomEntity, RoomState.PLAYING);
-        final MiniGameEntity miniGameEntity = new MiniGameEntity(roomEntity, miniGameType);
+        // 현재 RoomSession ID로 환원해 FK를 ID 참조로 들고, 방 영속 상태를 PLAYING으로 전이한다(:room이 소유).
+        final Long roomSessionId = roomReferencePort.findCurrentRoomSessionId(event.joinCode())
+                .orElseThrow(() -> new IllegalArgumentException("방이 존재하지 않습니다: " + event.joinCode()));
+        roomReferencePort.markRoomPlaying(event.joinCode());
+
+        final MiniGameEntity miniGameEntity = new MiniGameEntity(roomSessionId, miniGameType);
         miniGameEntityRepository.save(miniGameEntity);
 
         // 첫 게임 시작 여부는 게임 수 상태를 소유한 GameSession이 판정한다(ADR-0025 Step 5).
@@ -48,10 +47,5 @@ public class MiniGamePersistenceService {
         if (gameSessionService.getSession(roomJoinCode).isFirstGameStarted()) {
             eventPublisher.publishEvent(new PlayerSnapshotRequiredEvent(event.joinCode()));
         }
-    }
-
-    private RoomEntity getRoomEntity(String joinCode) {
-        return roomEntityRepository.findFirstByJoinCodeOrderByCreatedAtDesc(joinCode)
-                .orElseThrow(() -> new IllegalArgumentException("방이 존재하지 않습니다: " + joinCode));
     }
 }

--- a/backend/game/src/main/java/coffeeshout/minigame/application/port/MiniGameEntityRepository.java
+++ b/backend/game/src/main/java/coffeeshout/minigame/application/port/MiniGameEntityRepository.java
@@ -2,12 +2,11 @@ package coffeeshout.minigame.application.port;
 
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.minigame.infra.persistence.MiniGameEntity;
-import coffeeshout.room.infra.persistence.RoomEntity;
 import java.util.Optional;
 
 public interface MiniGameEntityRepository {
 
     MiniGameEntity save(MiniGameEntity miniGameEntity);
 
-    Optional<MiniGameEntity> findByRoomSessionAndMiniGameType(RoomEntity roomSession, MiniGameType miniGameType);
+    Optional<MiniGameEntity> findByRoomSessionIdAndMiniGameType(Long roomSessionId, MiniGameType miniGameType);
 }

--- a/backend/game/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
+++ b/backend/game/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
@@ -3,6 +3,8 @@ package coffeeshout.minigame.event;
 import coffeeshout.gamecommon.Gamer;
 import coffeeshout.gamecommon.JoinCode;
 import coffeeshout.gamecommon.Playable;
+import coffeeshout.gamecommon.PlayerRef;
+import coffeeshout.gamecommon.RoomReferencePort;
 import coffeeshout.global.lock.RedisLock;
 import coffeeshout.minigame.application.GameSessionService;
 import coffeeshout.minigame.domain.MiniGameResult;
@@ -13,10 +15,6 @@ import coffeeshout.minigame.infra.persistence.MiniGameEntity;
 import coffeeshout.minigame.infra.persistence.MiniGameJpaRepository;
 import coffeeshout.minigame.infra.persistence.MiniGameResultEntity;
 import coffeeshout.minigame.infra.persistence.MiniGameResultJpaRepository;
-import coffeeshout.room.infra.persistence.PlayerEntity;
-import coffeeshout.room.infra.persistence.PlayerJpaRepository;
-import coffeeshout.room.infra.persistence.RoomEntity;
-import coffeeshout.room.infra.persistence.RoomJpaRepository;
 import coffeeshout.user.application.service.UserStatsService;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
@@ -35,8 +33,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MiniGameResultSaveEventListener {
 
-    private final RoomJpaRepository roomJpaRepository;
-    private final PlayerJpaRepository playerJpaRepository;
+    private final RoomReferencePort roomReferencePort;
     private final MiniGameJpaRepository miniGameJpaRepository;
     private final MiniGameResultJpaRepository miniGameResultJpaRepository;
     private final GameSessionService gameSessionService;
@@ -55,12 +52,12 @@ public class MiniGameResultSaveEventListener {
             leaseTime = 5000
     )
     public void handle(MiniGameFinishedEvent event) {
-        final RoomEntity roomEntity = roomJpaRepository.findFirstByJoinCodeOrderByCreatedAtDesc(event.joinCode())
+        final Long roomSessionId = roomReferencePort.findCurrentRoomSessionId(event.joinCode())
                 .orElseThrow(() -> new IllegalArgumentException("방이 존재하지 않습니다: " + event.joinCode()));
         final MiniGameType miniGameType = MiniGameType.valueOf(event.miniGameType());
 
         final MiniGameEntity miniGameEntity = miniGameJpaRepository
-                .findByRoomSessionAndMiniGameType(roomEntity, miniGameType)
+                .findByRoomSessionIdAndMiniGameType(roomSessionId, miniGameType)
                 .orElseThrow(() -> new IllegalArgumentException("미니게임 엔티티가 존재하지 않습니다: " + event.joinCode()));
 
         final Playable miniGame = gameSessionService.getSession(new JoinCode(event.joinCode()))
@@ -73,44 +70,43 @@ public class MiniGameResultSaveEventListener {
                 .map(Gamer::getName)
                 .toList();
 
-        final Map<String, PlayerEntity> playerEntityMap = playerJpaRepository
-                .findByRoomSessionAndPlayerNameIn(roomEntity, playerNames)
+        final Map<String, PlayerRef> playerRefMap = roomReferencePort
+                .findPlayerRefs(roomSessionId, playerNames)
                 .stream()
                 .collect(Collectors.toMap(
-                        PlayerEntity::getPlayerName,
+                        PlayerRef::name,
                         Function.identity(),
                         (existing, replacement) -> existing
                 ));
 
         final List<MiniGameResultEntity> resultEntities = new ArrayList<>();
+        // PlayerEntity 참조가 사라져 저장 후 엔티티에서 userId를 다시 읽을 수 없으므로,
+        // 결과 조립 시점에 PlayerRef.userId를 캡처해 stats 갱신 목록을 함께 만든다.
+        final List<StatUpdate> statUpdates = new ArrayList<>();
 
         for (Map.Entry<Gamer, MiniGameScore> entry : scores.entrySet()) {
             final Gamer gamer = entry.getKey();
-            final PlayerEntity playerEntity = playerEntityMap.get(gamer.getName());
-            if (playerEntity == null) {
+            final PlayerRef playerRef = playerRefMap.get(gamer.getName());
+            if (playerRef == null) {
                 throw new IllegalArgumentException("플레이어가 존재하지 않습니다: " + gamer.getName());
             }
 
             final Integer rank = result.getPlayerRank(gamer);
             final Long score = entry.getValue().getValue();
 
-            resultEntities.add(new MiniGameResultEntity(
-                    miniGameEntity,
-                    playerEntity,
-                    rank,
-                    score
-            ));
+            resultEntities.add(new MiniGameResultEntity(miniGameEntity, playerRef.id(), rank, score));
+            if (playerRef.userId() != null) {
+                statUpdates.add(new StatUpdate(playerRef.userId(), rank == 1));
+            }
         }
 
         miniGameResultJpaRepository.bulkInsert(resultEntities);
 
-        resultEntities.stream()
-                .filter(entity -> entity.getPlayer().getUserId() != null)
-                .forEach(entity -> userStatsService.updateStats(
-                        entity.getPlayer().getUserId(),
-                        entity.getRank() == 1
-                ));
+        statUpdates.forEach(statUpdate -> userStatsService.updateStats(statUpdate.userId(), statUpdate.winner()));
 
         log.info("미니게임 결과 벌크 저장 완료: joinCode={}, playerCount={}", event.joinCode(), resultEntities.size());
+    }
+
+    private record StatUpdate(Long userId, boolean winner) {
     }
 }

--- a/backend/game/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameEntity.java
+++ b/backend/game/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameEntity.java
@@ -1,17 +1,13 @@
 package coffeeshout.minigame.infra.persistence;
 
 import coffeeshout.minigame.domain.MiniGameType;
-import coffeeshout.room.infra.persistence.RoomEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,16 +23,16 @@ public class MiniGameEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "room_session_id", nullable = false)
-    private RoomEntity roomSession;
+    // RoomEntity FK를 ID 참조로 분리한다(ADR-0025 FK 영속 책임 분리) — :game이 :room.infra를 모르게 한다.
+    @Column(name = "room_session_id", nullable = false)
+    private Long roomSessionId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private MiniGameType miniGameType;
 
-    public MiniGameEntity(RoomEntity roomSession, MiniGameType miniGameType) {
-        this.roomSession = roomSession;
+    public MiniGameEntity(Long roomSessionId, MiniGameType miniGameType) {
+        this.roomSessionId = roomSessionId;
         this.miniGameType = miniGameType;
     }
 }

--- a/backend/game/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultBulkRepositoryImpl.java
+++ b/backend/game/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultBulkRepositoryImpl.java
@@ -29,7 +29,7 @@ public class MiniGameResultBulkRepositoryImpl implements MiniGameResultBulkRepos
             public void setValues(PreparedStatement ps, int i) throws SQLException {
                 final MiniGameResultEntity entity = resultEntities.get(i);
                 ps.setLong(1, entity.getMiniGamePlay().getId());
-                ps.setLong(2, entity.getPlayer().getId());
+                ps.setLong(2, entity.getPlayerId());
                 ps.setInt(3, entity.getRank());
                 ps.setLong(4, entity.getScore());
                 ps.setString(5, entity.getMiniGameType().name());

--- a/backend/game/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultEntity.java
+++ b/backend/game/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultEntity.java
@@ -1,7 +1,6 @@
 package coffeeshout.minigame.infra.persistence;
 
 import coffeeshout.minigame.domain.MiniGameType;
-import coffeeshout.room.infra.persistence.PlayerEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -32,9 +31,9 @@ public class MiniGameResultEntity {
     @JoinColumn(name = "mini_game_play_id", nullable = false)
     private MiniGameEntity miniGamePlay;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "player_id", nullable = false)
-    private PlayerEntity player;
+    // PlayerEntity FK를 ID 참조로 분리한다(ADR-0025 FK 영속 책임 분리) — :game이 :room.infra를 모르게 한다.
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
 
     @Column(name = "player_rank", nullable = false)
     private Integer rank;
@@ -49,9 +48,9 @@ public class MiniGameResultEntity {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    public MiniGameResultEntity(MiniGameEntity miniGamePlay, PlayerEntity player, Integer rank, Long score) {
+    public MiniGameResultEntity(MiniGameEntity miniGamePlay, Long playerId, Integer rank, Long score) {
         this.miniGamePlay = miniGamePlay;
-        this.player = player;
+        this.playerId = playerId;
         this.rank = rank;
         this.score = score;
         this.miniGameType = miniGamePlay.getMiniGameType();

--- a/backend/game/src/main/java/coffeeshout/minigame/ui/MiniGameRestController.java
+++ b/backend/game/src/main/java/coffeeshout/minigame/ui/MiniGameRestController.java
@@ -2,6 +2,8 @@ package coffeeshout.minigame.ui;
 
 import coffeeshout.gamecommon.Gamer;
 import coffeeshout.gamecommon.JoinCode;
+import coffeeshout.global.exception.GlobalErrorCode;
+import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.minigame.application.GameSessionService;
 import coffeeshout.minigame.domain.MiniGameResult;
 import coffeeshout.minigame.domain.MiniGameScore;
@@ -9,7 +11,6 @@ import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.minigame.ui.response.MiniGameRanksResponse;
 import coffeeshout.minigame.ui.response.MiniGameScoresResponse;
 import coffeeshout.minigame.ui.response.RemainingMiniGameResponse;
-import coffeeshout.room.application.service.RoomQueryService;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MiniGameRestController implements MiniGameApi {
 
     private final GameSessionService gameSessionService;
-    private final RoomQueryService roomQueryService;
 
     @GetMapping("/minigames/scores")
     public ResponseEntity<MiniGameScoresResponse> getScores(
@@ -76,12 +76,16 @@ public class MiniGameRestController implements MiniGameApi {
     }
 
     /**
-     * 존재하지 않는 방은 404로 거부한다(이전 {@code :room} 엔드포인트의 응답 계약 유지). 세션은 게임 선택
-     * 시점에 지연 생성되므로(Step 6의 {@code initSession} 도입 전) 세션 부재만으로는 방 부재를 판별할 수 없다.
+     * 존재하지 않는 방은 404로 거부한다(이전 {@code :room} 엔드포인트의 응답 계약 유지). GameSession은 방 생성
+     * 시점에 {@code GameSessionInitConsumer}가 사전 생성하고 방 삭제 시 정리하므로 방과 1:1 대응한다
+     * (ADR-0025 결정 6 — 지연 생성 폐지). 따라서 세션 부재를 방 부재로 판정할 수 있어 {@code :room} 조회 없이
+     * 동일한 404 계약을 유지한다.
      */
     private JoinCode validateRoomExists(String joinCode) {
         final JoinCode code = new JoinCode(joinCode);
-        roomQueryService.getByJoinCode(code);
+        if (gameSessionService.findSession(code).isEmpty()) {
+            throw new BusinessException(GlobalErrorCode.NOT_EXIST, "방이 존재하지 않습니다.");
+        }
         return code;
     }
 }

--- a/backend/game/src/test/java/coffeeshout/minigame/application/MiniGamePersistenceServiceTest.java
+++ b/backend/game/src/test/java/coffeeshout/minigame/application/MiniGamePersistenceServiceTest.java
@@ -7,14 +7,12 @@ import static org.mockito.Mockito.verify;
 
 import coffeeshout.gamecommon.Gamer;
 import coffeeshout.gamecommon.JoinCode;
+import coffeeshout.gamecommon.RoomReferencePort;
 import coffeeshout.minigame.application.port.MiniGameEntityRepository;
 import coffeeshout.minigame.domain.GameSession;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.minigame.event.GameStartReadyEvent;
 import coffeeshout.minigame.event.PlayerSnapshotRequiredEvent;
-import coffeeshout.room.application.port.RoomEntityRepository;
-import coffeeshout.room.application.port.RoomStatusPort;
-import coffeeshout.room.infra.persistence.RoomEntity;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -32,24 +30,19 @@ import org.springframework.context.ApplicationEventPublisher;
 class MiniGamePersistenceServiceTest {
 
     private static final String JOIN_CODE = "ABCD";
+    private static final Long ROOM_SESSION_ID = 1L;
 
     @Mock
     private GameSessionService gameSessionService;
 
     @Mock
-    private RoomEntityRepository roomEntityRepository;
+    private RoomReferencePort roomReferencePort;
 
     @Mock
     private MiniGameEntityRepository miniGameEntityRepository;
 
     @Mock
-    private RoomStatusPort roomStatusPort;
-
-    @Mock
     private ApplicationEventPublisher eventPublisher;
-
-    @Mock
-    private RoomEntity roomEntity;
 
     @Mock
     private GameSession gameSession;
@@ -60,9 +53,8 @@ class MiniGamePersistenceServiceTest {
     void setUp() {
         service = new MiniGamePersistenceService(
                 gameSessionService,
-                roomEntityRepository,
+                roomReferencePort,
                 miniGameEntityRepository,
-                roomStatusPort,
                 eventPublisher
         );
     }
@@ -77,8 +69,8 @@ class MiniGamePersistenceServiceTest {
 
         @BeforeEach
         void 방과_세션을_스텁한다() {
-            given(roomEntityRepository.findFirstByJoinCodeOrderByCreatedAtDesc(JOIN_CODE))
-                    .willReturn(Optional.of(roomEntity));
+            given(roomReferencePort.findCurrentRoomSessionId(JOIN_CODE))
+                    .willReturn(Optional.of(ROOM_SESSION_ID));
             given(gameSessionService.getSession(new JoinCode(JOIN_CODE))).willReturn(gameSession);
         }
 

--- a/backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveEventListenerTest.java
+++ b/backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveEventListenerTest.java
@@ -13,6 +13,8 @@ import coffeeshout.fixture.PlayerFixture;
 import coffeeshout.gamecommon.Gamer;
 import coffeeshout.gamecommon.JoinCode;
 import coffeeshout.gamecommon.Playable;
+import coffeeshout.gamecommon.PlayerRef;
+import coffeeshout.gamecommon.RoomReferencePort;
 import coffeeshout.minigame.application.GameSessionService;
 import coffeeshout.minigame.domain.GameSession;
 import coffeeshout.minigame.domain.MiniGameResult;
@@ -23,10 +25,6 @@ import coffeeshout.minigame.infra.persistence.MiniGameEntity;
 import coffeeshout.minigame.infra.persistence.MiniGameJpaRepository;
 import coffeeshout.minigame.infra.persistence.MiniGameResultJpaRepository;
 import coffeeshout.room.domain.player.Player;
-import coffeeshout.room.infra.persistence.PlayerEntity;
-import coffeeshout.room.infra.persistence.PlayerJpaRepository;
-import coffeeshout.room.infra.persistence.RoomEntity;
-import coffeeshout.room.infra.persistence.RoomJpaRepository;
 import coffeeshout.user.application.service.UserStatsService;
 import java.util.List;
 import java.util.Map;
@@ -41,13 +39,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MiniGameResultSaveEventListenerTest {
 
+    private static final String JOIN_CODE = "AB3C";
+    private static final Long ROOM_SESSION_ID = 1L;
+
     @InjectMocks
     MiniGameResultSaveEventListener listener;
 
     @Mock
-    RoomJpaRepository roomJpaRepository;
-    @Mock
-    PlayerJpaRepository playerJpaRepository;
+    RoomReferencePort roomReferencePort;
     @Mock
     MiniGameJpaRepository miniGameJpaRepository;
     @Mock
@@ -56,8 +55,6 @@ class MiniGameResultSaveEventListenerTest {
     GameSessionService gameSessionService;
     @Mock
     UserStatsService userStatsService;
-
-    private static final String JOIN_CODE = "AB3C";
 
     @Nested
     class 게임_종료_시_UserStats_자동_업데이트 {
@@ -73,14 +70,14 @@ class MiniGameResultSaveEventListenerTest {
                     루키.toGamer(), new CardGameScore(80)
             );
 
-            RoomEntity roomEntity = 룸엔티티_설정();
-            미니게임엔티티_설정(roomEntity);
+            룸세션_설정();
+            미니게임엔티티_설정();
             게임세션_설정(result, scores);
 
-            PlayerEntity 한스Entity = 플레이어엔티티("한스", 1L);
-            PlayerEntity 루키Entity = 플레이어엔티티("루키", 2L);
-            when(playerJpaRepository.findByRoomSessionAndPlayerNameIn(eq(roomEntity), any()))
-                    .thenReturn(List.of(한스Entity, 루키Entity));
+            플레이어참조_설정(
+                    new PlayerRef(10L, 한스.toGamer().getName(), 1L),
+                    new PlayerRef(20L, 루키.toGamer().getName(), 2L)
+            );
 
             listener.handle(미니게임종료이벤트(result));
 
@@ -99,14 +96,14 @@ class MiniGameResultSaveEventListenerTest {
                     루키.toGamer(), new CardGameScore(80)
             );
 
-            RoomEntity roomEntity = 룸엔티티_설정();
-            미니게임엔티티_설정(roomEntity);
+            룸세션_설정();
+            미니게임엔티티_설정();
             게임세션_설정(result, scores);
 
-            PlayerEntity 한스Entity = 플레이어엔티티("한스", 1L);   // 회원
-            PlayerEntity 루키Entity = 플레이어엔티티("루키", null);  // 게스트
-            when(playerJpaRepository.findByRoomSessionAndPlayerNameIn(eq(roomEntity), any()))
-                    .thenReturn(List.of(한스Entity, 루키Entity));
+            플레이어참조_설정(
+                    new PlayerRef(10L, 한스.toGamer().getName(), 1L),    // 회원
+                    new PlayerRef(20L, 루키.toGamer().getName(), null)   // 게스트
+            );
 
             listener.handle(미니게임종료이벤트(result));
 
@@ -125,14 +122,14 @@ class MiniGameResultSaveEventListenerTest {
                     루키.toGamer(), new CardGameScore(80)
             );
 
-            RoomEntity roomEntity = 룸엔티티_설정();
-            미니게임엔티티_설정(roomEntity);
+            룸세션_설정();
+            미니게임엔티티_설정();
             게임세션_설정(result, scores);
 
-            PlayerEntity 한스Entity = 플레이어엔티티("한스", null);
-            PlayerEntity 루키Entity = 플레이어엔티티("루키", null);
-            when(playerJpaRepository.findByRoomSessionAndPlayerNameIn(eq(roomEntity), any()))
-                    .thenReturn(List.of(한스Entity, 루키Entity));
+            플레이어참조_설정(
+                    new PlayerRef(10L, 한스.toGamer().getName(), null),
+                    new PlayerRef(20L, 루키.toGamer().getName(), null)
+            );
 
             listener.handle(미니게임종료이벤트(result));
 
@@ -144,16 +141,14 @@ class MiniGameResultSaveEventListenerTest {
         return new MiniGameFinishedEvent(JOIN_CODE, MiniGameType.CARD_GAME.name(), result.toRankMap(), 1);
     }
 
-    private RoomEntity 룸엔티티_설정() {
-        RoomEntity roomEntity = mock(RoomEntity.class);
-        when(roomJpaRepository.findFirstByJoinCodeOrderByCreatedAtDesc(JOIN_CODE))
-                .thenReturn(Optional.of(roomEntity));
-        return roomEntity;
+    private void 룸세션_설정() {
+        when(roomReferencePort.findCurrentRoomSessionId(JOIN_CODE))
+                .thenReturn(Optional.of(ROOM_SESSION_ID));
     }
 
-    private void 미니게임엔티티_설정(RoomEntity roomEntity) {
+    private void 미니게임엔티티_설정() {
         MiniGameEntity miniGameEntity = mock(MiniGameEntity.class);
-        when(miniGameJpaRepository.findByRoomSessionAndMiniGameType(roomEntity, MiniGameType.CARD_GAME))
+        when(miniGameJpaRepository.findByRoomSessionIdAndMiniGameType(ROOM_SESSION_ID, MiniGameType.CARD_GAME))
                 .thenReturn(Optional.of(miniGameEntity));
     }
 
@@ -167,10 +162,8 @@ class MiniGameResultSaveEventListenerTest {
         when(gameSessionService.getSession(new JoinCode(JOIN_CODE))).thenReturn(session);
     }
 
-    private PlayerEntity 플레이어엔티티(String name, Long userId) {
-        PlayerEntity entity = mock(PlayerEntity.class);
-        when(entity.getPlayerName()).thenReturn(name);
-        when(entity.getUserId()).thenReturn(userId);
-        return entity;
+    private void 플레이어참조_설정(PlayerRef... refs) {
+        when(roomReferencePort.findPlayerRefs(eq(ROOM_SESSION_ID), any()))
+                .thenReturn(List.of(refs));
     }
 }

--- a/backend/game/src/test/java/coffeeshout/minigame/ui/MiniGameRestControllerTest.java
+++ b/backend/game/src/test/java/coffeeshout/minigame/ui/MiniGameRestControllerTest.java
@@ -1,0 +1,73 @@
+package coffeeshout.minigame.ui;
+
+import static coffeeshout.support.ExceptionAssertions.assertCoffeeShoutException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import coffeeshout.gamecommon.JoinCode;
+import coffeeshout.global.exception.GlobalErrorCode;
+import coffeeshout.minigame.application.GameSessionService;
+import coffeeshout.minigame.domain.GameSession;
+import coffeeshout.minigame.domain.MiniGameType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MiniGameRestController")
+class MiniGameRestControllerTest {
+
+    private static final String JOIN_CODE = "ABCD";
+
+    @Mock
+    private GameSessionService gameSessionService;
+
+    @InjectMocks
+    private MiniGameRestController controller;
+
+    @Nested
+    @DisplayName("방 존재 검증이 필요한 조회는 (RoomQueryService→GameSession 1:1 대응으로 전환)")
+    class 방_존재_검증 {
+
+        @Test
+        @DisplayName("세션이 없으면(=방 없음) NOT_EXIST(404)로 거부한다")
+        void 세션이_없으면_404로_거부한다() {
+            given(gameSessionService.findSession(new JoinCode(JOIN_CODE))).willReturn(Optional.empty());
+
+            assertCoffeeShoutException(
+                    () -> controller.getSelectedMiniGames(JOIN_CODE),
+                    GlobalErrorCode.NOT_EXIST
+            );
+        }
+
+        @Test
+        @DisplayName("세션이 있으면 선택된 미니게임 타입 목록을 반환한다")
+        void 세션이_있으면_선택_목록을_반환한다() {
+            given(gameSessionService.findSession(new JoinCode(JOIN_CODE)))
+                    .willReturn(Optional.of(mock(GameSession.class)));
+            given(gameSessionService.getSelectedTypes(new JoinCode(JOIN_CODE)))
+                    .willReturn(List.of(MiniGameType.CARD_GAME));
+
+            assertThat(controller.getSelectedMiniGames(JOIN_CODE).getBody())
+                    .containsExactly(MiniGameType.CARD_GAME);
+        }
+
+        @Test
+        @DisplayName("remaining 조회도 세션이 없으면 NOT_EXIST(404)로 거부한다")
+        void remaining_조회도_세션이_없으면_404로_거부한다() {
+            given(gameSessionService.findSession(new JoinCode(JOIN_CODE))).willReturn(Optional.empty());
+
+            assertCoffeeShoutException(
+                    () -> controller.getRemainingMiniGames(JOIN_CODE),
+                    GlobalErrorCode.NOT_EXIST
+            );
+        }
+    }
+}

--- a/backend/room/src/main/java/coffeeshout/room/infra/persistence/PlayerJpaRepository.java
+++ b/backend/room/src/main/java/coffeeshout/room/infra/persistence/PlayerJpaRepository.java
@@ -9,4 +9,7 @@ public interface PlayerJpaRepository extends Repository<PlayerEntity, Long>, Pla
     @Override
     @Query("SELECT p FROM PlayerEntity p JOIN FETCH p.roomSession WHERE p.playerName = :playerName")
     java.util.List<PlayerEntity> findAllByPlayerName(String playerName);
+
+    // RoomReferencePort 구현용 — :game이 RoomEntity 없이 roomSessionId만으로 플레이어를 조회한다.
+    java.util.List<PlayerEntity> findByRoomSessionIdAndPlayerNameIn(Long roomSessionId, java.util.List<String> playerNames);
 }

--- a/backend/room/src/main/java/coffeeshout/room/infra/persistence/RoomReferenceAdapter.java
+++ b/backend/room/src/main/java/coffeeshout/room/infra/persistence/RoomReferenceAdapter.java
@@ -1,0 +1,44 @@
+package coffeeshout.room.infra.persistence;
+
+import coffeeshout.gamecommon.PlayerRef;
+import coffeeshout.gamecommon.RoomReferencePort;
+import coffeeshout.room.domain.RoomState;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link RoomReferencePort}의 {@code :room} 구현. {@code :game} 영속 계층이 RoomEntity/PlayerEntity
+ * 구체 타입 없이 식별자만으로 동작하도록, "현재 세션" 판정·PLAYING 전이·플레이어 참조 조회를 :room 안에
+ * 가둔다(ADR-0025 FK 영속 책임 분리 후속).
+ *
+ * <p>{@code markRoomPlaying}은 호출자(:game 영속 서비스)의 {@code @Transactional} 안에서 실행돼
+ * 더티 체킹으로 flush된다 — {@link RoomStatusAdapter}의 joinCode 기반 전이와 동일한 방식이다.
+ */
+@Component
+@RequiredArgsConstructor
+public class RoomReferenceAdapter implements RoomReferencePort {
+
+    private final RoomJpaRepository roomJpaRepository;
+    private final PlayerJpaRepository playerJpaRepository;
+
+    @Override
+    public Optional<Long> findCurrentRoomSessionId(String joinCode) {
+        return roomJpaRepository.findFirstByJoinCodeOrderByCreatedAtDesc(joinCode)
+                .map(RoomEntity::getId);
+    }
+
+    @Override
+    public void markRoomPlaying(String joinCode) {
+        roomJpaRepository.findFirstByJoinCodeOrderByCreatedAtDesc(joinCode)
+                .ifPresent(roomEntity -> roomEntity.updateRoomStatus(RoomState.PLAYING));
+    }
+
+    @Override
+    public List<PlayerRef> findPlayerRefs(Long roomSessionId, List<String> playerNames) {
+        return playerJpaRepository.findByRoomSessionIdAndPlayerNameIn(roomSessionId, playerNames).stream()
+                .map(player -> new PlayerRef(player.getId(), player.getPlayerName(), player.getUserId()))
+                .toList();
+    }
+}

--- a/backend/room/src/test/java/coffeeshout/room/infra/persistence/RoomReferenceAdapterTest.java
+++ b/backend/room/src/test/java/coffeeshout/room/infra/persistence/RoomReferenceAdapterTest.java
@@ -1,0 +1,123 @@
+package coffeeshout.room.infra.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.RoomModuleServiceTest;
+import coffeeshout.gamecommon.PlayerRef;
+import coffeeshout.room.domain.RoomState;
+import coffeeshout.room.domain.player.PlayerType;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("RoomReferenceAdapter")
+class RoomReferenceAdapterTest extends RoomModuleServiceTest {
+
+    @Autowired
+    private RoomReferenceAdapter roomReferenceAdapter;
+
+    @Autowired
+    private RoomJpaRepository roomJpaRepository;
+
+    @Autowired
+    private PlayerJpaRepository playerJpaRepository;
+
+    @Nested
+    @DisplayName("findCurrentRoomSessionId는")
+    class FindCurrentRoomSessionId {
+
+        @Test
+        @DisplayName("joinCode에 해당하는 RoomSession의 ID를 반환한다")
+        void 방_세션_ID를_반환한다() {
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("ABCD"));
+
+            final Optional<Long> result = roomReferenceAdapter.findCurrentRoomSessionId("ABCD");
+
+            assertThat(result).contains(room.getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 joinCode면 빈 Optional을 반환한다")
+        void 존재하지_않으면_빈_Optional을_반환한다() {
+            final Optional<Long> result = roomReferenceAdapter.findCurrentRoomSessionId("ZZZZ");
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("markRoomPlaying은")
+    class MarkRoomPlaying {
+
+        @Test
+        @DisplayName("RoomSession의 상태를 PLAYING으로 전이한다")
+        void 상태를_PLAYING으로_전이한다() {
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("BCDE"));
+            assertThat(room.getRoomStatus()).isEqualTo(RoomState.READY);
+
+            roomReferenceAdapter.markRoomPlaying("BCDE");
+
+            final RoomEntity reloaded = roomJpaRepository.findFirstByJoinCodeOrderByCreatedAtDesc("BCDE")
+                    .orElseThrow();
+            assertThat(reloaded.getRoomStatus()).isEqualTo(RoomState.PLAYING);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 joinCode면 예외 없이 무시한다")
+        void 존재하지_않으면_무시한다() {
+            roomReferenceAdapter.markRoomPlaying("ZZZZ");
+        }
+    }
+
+    @Nested
+    @DisplayName("findPlayerRefs는")
+    class FindPlayerRefs {
+
+        @Test
+        @DisplayName("roomSessionId와 이름이 일치하는 플레이어의 id·name·userId를 반환한다")
+        void 일치하는_플레이어_참조를_반환한다() {
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("CDEF"));
+            final PlayerEntity 한스 = playerJpaRepository.save(new PlayerEntity(room, "한스", PlayerType.HOST, 1L));
+            final PlayerEntity 루키 = playerJpaRepository.save(new PlayerEntity(room, "루키", PlayerType.GUEST, null));
+
+            final List<PlayerRef> refs = roomReferenceAdapter.findPlayerRefs(room.getId(), List.of("한스", "루키"));
+
+            assertThat(refs).containsExactlyInAnyOrder(
+                    new PlayerRef(한스.getId(), "한스", 1L),
+                    new PlayerRef(루키.getId(), "루키", null)
+            );
+        }
+
+        @Test
+        @DisplayName("이름 목록에 없는 플레이어는 제외한다")
+        void 이름에_없는_플레이어는_제외한다() {
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("DEFG"));
+            playerJpaRepository.save(new PlayerEntity(room, "한스", PlayerType.HOST, 1L));
+            playerJpaRepository.save(new PlayerEntity(room, "미선택", PlayerType.GUEST, 2L));
+
+            final List<PlayerRef> refs = roomReferenceAdapter.findPlayerRefs(room.getId(), List.of("한스"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(refs).hasSize(1);
+                softly.assertThat(refs.getFirst().name()).isEqualTo("한스");
+            });
+        }
+
+        @Test
+        @DisplayName("다른 RoomSession의 동일 이름 플레이어는 제외한다")
+        void 다른_방의_동일_이름은_제외한다() {
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("EFGH"));
+            final RoomEntity otherRoom = roomJpaRepository.save(new RoomEntity("FGHI"));
+            final PlayerEntity 한스 = playerJpaRepository.save(new PlayerEntity(room, "한스", PlayerType.HOST, 1L));
+            playerJpaRepository.save(new PlayerEntity(otherRoom, "한스", PlayerType.HOST, 9L));
+
+            final List<PlayerRef> refs = roomReferenceAdapter.findPlayerRefs(room.getId(), List.of("한스"));
+
+            assertThat(refs).containsExactly(new PlayerRef(한스.getId(), "한스", 1L));
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 확인 (be/dev)
- [x] 현재 be/dev 최신 기준 **단일 커밋**(`084a065`)으로 분리(cherry-pick)

# 🔥 연관 이슈

- ADR-0025 (Room-GameSession 분리)의 「구현 완료 후속」 — `:game → :room` FK 영속 책임 분리
- PR #1413에서 커밋 `084a065`만 떼어낸 PR

# 🚀 작업 내용

ADR-0025가 후속으로 미뤄둔 FK 영속 책임 분리를 완료해 `:game` 프로덕션의 `:room` 의존을 **0건**으로 만든다. (PR #1413의 단일 커밋 `084a065`만 be/dev에서 분리)

1. **엔티티 FK → ID 참조**: `MiniGameEntity.roomSession`(`@ManyToOne RoomEntity`)→`roomSessionId`(`Long`), `MiniGameResultEntity.player`(`@ManyToOne PlayerEntity`)→`playerId`(`Long`). DB 스키마·FK 컬럼 불변, 객체 연관만 절단(애그리거트는 ID로 참조).
2. **포트 도입**: `:game-api` `gamecommon`에 `RoomReferencePort`/`PlayerRef` 신설, `:room`의 `RoomReferenceAdapter`가 구현(`findCurrentRoomSessionId`/`markRoomPlaying`/`findPlayerRefs`). `PlayerJpaRepository`에 `findByRoomSessionIdAndPlayerNameIn` 추가.
3. **소비자 전환**: `MiniGamePersistenceService`·`MiniGameResultSaveEventListener`가 포트 경유. PlayerEntity 참조 절단으로 `userId`는 `PlayerRef`에서 캡처해 UserStats 갱신.
4. **RestController**: `RoomQueryService`→`gameSessionService.findSession` (동일 `NOT_EXIST` 404 계약, 세션-방 1:1).
5. **빌드/아키텍처**: `game` build.gradle에서 `implementation(:room)` 제거→테스트로 이동. ArchUnit `game→room` 금지를 `room.domain`→`room` **전체**로 격상, `GameArchitectureTest`의 room.infra 예외 제거.
6. **admin 연쇄**: `QueryDslDashboardStatisticsRepository` 연관 조인→id 기반 `.on()` 조인.

# ✅ 검증 (이 브랜치 = 현재 be/dev + 단일 커밋, **실제 실행한 항목만 기재**)

- 5개 모듈 `compileJava`/`compileTestJava` 그린
- ArchUnit `GameArchitectureTest`·`RoomGameSeparationArchitectureTest` 통과 (`:game ↛ :room` 강제)
- 테스트 그린: `RoomReferenceAdapterTest`, `MiniGameRestControllerTest`, `MiniGamePersistenceServiceTest`, `MiniGameResultSaveEventListenerTest`, `DashboardServiceTest` (Docker TestContainers 기동 상태)

# 💬 리뷰 중점사항 / 분리 관련 안내

- **PR #1413과의 관계**: 이 PR은 #1413의 단일 커밋 `084a065`만 cherry-pick한 것이다. 이 PR이 be/dev에 머지되면 **#1413에서 해당 커밋은 rebase/drop이 필요**하다(중복 방지). 코디네이션 필요.
- **이 PR에 포함되지 않은 #1413의 형제 커밋**(요청대로 코드 커밋만 분리):
  - `438308fb` ADR-0025 문서 「FK 영속 분리 완료」 반영 — **미포함**. → 코드는 분리 완료지만 `docs/adr/index.md`·ADR-0025 본문은 여전히 "후속 예정" 표기로 남는다.
  - `5ff22580` RestController 404 주석에 init 레이스 창 명시 — **미포함**.
- **이중 저장소 PLAYING 전이**: 도메인 `Room.markPlaying`(인메모리)과 DB `RoomEntity` 전이(`markRoomPlaying`)는 서로 다른 저장소 — 중복 아님(미변경 유지).
- **RestController 404 의미 변경**: Room 존재→세션 존재. init 전 극소 레이스 창에서만 `200(빈 목록)→404`(재전송 복구).
- **이중 SELECT (의도)**: `findCurrentRoomSessionId`+`markRoomPlaying` 각각 조회 → CQS 분리 우선, 저빈도 경로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 게임과 방 모듈 간 아키텍처 분리를 강화하기 위해 내부 데이터 접근 패턴을 개선했습니다.
  * 모듈 간 의존성을 감소시켜 시스템 안정성을 향상시켰습니다.

* **테스트**
  * 아키텍처 변경에 맞춰 관련 테스트 케이스를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->