### PR TITLE
[feat] zzolbot 알림 분석 경로 eval 하네스 확장 — 7월 인시던트 골든셋 replay

### DIFF
--- a/backend/app/src/main/resources/db/migration/V42__add_eval_scenario_kind.sql
+++ b/backend/app/src/main/resources/db/migration/V42__add_eval_scenario_kind.sql
@@ -1,0 +1,13 @@
+-- 평가 시나리오에 검증 대상 경로(kind) 추가 (#1626)
+--
+-- 기존 eval 하네스는 챗봇(진단) 경로만 채점했다. 무인으로 Slack에 직행하는
+-- 알림 분석 경로(AnomalyAnalyzer)에도 골든 시나리오를 두기 위해, 시나리오가
+-- 어느 경로를 검증하는지 구분하는 kind(CHAT/MONITOR)를 추가한다.
+-- 출처(source_type)와 직교하는 축이다 — 출처는 "어디서 왔나", kind는 "무엇을 채점하나".
+
+ALTER TABLE zzolbot_eval_scenario
+    ADD COLUMN kind VARCHAR(20) NOT NULL DEFAULT 'CHAT' AFTER name;
+
+-- DEFAULT는 기존 행 백필용이다. 새 행은 앱이 항상 kind를 명시하므로 제거한다.
+ALTER TABLE zzolbot_eval_scenario
+    ALTER COLUMN kind DROP DEFAULT;

--- a/backend/app/src/main/resources/templates/admin/zzolbot.html
+++ b/backend/app/src/main/resources/templates/admin/zzolbot.html
@@ -334,10 +334,10 @@
             <div class="panel-head"><h2>시나리오</h2></div>
             <table class="data">
                 <thead>
-                <tr><th>이름</th><th>질문</th><th>채점 기준</th><th>출처</th><th>생성</th><th></th></tr>
+                <tr><th>이름</th><th>종류</th><th>질문</th><th>채점 기준</th><th>출처</th><th>생성</th><th></th></tr>
                 </thead>
                 <tbody id="evalScenariosBody">
-                <tr><td colspan="6" class="muted">불러오는 중...</td></tr>
+                <tr><td colspan="7" class="muted">불러오는 중...</td></tr>
                 </tbody>
             </table>
             <div class="form-grid">
@@ -645,10 +645,13 @@
         if (!label) return;
         // 최대 시도 횟수. PASS가 한 번 뜨면 멈추고, 전부 실패할 때만 재시도(최대 3). 기본 1이면 토큰 소모 종전과 동일.
         const repeats = Math.max(1, Math.min(3, parseInt(prompt('최대 시도 횟수 (PASS 뜨면 멈춤, 전부 실패 시 재시도. 기본 1, 최대 3):', '1'), 10) || 1));
+        const kindInput = (prompt('실행 대상 (all=전체, chat=챗봇, monitor=알림 분석):', 'all') || 'all').trim();
+        // all 또는 인식 불가 입력은 전체 실행(kind=null). 서버는 CHAT/MONITOR 외 값을 400으로 거절한다.
+        const kind = /^(chat|monitor)$/i.test(kindInput) ? kindInput.toUpperCase() : null;
         const btn = document.getElementById('runEvalBtn');
         btn.disabled = true; // 중복 클릭 방지 — RUNNING 동안은 renderEvalRuns가 계속 비활성으로 유지
         try {
-            await api('POST', '/admin/zzolbot/eval/runs', { label, repeats });
+            await api('POST', '/admin/zzolbot/eval/runs', { label, repeats, kind });
             // 백그라운드 실행 — RUNNING인 동안 목록·상세를 자동 폴링(채팅처럼 실시간). 새로고침 불필요.
             ensureEvalPolling();
         } catch (e) {
@@ -766,13 +769,13 @@
         try {
             const list = await api('GET', '/admin/zzolbot/eval/scenarios');
             if (!list.length) {
-                body.innerHTML = '<tr><td colspan="6" class="muted">시나리오가 없습니다</td></tr>';
+                body.innerHTML = '<tr><td colspan="7" class="muted">시나리오가 없습니다</td></tr>';
                 return;
             }
             body.innerHTML = '';
             list.forEach(s => {
                 const tr = document.createElement('tr');
-                tr.innerHTML = `<td>${esc(s.name)}</td><td>${esc(s.question)}</td>`
+                tr.innerHTML = `<td>${esc(s.name)}</td><td>${esc(s.kind)}</td><td>${esc(s.question)}</td>`
                     + `<td class="muted">${esc(s.rubric)}</td>`
                     + `<td>${esc(s.sourceType)}</td><td>${esc(s.createdAt)}</td>`
                     + `<td></td>`;
@@ -786,7 +789,7 @@
                 body.appendChild(tr);
             });
         } catch (e) {
-            body.innerHTML = `<tr><td colspan="6" class="muted">로드 실패: ${esc(e.message)}</td></tr>`;
+            body.innerHTML = `<tr><td colspan="7" class="muted">로드 실패: ${esc(e.message)}</td></tr>`;
         }
     }
 

--- a/backend/app/src/main/resources/templates/admin/zzolbot.html
+++ b/backend/app/src/main/resources/templates/admin/zzolbot.html
@@ -645,9 +645,10 @@
         if (!label) return;
         // 최대 시도 횟수. PASS가 한 번 뜨면 멈추고, 전부 실패할 때만 재시도(최대 3). 기본 1이면 토큰 소모 종전과 동일.
         const repeats = Math.max(1, Math.min(3, parseInt(prompt('최대 시도 횟수 (PASS 뜨면 멈춤, 전부 실패 시 재시도. 기본 1, 최대 3):', '1'), 10) || 1));
-        const kindInput = (prompt('실행 대상 (all=전체, chat=챗봇, monitor=알림 분석):', 'all') || 'all').trim();
+        const kindRaw = prompt('실행 대상 (all=전체, chat=챗봇, monitor=알림 분석):', 'all');
+        if (kindRaw === null) return; // 취소는 실행 중단 — 전체 실행(가장 비싼 선택지)으로 폴백하지 않는다
         // all 또는 인식 불가 입력은 전체 실행(kind=null). 서버는 CHAT/MONITOR 외 값을 400으로 거절한다.
-        const kind = /^(chat|monitor)$/i.test(kindInput) ? kindInput.toUpperCase() : null;
+        const kind = /^(chat|monitor)$/i.test(kindRaw.trim()) ? kindRaw.trim().toUpperCase() : null;
         const btn = document.getElementById('runEvalBtn');
         btn.disabled = true; // 중복 클릭 방지 — RUNNING 동안은 renderEvalRuns가 계속 비활성으로 유지
         try {

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/ChatScenarioEvaluator.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/ChatScenarioEvaluator.java
@@ -1,0 +1,43 @@
+package coffeeshout.zzolbot.eval.application;
+
+import coffeeshout.zzolbot.application.SessionSink;
+import coffeeshout.zzolbot.application.ZzolBotChatService;
+import coffeeshout.zzolbot.domain.ZzolBotChatResult;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
+import coffeeshout.zzolbot.eval.domain.ToolSnapshot;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
+import coffeeshout.zzolbot.eval.infra.ToolSnapshotCodec;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 챗봇(진단) 경로 평가기. 박제된 도구 스냅샷을 replay하고 LLM 추론만 라이브로 호출한다.
+ * 답변은 세션에 저장하지 않는다(NON_PERSIST) — 평가가 운영 세션 이력을 오염시키지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ChatScenarioEvaluator implements ScenarioEvaluator {
+
+    private static final Consumer<String> NO_PROGRESS = toolName -> {
+    };
+    private static final SessionSink NON_PERSIST =
+            (maskedQuestion, maskedAnswer, adminUsername, ctx) -> new ZzolBotChatResult(null, maskedAnswer);
+
+    private final ZzolBotChatService chatService;
+    private final ToolSnapshotCodec codec;
+
+    @Override
+    public ScenarioKind kind() {
+        return ScenarioKind.CHAT;
+    }
+
+    @Override
+    public EvalAnswer evaluate(EvalScenarioEntity scenario) {
+        final ToolSnapshot snapshot = codec.fromJson(scenario.getSnapshotJson());
+        final SnapshotToolResultSource source = new SnapshotToolResultSource(snapshot);
+        final ZzolBotChatResult result = chatService.ask(
+                scenario.getQuestion(), "eval", NO_PROGRESS, source, NON_PERSIST);
+        return new EvalAnswer(result.answer(), source.getMissingCount());
+    }
+}

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalAnswer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalAnswer.java
@@ -1,0 +1,8 @@
+package coffeeshout.zzolbot.eval.application;
+
+/**
+ * 평가기가 산출한 봇 출력. answer는 judge 채점 대상 텍스트이고,
+ * missingToolCalls는 replay 중 스냅샷에 없어 실패 처리된 도구 호출 수다(도구가 없는 경로는 0).
+ */
+public record EvalAnswer(String answer, int missingToolCalls) {
+}

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalRunner.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalRunner.java
@@ -1,12 +1,9 @@
 package coffeeshout.zzolbot.eval.application;
 
-import coffeeshout.zzolbot.application.SessionSink;
-import coffeeshout.zzolbot.application.ZzolBotChatService;
 import coffeeshout.zzolbot.config.ZzolBotProperties;
-import coffeeshout.zzolbot.domain.ZzolBotChatResult;
 import coffeeshout.zzolbot.eval.domain.EvalVerdict;
 import coffeeshout.zzolbot.eval.domain.JudgeScore;
-import coffeeshout.zzolbot.eval.domain.ToolSnapshot;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import coffeeshout.zzolbot.eval.infra.EvalResultEntity;
 import coffeeshout.zzolbot.eval.infra.EvalResultRepository;
 import coffeeshout.zzolbot.eval.infra.EvalRunEntity;
@@ -14,17 +11,15 @@ import coffeeshout.zzolbot.eval.infra.EvalRunRepository;
 import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
 import coffeeshout.zzolbot.eval.infra.EvalScenarioRepository;
 import coffeeshout.zzolbot.eval.infra.JudgeClient;
-import coffeeshout.zzolbot.eval.infra.ToolSnapshotCodec;
 import java.util.List;
-import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
  * 골든 시나리오를 일괄 실행해 채점·저장한다.
- * 각 시나리오는 박제된 도구 스냅샷을 replay하고(라이브 데이터 변동 제거) LLM 추론은 라이브로 호출해
- * 프롬프트/모델 변경의 A/B 비교가 성립하게 한다.
+ * 시나리오 replay는 kind별 {@link ScenarioEvaluator}에 위임하고(박제 입력 replay + LLM 추론만 라이브),
+ * 채점(judge)·재시도·결과 영속은 여기서 공통 처리해 프롬프트/모델 변경의 A/B 비교가 성립하게 한다.
  * judge 레이트리밋과 무료 티어 보호를 위해 시나리오는 순차 실행한다.
  */
 @Slf4j
@@ -32,18 +27,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EvalRunner {
 
-    private static final Consumer<String> NO_PROGRESS = toolName -> {
-    };
-    private static final SessionSink NON_PERSIST =
-            (maskedQuestion, maskedAnswer, adminUsername, ctx) -> new ZzolBotChatResult(null, maskedAnswer);
-
     private final EvalScenarioRepository scenarioRepository;
     private final EvalRunRepository runRepository;
     private final EvalResultRepository resultRepository;
-    private final ZzolBotChatService chatService;
     private final JudgeClient judgeClient;
-    private final ToolSnapshotCodec codec;
     private final ZzolBotProperties properties;
+    private final List<ScenarioEvaluator> evaluators;
 
     private static final int MAX_REPEATS = 3;
 
@@ -99,19 +88,24 @@ public class EvalRunner {
     }
 
     private boolean evaluateOne(Long runId, EvalScenarioEntity scenario) {
-        final ToolSnapshot snapshot = codec.fromJson(scenario.getSnapshotJson());
-        final SnapshotToolResultSource source = new SnapshotToolResultSource(snapshot);
+        final ScenarioEvaluator evaluator = evaluatorFor(scenario.getKind());
 
         final long startNanos = System.nanoTime();
-        final ZzolBotChatResult result = chatService.ask(
-                scenario.getQuestion(), "eval", NO_PROGRESS, source, NON_PERSIST);
+        final EvalAnswer answer = evaluator.evaluate(scenario);
         final long latencyMs = (System.nanoTime() - startNanos) / 1_000_000;
 
-        final JudgeScore score = judgeClient.evaluate(scenario.getQuestion(), scenario.getRubric(), result.answer());
+        final JudgeScore score = judgeClient.evaluate(scenario.getQuestion(), scenario.getRubric(), answer.answer());
         resultRepository.save(EvalResultEntity.create(
-                runId, scenario.getId(), result.answer(), score, latencyMs, source.getMissingCount()));
+                runId, scenario.getId(), answer.answer(), score, latencyMs, answer.missingToolCalls()));
 
         return score.verdict() == EvalVerdict.PASS;
+    }
+
+    private ScenarioEvaluator evaluatorFor(ScenarioKind kind) {
+        return evaluators.stream()
+                .filter(evaluator -> evaluator.kind() == kind)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("등록된 평가기가 없는 시나리오 kind: " + kind));
     }
 
     /**

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalRunner.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalRunner.java
@@ -37,17 +37,25 @@ public class EvalRunner {
     private static final int MAX_REPEATS = 3;
 
     public EvalRunEntity run(String label) {
-        return run(label, 1);
+        return run(label, 1, null);
+    }
+
+    public EvalRunEntity run(String label, int repeats) {
+        return run(label, repeats, null);
     }
 
     /**
      * 각 시나리오를 최대 {@code repeats}회까지 평가한다. PASS가 한 번 나오면 거기서 멈추고,
      * 모든 시도가 FAIL일 때만 FAIL로 본다 — LLM 변동으로 가끔 빗나가는 걸 재시도로 완화한다.
      * repeats는 1~{@value #MAX_REPEATS}로 클램프한다(기본 1이면 비용·동작 모두 종전과 동일).
+     * kind가 null이면 전체 시나리오를, 지정하면 해당 kind만 실행한다 — 경로 하나만 바꿨을 때
+     * 다른 경로 시나리오까지 LLM을 태우지 않기 위한 필터다.
      */
-    public EvalRunEntity run(String label, int repeats) {
+    public EvalRunEntity run(String label, int repeats, ScenarioKind kind) {
         final int attempts = Math.max(1, Math.min(MAX_REPEATS, repeats));
-        final List<EvalScenarioEntity> scenarios = scenarioRepository.findAllByOrderByCreatedAtDesc();
+        final List<EvalScenarioEntity> scenarios = kind == null
+                ? scenarioRepository.findAllByOrderByCreatedAtDesc()
+                : scenarioRepository.findAllByKindOrderByCreatedAtDesc(kind);
         final EvalRunEntity run = runRepository.save(
                 EvalRunEntity.start(label, properties.model(), null, scenarios.size()));
 

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalRunner.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalRunner.java
@@ -40,10 +40,6 @@ public class EvalRunner {
         return run(label, 1, null);
     }
 
-    public EvalRunEntity run(String label, int repeats) {
-        return run(label, repeats, null);
-    }
-
     /**
      * 각 시나리오를 최대 {@code repeats}회까지 평가한다. PASS가 한 번 나오면 거기서 멈추고,
      * 모든 시도가 FAIL일 때만 FAIL로 본다 — LLM 변동으로 가끔 빗나가는 걸 재시도로 완화한다.

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalScenarioService.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/EvalScenarioService.java
@@ -1,5 +1,6 @@
 package coffeeshout.zzolbot.eval.application;
 
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import coffeeshout.zzolbot.eval.domain.ScenarioSource;
 import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
 import coffeeshout.zzolbot.eval.infra.EvalScenarioRepository;
@@ -30,13 +31,15 @@ public class EvalScenarioService {
         final ScenarioRecorder.Recorded recorded = recorder.record(question, adminUsername);
         final String snapshotJson = codec.toJson(recorded.snapshot());
         return scenarioRepository.save(
-                EvalScenarioEntity.create(name, question, snapshotJson, rubric, ScenarioSource.RECORDED));
+                EvalScenarioEntity.create(name, ScenarioKind.CHAT, question, snapshotJson, rubric,
+                        ScenarioSource.RECORDED));
     }
 
     public EvalScenarioEntity registerManual(String name, String question, String snapshotJson, String rubric) {
         codec.fromJson(snapshotJson); // 잘못된 스냅샷 JSON을 저장 전에 빠르게 검증(실패 시 예외) — 이후 실행 깨짐 방지
         return scenarioRepository.save(
-                EvalScenarioEntity.create(name, question, snapshotJson, rubric, ScenarioSource.MANUAL));
+                EvalScenarioEntity.create(name, ScenarioKind.CHAT, question, snapshotJson, rubric,
+                        ScenarioSource.MANUAL));
     }
 
     @Transactional

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/MonitorScenarioEvaluator.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/MonitorScenarioEvaluator.java
@@ -1,0 +1,59 @@
+package coffeeshout.zzolbot.eval.application;
+
+import coffeeshout.zzolbot.eval.domain.MonitorScenarioFixture;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
+import coffeeshout.zzolbot.eval.infra.MonitorFixtureCodec;
+import coffeeshout.zzolbot.monitor.domain.MonitorAnalysis;
+import coffeeshout.zzolbot.monitor.infra.AnomalyAnalyzer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 알림 분석(무인) 경로 평가기. 박제된 알림·로그 샘플을 {@link AnomalyAnalyzer}에 직접 주입해
+ * LLM 추론만 라이브로 실행한다. {@code AlertEnrichmentService}를 거치지 않으므로
+ * 일일 예산 소모·Slack 발송·monitor_run 영속이 발생하지 않는다.
+ * 채점 대상은 근거 인용 검증(강등 포함)을 거친 최종 분석 — 실제 Slack에 나가는 그 형태다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MonitorScenarioEvaluator implements ScenarioEvaluator {
+
+    private final AnomalyAnalyzer analyzer;
+    private final MonitorFixtureCodec codec;
+
+    @Override
+    public ScenarioKind kind() {
+        return ScenarioKind.MONITOR;
+    }
+
+    @Override
+    public EvalAnswer evaluate(EvalScenarioEntity scenario) {
+        final MonitorScenarioFixture fixture = codec.fromJson(scenario.getSnapshotJson());
+        final MonitorAnalysis analysis = analyzer.analyze(
+                fixture.alert(), fixture.logSamples(), fixture.logEnvironment());
+        return new EvalAnswer(flatten(analysis), 0);
+    }
+
+    /**
+     * 구조화된 분석 결과를 judge의 3-String 계약(질문/기준/답변)에 태우기 위한 평탄화.
+     * 필드 라벨을 고정해 rubric이 "근거 발견: 아니오" 같은 표현을 안정적으로 참조할 수 있게 한다.
+     */
+    private String flatten(MonitorAnalysis analysis) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("요약: ").append(analysis.summary()).append('\n');
+        sb.append("근거 발견: ").append(analysis.evidenceFound() ? "예" : "아니오").append('\n');
+        sb.append("원인 가설: ")
+                .append(analysis.rootCauseHypothesis().isBlank() ? "(없음)" : analysis.rootCauseHypothesis())
+                .append('\n');
+        if (analysis.suggestedActions().isEmpty()) {
+            sb.append("제안 조치: (없음)");
+        } else {
+            sb.append("제안 조치:");
+            for (String action : analysis.suggestedActions()) {
+                sb.append("\n- ").append(action);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/ScenarioEvaluator.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/application/ScenarioEvaluator.java
@@ -1,0 +1,16 @@
+package coffeeshout.zzolbot.eval.application;
+
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
+
+/**
+ * 시나리오 1건을 replay해 봇 출력을 산출한다. kind별 구현이 박제 입력(snapshotJson)의
+ * 해석과 봇 호출을 담당하고, 채점(judge)과 결과 영속은 {@link EvalRunner}가 공통으로 처리한다.
+ * 새 검증 경로는 이 인터페이스의 구현을 추가하는 것으로 확장한다.
+ */
+public interface ScenarioEvaluator {
+
+    ScenarioKind kind();
+
+    EvalAnswer evaluate(EvalScenarioEntity scenario);
+}

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/config/EvalSeedInitializer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/config/EvalSeedInitializer.java
@@ -1,5 +1,6 @@
 package coffeeshout.zzolbot.eval.config;
 
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import coffeeshout.zzolbot.eval.domain.ScenarioSource;
 import coffeeshout.zzolbot.eval.domain.ToolCallKey;
 import coffeeshout.zzolbot.eval.domain.ToolSnapshot;
@@ -61,7 +62,8 @@ public class EvalSeedInitializer implements ApplicationRunner {
             }
             final String snapshotJson = codec.toJson(new ToolSnapshot(results));
             scenarioRepository.save(EvalScenarioEntity.create(
-                    seed.name(), seed.question(), snapshotJson, seed.rubric(), resolveSource(seed.source())));
+                    seed.name(), ScenarioKind.CHAT, seed.question(), snapshotJson, seed.rubric(),
+                    resolveSource(seed.source())));
             log.info("[ZzolBot] 평가 시드 적재: {}", seed.name());
         } catch (Exception e) {
             log.warn("[ZzolBot] 평가 시드 파일 처리 실패. resource={}", resource.getFilename(), e);

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/config/MonitorEvalSeedInitializer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/config/MonitorEvalSeedInitializer.java
@@ -1,0 +1,89 @@
+package coffeeshout.zzolbot.eval.config;
+
+import coffeeshout.zzolbot.eval.domain.MonitorScenarioFixture;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
+import coffeeshout.zzolbot.eval.domain.ScenarioSource;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioRepository;
+import coffeeshout.zzolbot.eval.infra.MonitorFixtureCodec;
+import coffeeshout.zzolbot.monitor.domain.FiringAlert;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+/**
+ * 알림 분석(MONITOR) 골든 시나리오 시드를 최초 1회 적재한다.
+ * 챗봇 시드({@code eval/seed/})와 파일 스키마가 달라 디렉터리를 분리한다 — 같은 글롭에 두면
+ * 한쪽 로더가 다른 쪽 파일을 파싱하다 조용히 스킵하는 사고가 난다.
+ * 동일 name 시나리오가 아직 없을 때만 삽입하고, 출처가 없으면 MANUAL로 분류한다.
+ */
+@Slf4j
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class MonitorEvalSeedInitializer implements ApplicationRunner {
+
+    private static final String SEED_LOCATION = "classpath:eval/monitor-seed/*.json";
+
+    private final EvalScenarioRepository scenarioRepository;
+    private final MonitorFixtureCodec codec;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            final Resource[] resources = new PathMatchingResourcePatternResolver().getResources(SEED_LOCATION);
+            for (Resource resource : resources) {
+                loadOne(resource);
+            }
+        } catch (Exception e) {
+            log.warn("[ZzolBot] 모니터 평가 시드 적재 실패", e);
+        }
+    }
+
+    private void loadOne(Resource resource) {
+        try {
+            final SeedFile seed = objectMapper.readValue(resource.getInputStream(), SeedFile.class);
+            if (scenarioRepository.existsByName(seed.name())) {
+                return;
+            }
+            final MonitorScenarioFixture fixture =
+                    new MonitorScenarioFixture(seed.alert(), seed.logSamples(), seed.logEnvironment());
+            scenarioRepository.save(EvalScenarioEntity.create(
+                    seed.name(), ScenarioKind.MONITOR, seed.question(), codec.toJson(fixture), seed.rubric(),
+                    resolveSource(seed.source())));
+            log.info("[ZzolBot] 모니터 평가 시드 적재: {}", seed.name());
+        } catch (Exception e) {
+            log.warn("[ZzolBot] 모니터 평가 시드 파일 처리 실패. resource={}", resource.getFilename(), e);
+        }
+    }
+
+    private ScenarioSource resolveSource(String source) {
+        if (source == null || source.isBlank()) {
+            return ScenarioSource.MANUAL;
+        }
+        try {
+            return ScenarioSource.valueOf(source.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return ScenarioSource.MANUAL;
+        }
+    }
+
+    private record SeedFile(
+            String name,
+            String question,
+            String rubric,
+            String source,
+            FiringAlert alert,
+            List<String> logSamples,
+            String logEnvironment) {
+    }
+}

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/domain/MonitorScenarioFixture.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/domain/MonitorScenarioFixture.java
@@ -1,0 +1,20 @@
+package coffeeshout.zzolbot.eval.domain;
+
+import coffeeshout.zzolbot.monitor.domain.FiringAlert;
+import java.util.List;
+
+/**
+ * 알림 분석(MONITOR) 시나리오의 박제 입력. 분석 포트({@code AnomalyAnalyzer})의 입력 3요소를
+ * 그대로 고정한다 — 챗봇 시나리오가 도구 결과를 박제하듯, 여기서는 알림과 로그 샘플을 박제해
+ * 라이브 데이터 변동 없이 LLM 추론만 비교 가능하게 한다.
+ */
+public record MonitorScenarioFixture(
+        FiringAlert alert,
+        List<String> logSamples,
+        String logEnvironment
+) {
+
+    public MonitorScenarioFixture {
+        logSamples = List.copyOf(logSamples);
+    }
+}

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/domain/ScenarioKind.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/domain/ScenarioKind.java
@@ -1,0 +1,13 @@
+package coffeeshout.zzolbot.eval.domain;
+
+/**
+ * 평가 시나리오가 검증하는 대상 경로. 출처({@link ScenarioSource})와 직교한다 —
+ * 어디서 온 시나리오인지와 무엇을 채점하는지는 별개의 축이다.
+ */
+public enum ScenarioKind {
+
+    /** 운영자 질문에 대한 챗봇 진단 답변을 채점하는 시나리오. */
+    CHAT,
+    /** Alertmanager 알림에 대한 무인 분석(AnomalyAnalyzer) 결과를 채점하는 시나리오. */
+    MONITOR
+}

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/infra/EvalScenarioEntity.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/infra/EvalScenarioEntity.java
@@ -1,5 +1,6 @@
 package coffeeshout.zzolbot.eval.infra;
 
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import coffeeshout.zzolbot.eval.domain.ScenarioSource;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,8 +18,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 평가 골든 시나리오. 질문 + 박제된 도구 결과(JSON) + 채점 기준(rubric)을 보관한다.
- * 도구 결과는 앱 계층에서 {@code ToolSnapshot}으로 직렬화/역직렬화하므로 엔티티는 JSON 문자열만 보관한다.
+ * 평가 골든 시나리오. 질문 + 박제된 입력(JSON) + 채점 기준(rubric)을 보관한다.
+ * 박제 입력의 해석은 kind에 따라 앱 계층이 담당한다 — CHAT은 {@code ToolSnapshot}(도구 결과),
+ * MONITOR는 알림 분석 픽스처. 엔티티는 JSON 문자열만 보관한다.
  */
 @Entity
 @Table(
@@ -37,6 +39,10 @@ public class EvalScenarioEntity {
     @Column(nullable = false, length = 200)
     private String name;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ScenarioKind kind;
+
     @Column(nullable = false, columnDefinition = "TEXT")
     private String question;
 
@@ -54,9 +60,11 @@ public class EvalScenarioEntity {
     private Instant createdAt;
 
     public static EvalScenarioEntity create(
-            String name, String question, String snapshotJson, String rubric, ScenarioSource sourceType) {
+            String name, ScenarioKind kind, String question, String snapshotJson, String rubric,
+            ScenarioSource sourceType) {
         final EvalScenarioEntity entity = new EvalScenarioEntity();
         entity.name = name;
+        entity.kind = kind;
         entity.question = question;
         entity.snapshotJson = snapshotJson;
         entity.rubric = rubric;

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/infra/EvalScenarioRepository.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/infra/EvalScenarioRepository.java
@@ -1,5 +1,6 @@
 package coffeeshout.zzolbot.eval.infra;
 
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface EvalScenarioRepository extends JpaRepository<EvalScenarioEntity, Long> {
 
     List<EvalScenarioEntity> findAllByOrderByCreatedAtDesc();
+
+    List<EvalScenarioEntity> findAllByKindOrderByCreatedAtDesc(ScenarioKind kind);
 
     Optional<EvalScenarioEntity> findByName(String name);
 

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/infra/MonitorFixtureCodec.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/infra/MonitorFixtureCodec.java
@@ -1,0 +1,32 @@
+package coffeeshout.zzolbot.eval.infra;
+
+import coffeeshout.zzolbot.eval.domain.MonitorScenarioFixture;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link MonitorScenarioFixture}를 DB 저장용 JSON 문자열로 직렬화/역직렬화한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MonitorFixtureCodec {
+
+    private final ObjectMapper objectMapper;
+
+    public String toJson(MonitorScenarioFixture fixture) {
+        try {
+            return objectMapper.writeValueAsString(fixture);
+        } catch (Exception e) {
+            throw new IllegalStateException("모니터 픽스처 직렬화 실패", e);
+        }
+    }
+
+    public MonitorScenarioFixture fromJson(String json) {
+        try {
+            return objectMapper.readValue(json, MonitorScenarioFixture.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("모니터 픽스처 역직렬화 실패", e);
+        }
+    }
+}

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/ui/ZzolBotEvalController.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/ui/ZzolBotEvalController.java
@@ -2,6 +2,7 @@ package coffeeshout.zzolbot.eval.ui;
 
 import coffeeshout.zzolbot.eval.application.EvalRunner;
 import coffeeshout.zzolbot.eval.application.EvalScenarioService;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import coffeeshout.zzolbot.eval.infra.EvalResultEntity;
 import coffeeshout.zzolbot.eval.infra.EvalResultRepository;
 import coffeeshout.zzolbot.eval.infra.EvalRunEntity;
@@ -20,6 +21,7 @@ import java.time.Clock;
 import java.time.format.DateTimeFormatter;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -75,13 +77,14 @@ public class ZzolBotEvalController {
     @PostMapping("/runs")
     public ResponseEntity<Void> startRun(@RequestBody @Valid RunRequest request) {
         final int repeats = request.repeats() == null ? 1 : request.repeats();
+        final ScenarioKind kind = parseKind(request.kind()); // 실행 가드를 잡기 전에 검증 — 잘못된 요청이 가드를 물고 죽지 않게
         if (!evalRunning.compareAndSet(false, true)) {
             return ResponseEntity.status(HttpStatus.CONFLICT).build(); // 이미 실행 중 — 중복 실행 차단
         }
         try {
             virtualThreadExecutor.execute(() -> {
                 try {
-                    evalRunner.run(request.label(), repeats);
+                    evalRunner.run(request.label(), repeats, kind);
                 } catch (Exception e) {
                     log.warn("[ZzolBot] 평가 실행 실패. label={}", request.label(), e);
                 } finally {
@@ -165,10 +168,22 @@ public class ZzolBotEvalController {
                 result.getAnswer());
     }
 
+    private ScenarioKind parseKind(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return ScenarioKind.valueOf(raw.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "알 수 없는 시나리오 kind: " + raw);
+        }
+    }
+
     private ScenarioResponse toScenarioResponse(EvalScenarioEntity scenario) {
         return new ScenarioResponse(
                 scenario.getId(),
                 scenario.getName(),
+                scenario.getKind().name(),
                 scenario.getQuestion(),
                 scenario.getRubric(),
                 scenario.getSourceType().name(),

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/ui/request/RunRequest.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/ui/request/RunRequest.java
@@ -2,5 +2,8 @@ package coffeeshout.zzolbot.eval.ui.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record RunRequest(@NotBlank String label, Integer repeats) {
+/**
+ * kind는 실행 대상 시나리오 종류(CHAT/MONITOR). null 또는 빈 값이면 전체를 실행한다.
+ */
+public record RunRequest(@NotBlank String label, Integer repeats, String kind) {
 }

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/ui/response/ScenarioResponse.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/eval/ui/response/ScenarioResponse.java
@@ -1,5 +1,5 @@
 package coffeeshout.zzolbot.eval.ui.response;
 
-public record ScenarioResponse(Long id, String name, String question, String rubric, String sourceType,
+public record ScenarioResponse(Long id, String name, String kind, String question, String rubric, String sourceType,
                                String createdAt) {
 }

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-error-spike-midnight-sparse-logs.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-error-spike-midnight-sparse-logs.json
@@ -1,0 +1,23 @@
+{
+  "name": "monitor-error-spike-midnight-sparse-logs",
+  "question": "알림 AppErrorLogSpike(warning)가 prod에서 자정 직후 발화했다 — ERROR 로그 급증. 봇에는 ERROR 로그 2줄만 주어졌다.",
+  "rubric": "5분에 30건 이상이라는 스파이크 알림을 시각이 동떨어진 ERROR 2줄로는 설명할 수 없다. 근거 불충분('근거 발견: 아니오')을 명시하면 정답. 스케줄러 예외 1건을 스파이크의 근본 원인으로 단정하면 오답.",
+  "source": "RECORDED",
+  "alert": {
+    "alertname": "AppErrorLogSpike",
+    "severity": "warning",
+    "fingerprint": "golden-run18",
+    "summary": "ERROR 로그 급증(최근 5분, prod-app)",
+    "description": "ERROR 로그가 20건(임계 30/5m)입니다. zzol-bot이 근본원인을 분석합니다.",
+    "labels": {
+      "alertname": "AppErrorLogSpike",
+      "severity": "warning",
+      "job": "prod-app"
+    }
+  },
+  "logSamples": [
+    "[2026-07-17 21:22:18.275] [ERROR] [,] --- [nunchi-task-1] c.g.s.GameTaskSchedulerFactory : [nunchi] 스케줄 실행 중 예외가 발생했습니다.",
+    "[2026-07-18 00:00:22.352] [ERROR] [,] --- [pool-11-thread-1] o.s.s.s.TaskUtils$LoggingErrorHandler : Unexpected error occurred in scheduled task"
+  ],
+  "logEnvironment": "prod"
+}

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-error-spike-midnight-sparse-logs.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-error-spike-midnight-sparse-logs.json
@@ -2,13 +2,13 @@
   "name": "monitor-error-spike-midnight-sparse-logs",
   "question": "알림 AppErrorLogSpike(warning)가 prod에서 자정 직후 발화했다 — ERROR 로그 급증. 봇에는 ERROR 로그 2줄만 주어졌다.",
   "rubric": "5분에 30건 이상이라는 스파이크 알림을 시각이 동떨어진 ERROR 2줄로는 설명할 수 없다. 근거 불충분('근거 발견: 아니오')을 명시하면 정답. 스케줄러 예외 1건을 스파이크의 근본 원인으로 단정하면 오답.",
-  "source": "RECORDED",
+  "source": "POSTMORTEM",
   "alert": {
     "alertname": "AppErrorLogSpike",
     "severity": "warning",
     "fingerprint": "golden-run18",
     "summary": "ERROR 로그 급증(최근 5분, prod-app)",
-    "description": "ERROR 로그가 20건(임계 30/5m)입니다. zzol-bot이 근본원인을 분석합니다.",
+    "description": "ERROR 로그가 34건(임계 30/5m)입니다. zzol-bot이 근본원인을 분석합니다.",
     "labels": {
       "alertname": "AppErrorLogSpike",
       "severity": "warning",

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-error-spike-stale-reingested-logs.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-error-spike-stale-reingested-logs.json
@@ -1,0 +1,41 @@
+{
+  "name": "monitor-error-spike-stale-reingested-logs",
+  "question": "알림 AppErrorLogSpike(warning)가 prod에서 자정 직후 발화했다 — ERROR 로그 급증. 봇에는 최근 30분 창에서 조회된 ERROR 로그 20줄이 주어졌으나, 본문 타임스탬프는 전날 하루에 흩어져 있다.",
+  "rubric": "로그 본문 타임스탬프가 알림 시각(자정 직후)이 아니라 전날 여러 시각에 흩어져 있다 — 로그 일괄 재적재 아티팩트다. 타임스탬프 불일치를 지적하거나 '근거 발견: 아니오'로 판정하면 정답. 전날 로그의 개별 에러 하나를 현재 스파이크의 근본 원인으로 단정하면 오답.",
+  "source": "RECORDED",
+  "alert": {
+    "alertname": "AppErrorLogSpike",
+    "severity": "warning",
+    "fingerprint": "golden-run3",
+    "summary": "ERROR 로그 급증(최근 5분, prod-app)",
+    "description": "ERROR 로그가 20건(임계 30/5m)입니다. zzol-bot이 근본원인을 분석합니다.",
+    "labels": {
+      "alertname": "AppErrorLogSpike",
+      "severity": "warning",
+      "job": "prod-app"
+    }
+  },
+  "logSamples": [
+    "[2026-07-09 16:51:51.000] [ERROR] [e3ce5814fc168152bb6098ac72d9e461,ffa78cdeade252e3] --- [redis-stream-thread-pool-room:join1] c.r.i.messaging.RoomEventWaitManager : 방 이벤트 자동 정리 (실패): eventId=9b34b181-f802-4dd8-80c6-4a98bf5f338b",
+    "[2026-07-09 16:51:51.000] [ERROR] [e3ce5814fc168152bb6098ac72d9e461,ffa78cdeade252e3] --- [redis-stream-thread-pool-room:join1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=RoomJoinConsumer, message=RoomJoinEvent[eventId=9b34b181-f802-4dd8-80c6-4a98bf5f338b, timestamp=2026-07-09T07:51:50.996218175Z, joinCode=FNGH, guestName=알밤이아부지, userId=null]",
+    "[2026-07-09 17:04:18.262] [ERROR] [3f9dbfc4916b622ea00e99f3c67559f3,08291ea24ff29533] --- [redis-stream-thread-pool-room:join1] c.r.application.service.RoomService : 방 참가 비동기 처리 실패: eventId=07297dcd-e71c-4065-a312-6e723d142975, joinCode=Z97J, playerName=PLAYER_3",
+    "[2026-07-09 17:04:18.262] [ERROR] [3f9dbfc4916b622ea00e99f3c67559f3,08291ea24ff29533] --- [redis-stream-thread-pool-room:join1] c.r.i.messaging.RoomEventWaitManager : 방 이벤트 자동 정리 (실패): eventId=07297dcd-e71c-4065-a312-6e723d142975",
+    "[2026-07-09 17:04:18.262] [ERROR] [3f9dbfc4916b622ea00e99f3c67559f3,08291ea24ff29533] --- [redis-stream-thread-pool-room:join1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=RoomJoinConsumer, message=RoomJoinEvent[eventId=07297dcd-e71c-4065-a312-6e723d142975, timestamp=2026-07-09T08:04:18.258625599Z, joinCode=Z97J, guestName=느린치타, userId=null]",
+    "[2026-07-09 17:04:32.891] [ERROR] [72fd3485f8a270f9591348958978bef5,cab75850dde78a26] --- [redis-stream-thread-pool-room:join1] c.r.application.service.RoomService : 방 참가 비동기 처리 실패: eventId=f661c711-bdb6-4cf3-ad6b-a7369970eece, joinCode=Z97J, playerName=PLAYER_4",
+    "[2026-07-09 17:04:32.891] [ERROR] [72fd3485f8a270f9591348958978bef5,cab75850dde78a26] --- [redis-stream-thread-pool-room:join1] c.r.i.messaging.RoomEventWaitManager : 방 이벤트 자동 정리 (실패): eventId=f661c711-bdb6-4cf3-ad6b-a7369970eece",
+    "[2026-07-09 17:04:32.891] [ERROR] [72fd3485f8a270f9591348958978bef5,cab75850dde78a26] --- [redis-stream-thread-pool-room:join1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=RoomJoinConsumer, message=RoomJoinEvent[eventId=f661c711-bdb6-4cf3-ad6b-a7369970eece, timestamp=2026-07-09T08:04:32.887524962Z, joinCode=Z97J, guestName=활발한호랑이, userId=null]",
+    "[2026-07-09 17:04:37.531] [ERROR] [72c9a94d4ef6682072cd282686402727,c49ddc1c08766ef5] --- [redis-stream-thread-pool-room:join1] c.r.application.service.RoomService : 방 참가 비동기 처리 실패: eventId=d9cda4a4-0fe4-4a7a-88ce-68b05c636a07, joinCode=Z97J, playerName=PLAYER_3",
+    "[2026-07-09 17:04:37.532] [ERROR] [72c9a94d4ef6682072cd282686402727,c49ddc1c08766ef5] --- [redis-stream-thread-pool-room:join1] c.r.i.messaging.RoomEventWaitManager : 방 이벤트 자동 정리 (실패): eventId=d9cda4a4-0fe4-4a7a-88ce-68b05c636a07",
+    "[2026-07-09 17:04:37.532] [ERROR] [72c9a94d4ef6682072cd282686402727,c49ddc1c08766ef5] --- [redis-stream-thread-pool-room:join1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=RoomJoinConsumer, message=RoomJoinEvent[eventId=d9cda4a4-0fe4-4a7a-88ce-68b05c636a07, timestamp=2026-07-09T08:04:37.528018795Z, joinCode=Z97J, guestName=느린치타, userId=null]",
+    "[2026-07-09 17:16:21.581] [ERROR] [,] --- [redis-stream-thread-pool-concurrent1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=PlayerDisconnectedConsumer, message=PlayerDisconnectedEvent[eventId=c483b8bc-d57c-4ac3-bfb0-4a3a2aea94b3, timestamp=2026-07-09T08:16:21.578716415Z, eventType=PLAYER_DISCONNECTED, playerKey=V64R:ㄱㅁㄱ, sessionId=1tiqstn0, reason=SESSION_DISCONNECT]",
+    "[2026-07-09 17:20:39.271] [ERROR] [0e7dfc5df48cd63410bad39c2bc4a9c5,c70e67eb9c9561b4] --- [redis-stream-thread-pool-room:join1] c.r.application.service.RoomService : 방 참가 비동기 처리 실패: eventId=64b02e28-1e8f-4dc4-8696-afac3b83a4c7, joinCode=GL8J, playerName=PLAYER_5",
+    "[2026-07-09 17:20:39.272] [ERROR] [0e7dfc5df48cd63410bad39c2bc4a9c5,c70e67eb9c9561b4] --- [redis-stream-thread-pool-room:join1] c.r.i.messaging.RoomEventWaitManager : 방 이벤트 자동 정리 (실패): eventId=64b02e28-1e8f-4dc4-8696-afac3b83a4c7",
+    "[2026-07-09 17:20:39.272] [ERROR] [0e7dfc5df48cd63410bad39c2bc4a9c5,c70e67eb9c9561b4] --- [redis-stream-thread-pool-room:join1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=RoomJoinConsumer, message=RoomJoinEvent[eventId=64b02e28-1e8f-4dc4-8696-afac3b83a4c7, timestamp=2026-07-09T08:20:39.267873329Z, joinCode=GL8J, guestName=이제 회식 참가 안, userId=null]",
+    "[2026-07-09 17:20:46.002] [ERROR] [5240ddb9cee88ea357d8054a791b8159,2b80a41e4694f322] --- [redis-stream-thread-pool-room:join1] c.r.application.service.RoomService : 방 참가 비동기 처리 실패: eventId=610fa07d-6528-43be-9853-2c8241382271, joinCode=GL8J, playerName=PLAYER_6",
+    "[2026-07-09 17:20:46.002] [ERROR] [5240ddb9cee88ea357d8054a791b8159,2b80a41e4694f322] --- [redis-stream-thread-pool-room:join1] c.r.i.messaging.RoomEventWaitManager : 방 이벤트 자동 정리 (실패): eventId=610fa07d-6528-43be-9853-2c8241382271",
+    "[2026-07-09 17:20:46.002] [ERROR] [5240ddb9cee88ea357d8054a791b8159,2b80a41e4694f322] --- [redis-stream-thread-pool-room:join1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=RoomJoinConsumer, message=RoomJoinEvent[eventId=610fa07d-6528-43be-9853-2c8241382271, timestamp=2026-07-09T08:20:45.999512757Z, joinCode=GL8J, guestName=이제회식참가안함, userId=null]",
+    "[2026-07-09 20:54:15.877] [ERROR] [68d2f89a9defc8f20c73c45f5848defd,87af7d944bfe8d67] --- [redis-stream-thread-pool-concurrent2] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=MiniGameStartConsumer, message=StartMiniGameCommandEvent[eventId=c5431ad8-a22d-4661-a31c-ec0c75c2b60f, timestamp=2026-07-09T11:54:15.875055793Z, joinCode=LJWC, hostName=오세]",
+    "[2026-07-10 00:01:04.886] [ERROR] [,] --- [pool-12-thread-1] o.s.s.s.TaskUtils$LoggingErrorHandler : Unexpected error occurred in scheduled task"
+  ],
+  "logEnvironment": "prod"
+}

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-error-spike-stale-reingested-logs.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-error-spike-stale-reingested-logs.json
@@ -2,13 +2,13 @@
   "name": "monitor-error-spike-stale-reingested-logs",
   "question": "알림 AppErrorLogSpike(warning)가 prod에서 자정 직후 발화했다 — ERROR 로그 급증. 봇에는 최근 30분 창에서 조회된 ERROR 로그 20줄이 주어졌으나, 본문 타임스탬프는 전날 하루에 흩어져 있다.",
   "rubric": "로그 본문 타임스탬프가 알림 시각(자정 직후)이 아니라 전날 여러 시각에 흩어져 있다 — 로그 일괄 재적재 아티팩트다. 타임스탬프 불일치를 지적하거나 '근거 발견: 아니오'로 판정하면 정답. 전날 로그의 개별 에러 하나를 현재 스파이크의 근본 원인으로 단정하면 오답.",
-  "source": "RECORDED",
+  "source": "POSTMORTEM",
   "alert": {
     "alertname": "AppErrorLogSpike",
     "severity": "warning",
     "fingerprint": "golden-run3",
     "summary": "ERROR 로그 급증(최근 5분, prod-app)",
-    "description": "ERROR 로그가 20건(임계 30/5m)입니다. zzol-bot이 근본원인을 분석합니다.",
+    "description": "ERROR 로그가 45건(임계 30/5m)입니다. zzol-bot이 근본원인을 분석합니다.",
     "labels": {
       "alertname": "AppErrorLogSpike",
       "severity": "warning",

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-ip-ban-unrelated-cardgame-errors.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-ip-ban-unrelated-cardgame-errors.json
@@ -2,7 +2,7 @@
   "name": "monitor-ip-ban-unrelated-cardgame-errors",
   "question": "알림 IpBanRateSpike(warning)가 prod에서 발화했다 — 신규 IP BAN 급증. 봇에는 최근 30분 ERROR 로그 샘플 4줄(카드게임 이벤트 처리 실패)이 주어졌다.",
   "rubric": "주어진 ERROR 로그는 카드게임 SelectCardCommandEvent 처리 실패로, IP 차단/BAN 급증 알림과 무관하다. '근거 발견: 아니오'로 판정하고 원인 가설을 내지 않아야 정답. 카드게임·Redis Stream 이벤트 실패를 차단/BAN 급증의 원인으로 지목하면 오답(2026-07-15 실제 프로덕션 오진 사례).",
-  "source": "RECORDED",
+  "source": "POSTMORTEM",
   "alert": {
     "alertname": "IpBanRateSpike",
     "severity": "warning",

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-ip-ban-unrelated-cardgame-errors.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-ip-ban-unrelated-cardgame-errors.json
@@ -1,0 +1,26 @@
+{
+  "name": "monitor-ip-ban-unrelated-cardgame-errors",
+  "question": "알림 IpBanRateSpike(warning)가 prod에서 발화했다 — 신규 IP BAN 급증. 봇에는 최근 30분 ERROR 로그 샘플 4줄(카드게임 이벤트 처리 실패)이 주어졌다.",
+  "rubric": "주어진 ERROR 로그는 카드게임 SelectCardCommandEvent 처리 실패로, IP 차단/BAN 급증 알림과 무관하다. '근거 발견: 아니오'로 판정하고 원인 가설을 내지 않아야 정답. 카드게임·Redis Stream 이벤트 실패를 차단/BAN 급증의 원인으로 지목하면 오답(2026-07-15 실제 프로덕션 오진 사례).",
+  "source": "RECORDED",
+  "alert": {
+    "alertname": "IpBanRateSpike",
+    "severity": "warning",
+    "fingerprint": "golden-run15",
+    "summary": "신규 IP BAN 급증 (prod-app)",
+    "description": "신규 BAN이 2.17 /s. 차단된 IP 대역과 접근 경로를 확인.",
+    "labels": {
+      "alertname": "IpBanRateSpike",
+      "severity": "warning",
+      "job": "prod-app",
+      "incident_group": "ip-blocking"
+    }
+  },
+  "logSamples": [
+    "[2026-07-15 10:15:29.485] [ERROR] [dce002d154995f92e4b17310d5fe0328,4551564164395041] --- [redis-stream-thread-pool-cardgame:select1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=SelectCardCommandEventConsumer, message=SelectCardCommandEvent[eventId=75aae484-008d-4f2f-985b-269880c3f28b, timestamp=2026-07-15T01:15:29.482188344Z, joinCode=PXMH, playerName=PLAYER_1, cardIndex=3]",
+    "[2026-07-15 10:15:37.299] [ERROR] [023185781de2fa754f135e1ccc72a6e6,3cfe10151fe362ea] --- [redis-stream-thread-pool-cardgame:select1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=SelectCardCommandEventConsumer, message=SelectCardCommandEvent[eventId=9d70163a-aa1c-4338-9512-3435fbd1d7e8, timestamp=2026-07-15T01:15:37.296826397Z, joinCode=PXMH, playerName=PLAYER_2, cardIndex=6]",
+    "[2026-07-15 10:15:37.434] [ERROR] [ef5b83dd6952c754c88090b982a60403,5ae6e3c872b81ce2] --- [redis-stream-thread-pool-cardgame:select1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=SelectCardCommandEventConsumer, message=SelectCardCommandEvent[eventId=a61c25e3-2fb3-4c11-aff1-f23ee15f543a, timestamp=2026-07-15T01:15:37.431675482Z, joinCode=PXMH, playerName=PLAYER_2, cardIndex=6]",
+    "[2026-07-15 10:15:38.474] [ERROR] [266f2a2fb6f056d724079820d8715c26,54de62515074bfb5] --- [redis-stream-thread-pool-cardgame:select1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=SelectCardCommandEventConsumer, message=SelectCardCommandEvent[eventId=167dfb29-1842-4d12-8993-4fa54f18505c, timestamp=2026-07-15T01:15:38.471834148Z, joinCode=PXMH, playerName=PLAYER_1, cardIndex=0]"
+  ],
+  "logEnvironment": "prod"
+}

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-ip-blocking-true-scanner-evidence.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-ip-blocking-true-scanner-evidence.json
@@ -1,0 +1,42 @@
+{
+  "name": "monitor-ip-blocking-true-scanner-evidence",
+  "question": "알림 MassIpBlockingSpike(critical)가 prod에서 발화했다 — IP 차단 요청 급증. 봇에는 같은 시각의 IP 차단 관련 WARN 로그 20줄이 주어졌다(로그 필터 개선 후 도달할 입력의 선행 검증).",
+  "rubric": "로그의 악성 경로 접근(/.git/config, /.env 등 스캐너 패턴 경로)과 IP 차단 등록 급증이 알림을 직접 뒷받침한다. '근거 발견: 예'로 판정하고 스캐너/봇 스윕에 의한 차단 급증으로 진단하면 정답. 근거 없음으로 처리하거나 무관한 원인(애플리케이션 장애 등)을 지목하면 오답.",
+  "source": "MANUAL",
+  "alert": {
+    "alertname": "MassIpBlockingSpike",
+    "severity": "critical",
+    "fingerprint": "golden-run16",
+    "summary": "IP 차단 요청 급증 (prod-app)",
+    "description": "차단 요청이 10.54 req/s. 베이스라인(약 0.5 req/s) 대비 급증. 차단된 IP와 요청 경로를 확인.",
+    "labels": {
+      "alertname": "MassIpBlockingSpike",
+      "severity": "critical",
+      "job": "prod-app",
+      "incident_group": "ip-blocking"
+    }
+  },
+  "logSamples": [
+    "[2026-07-15 10:57:26.184] [WARN] [,] --- [http-nio-8080-exec-8] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/bthil.php",
+    "[2026-07-15 10:57:26.600] [WARN] [,] --- [http-nio-8080-exec-16] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/class-t.api.php",
+    "[2026-07-15 10:57:27.008] [WARN] [,] --- [http-nio-8080-exec-7] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/yas.php",
+    "[2026-07-15 10:57:27.416] [WARN] [,] --- [http-nio-8080-exec-4] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=//test.php",
+    "[2026-07-15 10:57:27.834] [WARN] [,] --- [http-nio-8080-exec-30] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/test.php",
+    "[2026-07-15 10:57:28.243] [WARN] [,] --- [http-nio-8080-exec-19] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/amax.php",
+    "[2026-07-15 10:57:28.652] [WARN] [,] --- [http-nio-8080-exec-14] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/wp5.php",
+    "[2026-07-15 10:57:29.062] [WARN] [,] --- [http-nio-8080-exec-29] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/wp-slss.php",
+    "[2026-07-15 10:57:29.470] [WARN] [,] --- [http-nio-8080-exec-18] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/v2.php",
+    "[2026-07-15 10:57:29.906] [WARN] [,] --- [http-nio-8080-exec-24] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=//min.php",
+    "[2026-07-15 10:57:30.314] [WARN] [,] --- [http-nio-8080-exec-9] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/error.php",
+    "[2026-07-15 10:57:30.721] [WARN] [,] --- [http-nio-8080-exec-25] c.global.ipblock.IpBlockFilter : 악성 경로 접근 감지 → IP 즉시 차단: ip=203.0.113.1 uri=/wp-admin/css/colors/blue/file.php",
+    "[2026-07-15 10:57:30.722] [WARN] [,] --- [http-nio-8080-exec-25] c.global.ipblock.IpBlockStore : IP 차단 등록: ip=203.0.113.1 ttl=24h",
+    "[2026-07-15 10:57:31.132] [WARN] [,] --- [http-nio-8080-exec-12] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/wmore1.php",
+    "[2026-07-15 10:57:31.540] [WARN] [,] --- [http-nio-8080-exec-6] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/bless24.php",
+    "[2026-07-15 10:57:31.948] [WARN] [,] --- [http-nio-8080-exec-3] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/wp-wz.php",
+    "[2026-07-15 10:57:32.366] [WARN] [,] --- [http-nio-8080-exec-5] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/pouhg.php",
+    "[2026-07-15 10:57:32.775] [WARN] [,] --- [http-nio-8080-exec-27] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/wp-su.php",
+    "[2026-07-15 10:57:33.186] [WARN] [,] --- [http-nio-8080-exec-21] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/b.php",
+    "[2026-07-15 10:57:33.594] [WARN] [,] --- [http-nio-8080-exec-2] c.global.ipblock.IpBlockFilter : 차단된 IP 접근 시도: ip=203.0.113.1 uri=/1index.php"
+  ],
+  "logEnvironment": "prod"
+}

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-mass-ip-blocking-unrelated-cardgame-errors.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-mass-ip-blocking-unrelated-cardgame-errors.json
@@ -2,7 +2,7 @@
   "name": "monitor-mass-ip-blocking-unrelated-cardgame-errors",
   "question": "알림 MassIpBlockingSpike(critical)가 prod에서 발화했다 — IP 차단 요청 급증. 봇에는 최근 30분 ERROR 로그 샘플 4줄(카드게임 이벤트 처리 실패)이 주어졌다.",
   "rubric": "주어진 ERROR 로그는 카드게임 SelectCardCommandEvent 처리 실패로, IP 차단/BAN 급증 알림과 무관하다. '근거 발견: 아니오'로 판정하고 원인 가설을 내지 않아야 정답. 카드게임·Redis Stream 이벤트 실패를 차단/BAN 급증의 원인으로 지목하면 오답(2026-07-15 실제 프로덕션 오진 사례).",
-  "source": "RECORDED",
+  "source": "POSTMORTEM",
   "alert": {
     "alertname": "MassIpBlockingSpike",
     "severity": "critical",

--- a/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-mass-ip-blocking-unrelated-cardgame-errors.json
+++ b/backend/zzolbot/src/main/resources/eval/monitor-seed/monitor-mass-ip-blocking-unrelated-cardgame-errors.json
@@ -1,0 +1,26 @@
+{
+  "name": "monitor-mass-ip-blocking-unrelated-cardgame-errors",
+  "question": "알림 MassIpBlockingSpike(critical)가 prod에서 발화했다 — IP 차단 요청 급증. 봇에는 최근 30분 ERROR 로그 샘플 4줄(카드게임 이벤트 처리 실패)이 주어졌다.",
+  "rubric": "주어진 ERROR 로그는 카드게임 SelectCardCommandEvent 처리 실패로, IP 차단/BAN 급증 알림과 무관하다. '근거 발견: 아니오'로 판정하고 원인 가설을 내지 않아야 정답. 카드게임·Redis Stream 이벤트 실패를 차단/BAN 급증의 원인으로 지목하면 오답(2026-07-15 실제 프로덕션 오진 사례).",
+  "source": "RECORDED",
+  "alert": {
+    "alertname": "MassIpBlockingSpike",
+    "severity": "critical",
+    "fingerprint": "golden-run16",
+    "summary": "IP 차단 요청 급증 (prod-app)",
+    "description": "차단 요청이 10.54 req/s. 베이스라인(약 0.5 req/s) 대비 급증. 차단된 IP와 요청 경로를 확인.",
+    "labels": {
+      "alertname": "MassIpBlockingSpike",
+      "severity": "critical",
+      "job": "prod-app",
+      "incident_group": "ip-blocking"
+    }
+  },
+  "logSamples": [
+    "[2026-07-15 10:15:29.485] [ERROR] [dce002d154995f92e4b17310d5fe0328,4551564164395041] --- [redis-stream-thread-pool-cardgame:select1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=SelectCardCommandEventConsumer, message=SelectCardCommandEvent[eventId=75aae484-008d-4f2f-985b-269880c3f28b, timestamp=2026-07-15T01:15:29.482188344Z, joinCode=PXMH, playerName=PLAYER_1, cardIndex=3]",
+    "[2026-07-15 10:15:37.299] [ERROR] [023185781de2fa754f135e1ccc72a6e6,3cfe10151fe362ea] --- [redis-stream-thread-pool-cardgame:select1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=SelectCardCommandEventConsumer, message=SelectCardCommandEvent[eventId=9d70163a-aa1c-4338-9512-3435fbd1d7e8, timestamp=2026-07-15T01:15:37.296826397Z, joinCode=PXMH, playerName=PLAYER_2, cardIndex=6]",
+    "[2026-07-15 10:15:37.434] [ERROR] [ef5b83dd6952c754c88090b982a60403,5ae6e3c872b81ce2] --- [redis-stream-thread-pool-cardgame:select1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=SelectCardCommandEventConsumer, message=SelectCardCommandEvent[eventId=a61c25e3-2fb3-4c11-aff1-f23ee15f543a, timestamp=2026-07-15T01:15:37.431675482Z, joinCode=PXMH, playerName=PLAYER_2, cardIndex=6]",
+    "[2026-07-15 10:15:38.474] [ERROR] [266f2a2fb6f056d724079820d8715c26,54de62515074bfb5] --- [redis-stream-thread-pool-cardgame:select1] c.global.redis.EventDispatcher : 이벤트 처리 실패: consumer=SelectCardCommandEventConsumer, message=SelectCardCommandEvent[eventId=167dfb29-1842-4d12-8993-4fa54f18505c, timestamp=2026-07-15T01:15:38.471834148Z, joinCode=PXMH, playerName=PLAYER_1, cardIndex=0]"
+  ],
+  "logEnvironment": "prod"
+}

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/ChatScenarioEvaluatorTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/ChatScenarioEvaluatorTest.java
@@ -1,0 +1,58 @@
+package coffeeshout.zzolbot.eval.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import coffeeshout.zzolbot.application.ZzolBotChatService;
+import coffeeshout.zzolbot.domain.ZzolBotChatResult;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
+import coffeeshout.zzolbot.eval.domain.ScenarioSource;
+import coffeeshout.zzolbot.eval.domain.ToolSnapshot;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
+import coffeeshout.zzolbot.eval.infra.ToolSnapshotCodec;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatScenarioEvaluatorTest {
+
+    @Mock
+    private ZzolBotChatService chatService;
+    @Mock
+    private ToolSnapshotCodec codec;
+
+    private ChatScenarioEvaluator evaluator;
+
+    @BeforeEach
+    void setUp() {
+        evaluator = new ChatScenarioEvaluator(chatService, codec);
+    }
+
+    @Test
+    void kind는_CHAT이다() {
+        assertThat(evaluator.kind()).isEqualTo(ScenarioKind.CHAT);
+    }
+
+    @Test
+    void 스냅샷을_replay해_챗봇_답변을_산출한다() {
+        given(codec.fromJson("[]")).willReturn(new ToolSnapshot(Map.of()));
+        given(chatService.ask(eq("질문"), eq("eval"), any(), any(SnapshotToolResultSource.class), any()))
+                .willReturn(new ZzolBotChatResult(null, "진단 답변"));
+        final EvalScenarioEntity scenario = EvalScenarioEntity.create(
+                "chat-1", ScenarioKind.CHAT, "질문", "[]", "rubric", ScenarioSource.MANUAL);
+
+        final EvalAnswer answer = evaluator.evaluate(scenario);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(answer.answer()).isEqualTo("진단 답변");
+            softly.assertThat(answer.missingToolCalls()).isZero();
+        });
+    }
+}

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/EvalRunnerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/EvalRunnerTest.java
@@ -7,11 +7,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
 import coffeeshout.zzolbot.config.ZzolBotProperties;
-import coffeeshout.zzolbot.domain.ZzolBotChatResult;
 import coffeeshout.zzolbot.eval.domain.EvalRunStatus;
 import coffeeshout.zzolbot.eval.domain.EvalVerdict;
 import coffeeshout.zzolbot.eval.domain.JudgeScore;
-import coffeeshout.zzolbot.eval.domain.ToolSnapshot;
 import coffeeshout.zzolbot.eval.infra.EvalResultEntity;
 import coffeeshout.zzolbot.eval.infra.EvalResultRepository;
 import coffeeshout.zzolbot.eval.infra.EvalRunEntity;
@@ -19,12 +17,9 @@ import coffeeshout.zzolbot.eval.infra.EvalRunRepository;
 import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
 import coffeeshout.zzolbot.eval.infra.EvalScenarioRepository;
 import coffeeshout.zzolbot.eval.infra.JudgeClient;
-import coffeeshout.zzolbot.eval.infra.ToolSnapshotCodec;
-import coffeeshout.zzolbot.application.ZzolBotChatService;
 import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import coffeeshout.zzolbot.eval.domain.ScenarioSource;
 import java.util.List;
-import java.util.Map;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,18 +49,16 @@ class EvalRunnerTest {
     @Mock
     private EvalResultRepository resultRepository;
     @Mock
-    private ZzolBotChatService chatService;
-    @Mock
     private JudgeClient judgeClient;
     @Mock
-    private ToolSnapshotCodec codec;
+    private ScenarioEvaluator chatEvaluator;
 
     private EvalRunner runner;
 
     @BeforeEach
     void setUp() {
         runner = new EvalRunner(scenarioRepository, runRepository, resultRepository,
-                chatService, judgeClient, codec, PROPERTIES);
+                judgeClient, PROPERTIES, List.of(chatEvaluator));
 
         given(runRepository.save(any())).willAnswer(invocation -> {
             final EvalRunEntity run = invocation.getArgument(0);
@@ -74,9 +67,8 @@ class EvalRunnerTest {
             }
             return run;
         });
-        given(codec.fromJson(anyString())).willReturn(new ToolSnapshot(Map.of()));
-        given(chatService.ask(anyString(), anyString(), any(), any(), any()))
-                .willReturn(new ZzolBotChatResult(null, "진단 답변"));
+        given(chatEvaluator.kind()).willReturn(ScenarioKind.CHAT);
+        given(chatEvaluator.evaluate(any())).willReturn(new EvalAnswer("진단 답변", 0));
     }
 
     @Test
@@ -108,6 +100,24 @@ class EvalRunnerTest {
             softly.assertThat(run.getPassCount()).isZero();
         });
         verify(resultRepository, times(0)).save(any());
+    }
+
+    @Test
+    void 평가기가_없는_kind의_시나리오는_FAIL_결과로_기록된다() {
+        final EvalScenarioEntity monitorScenario = EvalScenarioEntity.create(
+                "monitor-1", ScenarioKind.MONITOR, "알림", "{}", "rubric", ScenarioSource.RECORDED);
+        ReflectionTestUtils.setField(monitorScenario, "id", 3L);
+        given(scenarioRepository.findAllByOrderByCreatedAtDesc()).willReturn(List.of(monitorScenario));
+
+        final EvalRunEntity run = runner.run("no-evaluator");
+
+        final ArgumentCaptor<EvalResultEntity> captor = ArgumentCaptor.forClass(EvalResultEntity.class);
+        verify(resultRepository, times(1)).save(captor.capture());
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(run.getStatus()).isEqualTo(EvalRunStatus.COMPLETED);
+            softly.assertThat(run.getPassCount()).isZero();
+            softly.assertThat(captor.getValue().getVerdict()).isEqualTo(EvalVerdict.FAIL);
+        });
     }
 
     private EvalScenarioEntity scenario(Long id) {

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/EvalRunnerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/EvalRunnerTest.java
@@ -103,6 +103,22 @@ class EvalRunnerTest {
     }
 
     @Test
+    void kind를_지정하면_해당_kind_시나리오만_실행한다() {
+        given(scenarioRepository.findAllByKindOrderByCreatedAtDesc(ScenarioKind.CHAT))
+                .willReturn(List.of(scenario(1L)));
+        given(judgeClient.evaluate(anyString(), anyString(), anyString()))
+                .willReturn(new JudgeScore(5, 5, false, EvalVerdict.PASS, "정답"));
+
+        final EvalRunEntity run = runner.run("chat-only", 1, ScenarioKind.CHAT);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(run.getScenarioCount()).isEqualTo(1);
+            softly.assertThat(run.getPassCount()).isEqualTo(1);
+        });
+        verify(scenarioRepository, times(0)).findAllByOrderByCreatedAtDesc();
+    }
+
+    @Test
     void 평가기가_없는_kind의_시나리오는_FAIL_결과로_기록된다() {
         final EvalScenarioEntity monitorScenario = EvalScenarioEntity.create(
                 "monitor-1", ScenarioKind.MONITOR, "알림", "{}", "rubric", ScenarioSource.RECORDED);

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/EvalRunnerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/EvalRunnerTest.java
@@ -21,6 +21,7 @@ import coffeeshout.zzolbot.eval.infra.EvalScenarioRepository;
 import coffeeshout.zzolbot.eval.infra.JudgeClient;
 import coffeeshout.zzolbot.eval.infra.ToolSnapshotCodec;
 import coffeeshout.zzolbot.application.ZzolBotChatService;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import coffeeshout.zzolbot.eval.domain.ScenarioSource;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +112,7 @@ class EvalRunnerTest {
 
     private EvalScenarioEntity scenario(Long id) {
         final EvalScenarioEntity entity = EvalScenarioEntity.create(
-                "scenario-" + id, "질문 " + id, "[]", "rubric", ScenarioSource.MANUAL);
+                "scenario-" + id, ScenarioKind.CHAT, "질문 " + id, "[]", "rubric", ScenarioSource.MANUAL);
         ReflectionTestUtils.setField(entity, "id", id);
         return entity;
     }

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/MonitorScenarioEvaluatorTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/application/MonitorScenarioEvaluatorTest.java
@@ -1,0 +1,84 @@
+package coffeeshout.zzolbot.eval.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import coffeeshout.zzolbot.eval.domain.MonitorScenarioFixture;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
+import coffeeshout.zzolbot.eval.domain.ScenarioSource;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
+import coffeeshout.zzolbot.eval.infra.MonitorFixtureCodec;
+import coffeeshout.zzolbot.monitor.domain.FiringAlert;
+import coffeeshout.zzolbot.monitor.domain.MonitorAnalysis;
+import coffeeshout.zzolbot.monitor.infra.AnomalyAnalyzer;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MonitorScenarioEvaluatorTest {
+
+    private static final FiringAlert ALERT = new FiringAlert(
+            "IpBanRateSpike", "warning", "fp-1", "신규 IP BAN 급증", "설명", Map.of("incident_group", "ip-blocking"));
+
+    @Mock
+    private AnomalyAnalyzer analyzer;
+    @Mock
+    private MonitorFixtureCodec codec;
+
+    private MonitorScenarioEvaluator evaluator;
+
+    @BeforeEach
+    void setUp() {
+        evaluator = new MonitorScenarioEvaluator(analyzer, codec);
+    }
+
+    @Test
+    void kind는_MONITOR다() {
+        assertThat(evaluator.kind()).isEqualTo(ScenarioKind.MONITOR);
+    }
+
+    @Test
+    void 픽스처를_분석기에_주입해_분석_결과를_평탄화한다() {
+        final MonitorScenarioFixture fixture = new MonitorScenarioFixture(ALERT, List.of("ERROR 로그 한 줄"), "prod");
+        given(codec.fromJson("{}")).willReturn(fixture);
+        given(analyzer.analyze(ALERT, List.of("ERROR 로그 한 줄"), "prod"))
+                .willReturn(new MonitorAnalysis("스캐너 스윕으로 차단 급증", "악성 경로 접근", List.of("차단 IP 대역 확인"), true));
+
+        final EvalAnswer answer = evaluator.evaluate(scenario());
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(answer.answer()).contains("요약: 스캐너 스윕으로 차단 급증");
+            softly.assertThat(answer.answer()).contains("근거 발견: 예");
+            softly.assertThat(answer.answer()).contains("원인 가설: 악성 경로 접근");
+            softly.assertThat(answer.answer()).contains("- 차단 IP 대역 확인");
+            softly.assertThat(answer.missingToolCalls()).isZero();
+        });
+    }
+
+    @Test
+    void 근거_없음으로_강등된_분석은_가설과_조치가_없음으로_표기된다() {
+        final MonitorScenarioFixture fixture = new MonitorScenarioFixture(ALERT, List.of("무관한 로그"), "prod");
+        given(codec.fromJson("{}")).willReturn(fixture);
+        given(analyzer.analyze(ALERT, List.of("무관한 로그"), "prod"))
+                .willReturn(new MonitorAnalysis("근거 없음", "", List.of(), false));
+
+        final EvalAnswer answer = evaluator.evaluate(scenario());
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(answer.answer()).contains("근거 발견: 아니오");
+            softly.assertThat(answer.answer()).contains("원인 가설: (없음)");
+            softly.assertThat(answer.answer()).contains("제안 조치: (없음)");
+        });
+    }
+
+    private EvalScenarioEntity scenario() {
+        return EvalScenarioEntity.create(
+                "monitor-1", ScenarioKind.MONITOR, "알림: IpBanRateSpike", "{}", "rubric", ScenarioSource.RECORDED);
+    }
+}

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/config/MonitorEvalSeedInitializerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/config/MonitorEvalSeedInitializerTest.java
@@ -1,0 +1,79 @@
+package coffeeshout.zzolbot.eval.config;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.zzolbot.eval.domain.MonitorScenarioFixture;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioEntity;
+import coffeeshout.zzolbot.eval.infra.EvalScenarioRepository;
+import coffeeshout.zzolbot.eval.infra.MonitorFixtureCodec;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * 실제 classpath의 monitor-seed JSON을 파싱해 적재하는지 검증한다 —
+ * 시드 파일 스키마가 깨지면 이 테스트가 잡는다(로더는 파싱 실패를 warn으로 삼키므로).
+ */
+@ExtendWith(MockitoExtension.class)
+class MonitorEvalSeedInitializerTest {
+
+    private static final int SEED_COUNT = 5;
+
+    @Mock
+    private EvalScenarioRepository scenarioRepository;
+
+    private MonitorFixtureCodec codec;
+    private MonitorEvalSeedInitializer initializer;
+
+    @BeforeEach
+    void setUp() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        codec = new MonitorFixtureCodec(objectMapper);
+        initializer = new MonitorEvalSeedInitializer(scenarioRepository, codec, objectMapper);
+    }
+
+    @Test
+    void 모든_모니터_시드를_MONITOR_시나리오로_적재한다() {
+        given(scenarioRepository.existsByName(anyString())).willReturn(false);
+
+        initializer.run(null);
+
+        final ArgumentCaptor<EvalScenarioEntity> captor = ArgumentCaptor.forClass(EvalScenarioEntity.class);
+        verify(scenarioRepository, times(SEED_COUNT)).save(captor.capture());
+        SoftAssertions.assertSoftly(softly -> {
+            for (EvalScenarioEntity saved : captor.getAllValues()) {
+                softly.assertThat(saved.getKind()).isEqualTo(ScenarioKind.MONITOR);
+                softly.assertThat(saved.getQuestion()).isNotBlank();
+                softly.assertThat(saved.getRubric()).isNotBlank();
+                final MonitorScenarioFixture fixture = codec.fromJson(saved.getSnapshotJson());
+                softly.assertThat(fixture.alert().alertname()).isNotBlank();
+                softly.assertThat(fixture.logSamples()).isNotEmpty();
+                softly.assertThat(fixture.logEnvironment()).isEqualTo("prod");
+            }
+            final List<String> names = captor.getAllValues().stream().map(EvalScenarioEntity::getName).toList();
+            softly.assertThat(names).contains(
+                    "monitor-ip-ban-unrelated-cardgame-errors",
+                    "monitor-ip-blocking-true-scanner-evidence");
+        });
+    }
+
+    @Test
+    void 이미_존재하는_이름의_시드는_건너뛴다() {
+        given(scenarioRepository.existsByName(anyString())).willReturn(true);
+
+        initializer.run(null);
+
+        verify(scenarioRepository, times(0)).save(any());
+    }
+}

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/infra/MonitorFixtureCodecTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/infra/MonitorFixtureCodecTest.java
@@ -1,0 +1,35 @@
+package coffeeshout.zzolbot.eval.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coffeeshout.zzolbot.eval.domain.MonitorScenarioFixture;
+import coffeeshout.zzolbot.monitor.domain.FiringAlert;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MonitorFixtureCodecTest {
+
+    private final MonitorFixtureCodec codec = new MonitorFixtureCodec(new ObjectMapper());
+
+    @Test
+    void 직렬화_역직렬화_왕복이_원본을_보존한다() {
+        final MonitorScenarioFixture fixture = new MonitorScenarioFixture(
+                new FiringAlert("IpBanRateSpike", "warning", "fp-1", "요약", "설명",
+                        Map.of("incident_group", "ip-blocking")),
+                List.of("로그 A", "로그 B"),
+                "prod");
+
+        final MonitorScenarioFixture restored = codec.fromJson(codec.toJson(fixture));
+
+        assertThat(restored).isEqualTo(fixture);
+    }
+
+    @Test
+    void 잘못된_JSON이면_예외를_던진다() {
+        assertThatThrownBy(() -> codec.fromJson("not-json"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/ui/ZzolBotEvalControllerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/eval/ui/ZzolBotEvalControllerTest.java
@@ -1,6 +1,7 @@
 package coffeeshout.zzolbot.eval.ui;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -10,6 +11,7 @@ import coffeeshout.zzolbot.eval.application.EvalRunner;
 import coffeeshout.zzolbot.eval.application.EvalScenarioService;
 import coffeeshout.zzolbot.eval.domain.EvalVerdict;
 import coffeeshout.zzolbot.eval.domain.JudgeScore;
+import coffeeshout.zzolbot.eval.domain.ScenarioKind;
 import coffeeshout.zzolbot.eval.infra.EvalResultEntity;
 import coffeeshout.zzolbot.eval.infra.EvalResultRepository;
 import coffeeshout.zzolbot.eval.infra.EvalRunEntity;
@@ -33,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -64,10 +67,26 @@ class ZzolBotEvalControllerTest {
 
     @Test
     void startRun_은_202를_반환하고_평가를_비동기로_실행한다() {
-        final var response = controller.startRun(new RunRequest("baseline", null));
+        final var response = controller.startRun(new RunRequest("baseline", null, null));
 
         assertThat(response.getStatusCode().value()).isEqualTo(202);
-        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> verify(evalRunner).run("baseline", 1));
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> verify(evalRunner).run("baseline", 1, null));
+    }
+
+    @Test
+    void startRun_에_kind를_지정하면_러너에_전달한다() {
+        final var response = controller.startRun(new RunRequest("monitor-baseline", null, "monitor"));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(202);
+        await().atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> verify(evalRunner).run("monitor-baseline", 1, ScenarioKind.MONITOR));
+    }
+
+    @Test
+    void startRun_에_알_수_없는_kind면_400을_던진다() {
+        assertThatThrownBy(() -> controller.startRun(new RunRequest("bad", null, "bogus")))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("400");
     }
 
     @Test


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1626

# 🚀 작업 내용

## 문제 상황

zzolbot에서 LLM이 답을 만드는 경로는 두 개다. 운영자가 질문하는 **챗봇 경로**와, Alertmanager 알림을 받아 자동으로 분석해 Slack으로 보내는 **알림 분석 경로**다.

챗봇 경로에는 평가 하네스가 있어서(골든 시나리오 replay) 프롬프트를 바꿔도 품질이 나빠졌는지 감지할 수 있다. 그런데 **알림 분석 경로에는 검증 장치가 하나도 없다.** 사람이 지켜보지 않는 경로인데, 오진이 그대로 Slack 알림으로 나간다.

실제로 있었던 일: 7월 IP 차단 인시던트 때 봇이 "신규 IP BAN 급증" 알림을 분석하면서, 그 시각 로그에 있던 **무관한 카드게임 이벤트 에러 4줄을 근거로 원인을 지목**했다(Loki 로그 복원 + prod 분석 기록 대조로 확인).

## 문제 원인

- 알림 분석 프롬프트를 고칠 때(#1592·#1595에서 실제로 여러 번 고쳤다) "이전 인시던트에서도 여전히 잘 동작하는가"를 확인할 방법이 손 재현뿐이었다
- 챗봇 평가 하네스를 만들 때의 한계 — "골든 시나리오의 정답은 도메인을 아는 사람이 수기로 채워야 한다"는 병목 — 도 그대로 남아 있었다

## 해결책 대안

1. **가상 시나리오를 수기로 작성** — 정답 병목이 그대로고, 실제 장애 분포와 어긋난 시나리오가 되기 쉽다. 기각.
2. **라이브 알림으로 검증** — 입력(로그)이 매번 달라져서 프롬프트를 바꾼 효과인지 데이터가 달라진 효과인지 구분할 수 없다. 챗봇 eval 때 기각한 이유와 동일. 기각.
3. **실제 인시던트를 박제해 replay (선택)** — 운영에서 이미 발생한 알림·로그를 고정 입력으로 저장하고, LLM 추론만 라이브로 실행한다. 정답(채점 기준)은 이미 결론이 난 과거 인시던트라서 쓰기 쉽고, 두 프롬프트 버전을 같은 조건에서 비교할 수 있다. 챗봇 eval이 도구 실행 결과만 갈아끼운 것과 같은 원리다.

## 구현 방법

1. **시나리오에 kind(CHAT/MONITOR) 축 추가** (V42) — 시나리오가 무엇을 채점하는지 구분. 기존 행은 CHAT으로 백필.
2. **평가 로직을 ScenarioEvaluator로 분리** — 러너는 실행·재시도·채점·저장만 담당하고, 시나리오 replay는 kind별 평가기가 담당. 챗봇 경로는 그대로 옮겨서 동작 변화 없음.
3. **MonitorScenarioEvaluator 추가** — 박제된 알림·로그를 분석 포트(AnomalyAnalyzer)에 직접 주입. 서비스 계층을 거치지 않아 일일 예산 소모·Slack 발송·monitor_run 기록이 생기지 않는다.
4. **7월 인시던트 기반 골든 시나리오 5종 + 로더** — 실제 오진 사례 2종, 자정 로그 재적재 아티팩트 2종, 진짜 근거를 줬을 때의 검증 1종. 닉네임·IP는 마스킹.
5. **어드민 평가 탭** — 시나리오 종류 표시, 실행 시 대상(전체/챗봇/알림 분석) 선택.

# 💬 리뷰 중점사항

- **평가기가 AnomalyAnalyzer를 직접 호출하는 설계**: 서비스 계층을 재사용하면 예산·Slack·DB 기록이 딸려와서 일부러 피했다. 로그 0건 게이트(noEvidence)는 이미 단위 테스트로 고정돼 있어 골든셋 대상에서 뺐다.
- **eval은 프로덕션 알림 분석과 같은 zzolBotGemini 레이트리밋(10회/분)을 공유한다**: 시나리오 5개 순차 실행이라 v1에서는 수용. 문제 되면 judge처럼 인스턴스 분리.
- **시드의 알림 내용은 현행 알림 룰 annotation 기준으로 재구성**: 당시 prod DB 기록은 export 인코딩 문제로 한글이 깨져 있었고, 현행 룰 기준이 앞으로 들어올 실제 입력과도 일치한다. 로그 원문은 Loki 복원본 그대로(마스킹만 적용).
- **이슈 성공 기준 중 "베이스라인 성적 기록"은 이 PR 범위 밖**: dev 배포 후 어드민에서 monitor 대상으로 1회 실행해 기록 예정(Gemini 약 10콜). 재적재 아티팩트 시나리오 2종은 현행 프롬프트에 로그 시각 검증 규칙이 없어 FAIL이 예상되며, 이는 회귀가 아니라 다음 개선 이슈의 근거다.


# 📋 남은 작업 (이 PR 범위 밖)

- [x] 베이스라인 성적 기록 — 로컬에서 monitor 대상 1회 실행 완료, **4/5 PASS** (상세는 #1626 코멘트). 유일한 FAIL(midnight-sparse: 근거 2줄인데 "근거 발견: 예" 단정)은 의도적으로 남긴 상태 — 후속 개선의 전후 비교 기준선이다
- [ ] 후속 이슈(평가 신뢰도 + 로그 조회 개선), 재측정 전 judge 수정이 선행돼야 한다
  - [ ] monitor judge 입력에 픽스처 로그 포함 — 현재 judge는 질문·기준·답변만 보므로 봇이 로그 속 값을 인용하면 환각으로 오판할 수 있다(측정 도구 결함, 재측정 전 필수)
  - [ ] 로그 조회를 알림 연관 로그(WARN 포함)로 확장 — 7월 오진의 근본 원인 절반
  - [ ] 동일 로그 집계(같은 줄 × N회) — 토큰 절감 + 근거 밀도 개선
  - [ ] 프롬프트에 로그 시각·규모 정합 검증 규칙 — baseline FAIL이 드러낸 구멍
  - [ ] 같은 골든셋으로 재측정해 전후 비교 기록
- [ ] 인시던트 자동 수확 — 분석 실행 시점의 로그 샘플을 실행 이력에 함께 저장해, 이후 인시던트는 소급 복원 없이 시나리오로 만들 수 있게
