### PR TITLE
[fix] edge-cd monitoring conf rsync --inplace — 단일 파일 마운트 inode 정체 해소

### DIFF
--- a/.github/scripts/deploy-edge.sh
+++ b/.github/scripts/deploy-edge.sh
@@ -214,7 +214,11 @@ apply_monitoring() {
 
     # best-effort지만 각 단계 실패를 집계해 호출부(main)가 경고를 띄울 수 있도록 비0 전파.
     local rc=0
-    rsync -a --delete "${MONITOR_SRC}/conf/" "${MONITOR_DIR}/conf/" \
+    # --inplace: 기존 inode에 덮어쓴다. 미지정 시 rsync는 temp+rename으로 새 inode를
+    # 만드는데, prometheus.yml처럼 단일 파일을 bind-mount한 컨테이너는 기동 시 inode에
+    # 고정돼 새 inode를 못 본다 → 아래 SIGHUP 리로드가 옛 파일만 읽어 갱신이 조용히 실패한다
+    # (restart/recreate로만 반영). --inplace로 inode를 유지해 SIGHUP 핫리로드가 먹게 한다.
+    rsync -a --delete --inplace "${MONITOR_SRC}/conf/" "${MONITOR_DIR}/conf/" \
         || { log_warning "monitor conf sync 실패"; rc=1; }
     cp -a "${MONITOR_SRC}/docker-compose.yml" "${MONITOR_DIR}/docker-compose.yml" \
         || { log_warning "monitor compose 복사 실패"; rc=1; }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (be/dev)

# 🔥 연관 이슈

- 관련 ADR-0023(edge-cd GitOps), ADR-0028(Alloy)

# 🚀 작업 내용

1. `deploy-edge.sh` `apply_monitoring`의 monitoring conf rsync에 **`--inplace` 추가**.

**배경**: ADR-0028(#1416) 머지 후 edge-cd가 `prometheus.yml`(alloy 스크레이프 job 추가)을 정상 rsync하고 SIGHUP까지 보냈는데도 라이브 Prometheus에 반영되지 않고 `up{job="alloy"}`가 안 떴음. `docker restart prometheus`로만 반영됨.

**원인**: monitoring compose가 `prometheus.yml`을 **단일 파일** bind-mount(`./conf/prometheus.yml:/etc/prometheus/prometheus.yml`). rsync 기본 동작(temp 파일 생성 후 rename)이 **새 inode**를 만드는데, 단일 파일 마운트는 컨테이너 기동 시 inode에 고정되므로 컨테이너가 옛 inode의 내용을 계속 봄 → SIGHUP 리로드가 옛 파일만 읽어 **조용히 실패**. (`rules`는 디렉터리 마운트라 영향 없음 — 룰 변경은 정상 반영됨.)

**수정**: `--inplace`로 기존 inode에 덮어써 컨테이너가 바인딩한 inode를 유지 → SIGHUP 핫리로드가 정상 동작. 핫리로드를 유지하는 최소 변경(컨테이너 상시 재시작 불필요).

# 💬 리뷰 중점사항

- `--inplace`는 원자적 교체(temp+rename)를 포기하지만, rsync 완료 **후**에 SIGHUP이 발생하므로 부분 기록을 읽을 위험은 없음.
- **배포 후 1회** `docker restart prometheus`가 필요할 수 있음 — 컨테이너가 현재 경로 inode에 재바인딩되도록(이후 `--inplace`가 그 inode를 유지하므로 안정). dev는 이미 수동 restart로 정상화됨.
- 대안: ①디렉터리 마운트(더 견고하나 침습적) ②conf 변경 시 컨테이너 recreate(핫리로드 상실) — 둘 다 비채택, 최소·핫리로드 유지 관점에서 `--inplace` 선택.

🤖 Generated with [Claude Code](https://claude.com/claude-code)