### PR TITLE
[chore] 워크트리에서 로컬 실행 가능하게 — bootRun 작업 디렉터리·env 자동 연결

### DIFF
--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -82,6 +82,9 @@ MAIN="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"   # 주 저�
 git fetch origin dev
 git worktree add -b "{type}/{N}-{slug}" "$MAIN/.claude/worktrees/{type}-{N}" origin/dev
 git -C "$MAIN/.claude/worktrees/{type}-{N}" branch --unset-upstream 2>/dev/null || true
+
+# env 심볼릭 링크 + 워크트리 전용 포트 (#1660)
+bash "$MAIN/.claude/skills/create-issue/worktree-setup.sh" "$MAIN/.claude/worktrees/{type}-{N}"
 ```
 
 그 뒤 `EnterWorktree`에 `path`로 그 경로를 넘겨 세션을 옮긴다.
@@ -89,6 +92,7 @@ git -C "$MAIN/.claude/worktrees/{type}-{N}" branch --unset-upstream 2>/dev/null 
 - **디렉터리명(`{type}-{N}`)과 브랜치명(`{type}/{N}-{slug}`)은 다르다.** 디렉터리에는 `/`를 쓸 수 없고, 브랜치명은 `create-pr`이 `{N}`을 뽑아 `close #N`을 채우는 근거라 규약을 지켜야 한다.
 - **`EnterWorktree`를 `name`으로 부르지 않는다.** 그러면 브랜치명이 `worktree-<name>`이 되어 규약을 깨고 이슈 번호 추출이 실패한다. 브랜치는 위처럼 `git worktree add -b`로 만들고, `EnterWorktree`는 `path`로 들어가기만 한다.
 - `.claude/worktrees/`는 `.gitignore` 대상이다 — 워크트리가 저장소를 더럽히지 않는다.
+- **`.env` 계열은 `.gitignore` 대상이라 `git worktree add`가 가져오지 않는다.** 위 `worktree-setup.sh`가 주 저장소에서 심볼릭 링크하고, 워크트리 전용 포트를 `.ports`에 잡는다. 이걸 건너뛰면 백엔드는 OAuth 없이 뜨고 프론트는 `API_URL`이 `undefined`인 채로 조용히 백엔드에 못 붙는다(#1660). 실행은 [`run-local`](../skills/run-local/SKILL.md).
 - 워크트리는 작업이 끝나도 자동으로 지우지 않는다. PR이 merge된 뒤 정리한다.
 
   ```bash

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -112,6 +112,11 @@ fi
 git -C "$WT" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1 && {
   echo "ABORT: upstream 이 남아있다 — 이 상태로 두면 push 가 dev 로 직행한다(#1404)"; exit 1; }
 
+# env 심볼릭 링크 + 워크트리 전용 포트 (#1660). 이게 없으면 워크트리에서 앱을 띄울 수 없고,
+# 프론트는 API_URL 이 undefined 인 채로 조용히 백엔드에 못 붙는다.
+bash "$MAIN/.claude/skills/create-issue/worktree-setup.sh" "$WT" || {
+  echo "경고: 워크트리 준비 실패 — 로컬 실행 시 run-local 스킬의 1단계를 수동으로 돌린다"; }
+
 echo "$WT"
 ```
 

--- a/.claude/skills/create-issue/worktree-setup.sh
+++ b/.claude/skills/create-issue/worktree-setup.sh
@@ -15,12 +15,25 @@ WT="${1:?ABORT: 워크트리 경로를 인자로 넘겨야 한다}"
 MAIN="$(git -C "$WT" worktree list --porcelain | sed -n '1s/^worktree //p')"
 [ -n "$MAIN" ] || { echo "ABORT: 주 저장소 경로를 찾지 못했다"; exit 1; }
 
+# 주 저장소를 대상으로 돌리면 ln -sfn 이 자기 자신을 가리키는 링크를 만드는데,
+# ln -f 는 타깃을 먼저 지우므로 원본 .env 가 파괴된다(자기참조 dangling 링크만 남는다).
+# gitignore 대상이라 백업도 없어 복구가 불가능하다.
+[ "$(cd "$WT" && pwd -P)" != "$(cd "$MAIN" && pwd -P)" ] || {
+  echo "ABORT: 주 저장소에서는 돌리지 않는다 — 워크트리 경로를 넘겨라"; exit 1; }
+
 # ── 1. env 심볼릭 링크 ────────────────────────────────────────────────
 # 사본이 아니라 링크다. 원본이 하나만 존재해 오래된 사본이 남지 않고,
 # 비밀값이 디스크에 한 벌만 있다. 워크트리별로 다른 값이 필요하면 그 링크만 cp 로 바꾼다.
 #
 # git 은 통째로 무시된 디렉터리를 "dir/" 한 줄로 접어서 내놓는다. 다른 워크트리가 그렇게 걸리므로
 # pathspec 에 기대지 않고 명시적으로 거른다 — 안 거르면 워크트리 안에 워크트리를 링크하려다 죽는다.
+#
+# 프로세스 치환(`done < <(git ...)`)은 set -e·pipefail 어느 쪽에도 걸리지 않는다.
+# git 이 실패하면 루프가 0회 돌고 exit 0 으로 끝나, 호출부의 `|| 경고` 가드가 감지하지 못한다.
+# 그러면 이 스크립트가 막으려던 "env 없는 워크트리"가 조용히 만들어진다. 먼저 받아서 실패를 드러낸다.
+env_files="$(git -C "$MAIN" ls-files --others --ignored --exclude-standard -- '*.env' '*.env.*')" \
+  || { echo "ABORT: env 파일 목록 조회 실패"; exit 1; }
+
 linked=0
 while IFS= read -r f; do
   [ -n "$f" ] || continue
@@ -29,11 +42,18 @@ while IFS= read -r f; do
     */) continue ;;                    # 접힌 디렉터리
   esac
   [ -f "$MAIN/$f" ] || continue        # 실제 파일만
+  # 링크가 아닌 실파일이 이미 있으면 워크트리 전용 값을 일부러 둔 것이다(위 주석의 cp 사용법).
+  # 덮어쓰면 그 값이 말없이 사라진다.
+  if [ -e "$WT/$f" ] && [ ! -L "$WT/$f" ]; then
+    echo "  keep: $f (워크트리 전용 실파일)"
+    linked=$((linked + 1))
+    continue
+  fi
   mkdir -p "$WT/$(dirname "$f")"
   ln -sfn "$MAIN/$f" "$WT/$f"
   echo "  link: $f"
   linked=$((linked + 1))
-done < <(git -C "$MAIN" ls-files --others --ignored --exclude-standard -- '*.env' '*.env.*')
+done <<< "$env_files"
 
 [ "$linked" -gt 0 ] || echo "  (연결할 env 파일 없음)"
 

--- a/.claude/skills/create-issue/worktree-setup.sh
+++ b/.claude/skills/create-issue/worktree-setup.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# 새 워크트리를 로컬 실행 가능한 상태로 만든다 (#1660).
+#
+#   1. 주 저장소의 gitignore 된 env 파일을 심볼릭 링크로 건다
+#   2. 이 워크트리 전용 포트 쌍을 잡아 .ports 에 기록한다
+#
+# 사용: bash worktree-setup.sh <워크트리 경로>
+#
+# env 파일은 열지 않는다 — 경로만 다루므로 비밀값이 로그·출력에 남지 않는다.
+set -euo pipefail
+
+WT="${1:?ABORT: 워크트리 경로를 인자로 넘겨야 한다}"
+[ -d "$WT" ] || { echo "ABORT: 워크트리 경로가 없다: $WT"; exit 1; }
+
+MAIN="$(git -C "$WT" worktree list --porcelain | sed -n '1s/^worktree //p')"
+[ -n "$MAIN" ] || { echo "ABORT: 주 저장소 경로를 찾지 못했다"; exit 1; }
+
+# ── 1. env 심볼릭 링크 ────────────────────────────────────────────────
+# 사본이 아니라 링크다. 원본이 하나만 존재해 오래된 사본이 남지 않고,
+# 비밀값이 디스크에 한 벌만 있다. 워크트리별로 다른 값이 필요하면 그 링크만 cp 로 바꾼다.
+#
+# git 은 통째로 무시된 디렉터리를 "dir/" 한 줄로 접어서 내놓는다. 다른 워크트리가 그렇게 걸리므로
+# pathspec 에 기대지 않고 명시적으로 거른다 — 안 거르면 워크트리 안에 워크트리를 링크하려다 죽는다.
+linked=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  case "$f" in
+    .claude/worktrees/*) continue ;;   # 다른 워크트리의 사본
+    */) continue ;;                    # 접힌 디렉터리
+  esac
+  [ -f "$MAIN/$f" ] || continue        # 실제 파일만
+  mkdir -p "$WT/$(dirname "$f")"
+  ln -sfn "$MAIN/$f" "$WT/$f"
+  echo "  link: $f"
+  linked=$((linked + 1))
+done < <(git -C "$MAIN" ls-files --others --ignored --exclude-standard -- '*.env' '*.env.*')
+
+[ "$linked" -gt 0 ] || echo "  (연결할 env 파일 없음)"
+
+# ── 2. 워크트리 전용 포트 ─────────────────────────────────────────────
+# 심볼릭 링크한 env 는 모든 워크트리가 공유하므로 포트를 거기 둘 수 없다.
+# 여기서 잡은 값을 런처가 환경변수로 export 하면, dotenv 계열은 이미 있는
+# 환경변수를 덮지 않으므로 링크된 파일 값을 이긴다.
+port_taken() {
+  local port="$1"
+  lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && return 0
+  grep -rqs "=${port}\$" "$MAIN/.claude/worktrees"/*/.ports 2>/dev/null && return 0
+  return 1
+}
+
+find_free_port() {
+  local port="$1"
+  while port_taken "$port"; do
+    port=$((port + 1))
+  done
+  echo "$port"
+}
+
+if [ -f "$WT/.ports" ]; then
+  echo "  .ports 이미 있음 — 유지한다"
+else
+  BACKEND_PORT="$(find_free_port 8080)"
+  FRONTEND_PORT="$(find_free_port 3000)"
+  cat > "$WT/.ports" <<EOF
+# 이 워크트리 전용 포트 (#1660). 런처가 읽어 환경변수로 export 한다.
+BACKEND_PORT=$BACKEND_PORT
+FRONTEND_PORT=$FRONTEND_PORT
+EOF
+  echo "  ports: backend=$BACKEND_PORT frontend=$FRONTEND_PORT"
+fi

--- a/.claude/skills/create-issue/worktree-setup.sh
+++ b/.claude/skills/create-issue/worktree-setup.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # 새 워크트리를 로컬 실행 가능한 상태로 만든다 (#1660).
 #
-#   1. 주 저장소의 gitignore 된 env 파일을 심볼릭 링크로 건다
-#   2. 이 워크트리 전용 포트 쌍을 잡아 .ports 에 기록한다
+# 주 저장소의 gitignore 된 env 파일을 심볼릭 링크로 건다.
 #
 # 사용: bash worktree-setup.sh <워크트리 경로>
 #
@@ -56,35 +55,3 @@ while IFS= read -r f; do
 done <<< "$env_files"
 
 [ "$linked" -gt 0 ] || echo "  (연결할 env 파일 없음)"
-
-# ── 2. 워크트리 전용 포트 ─────────────────────────────────────────────
-# 심볼릭 링크한 env 는 모든 워크트리가 공유하므로 포트를 거기 둘 수 없다.
-# 여기서 잡은 값을 런처가 환경변수로 export 하면, dotenv 계열은 이미 있는
-# 환경변수를 덮지 않으므로 링크된 파일 값을 이긴다.
-port_taken() {
-  local port="$1"
-  lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && return 0
-  grep -rqs "=${port}\$" "$MAIN/.claude/worktrees"/*/.ports 2>/dev/null && return 0
-  return 1
-}
-
-find_free_port() {
-  local port="$1"
-  while port_taken "$port"; do
-    port=$((port + 1))
-  done
-  echo "$port"
-}
-
-if [ -f "$WT/.ports" ]; then
-  echo "  .ports 이미 있음 — 유지한다"
-else
-  BACKEND_PORT="$(find_free_port 8080)"
-  FRONTEND_PORT="$(find_free_port 3000)"
-  cat > "$WT/.ports" <<EOF
-# 이 워크트리 전용 포트 (#1660). 런처가 읽어 환경변수로 export 한다.
-BACKEND_PORT=$BACKEND_PORT
-FRONTEND_PORT=$FRONTEND_PORT
-EOF
-  echo "  ports: backend=$BACKEND_PORT frontend=$FRONTEND_PORT"
-fi

--- a/.claude/skills/run-local/SKILL.md
+++ b/.claude/skills/run-local/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: run-local
-description: 현재 워크트리에서 백엔드·프론트엔드를 로컬로 띄운다. "서버 띄워줘", "로컬에서 실행해줘", 변경을 실제 앱에서 확인해야 할 때 사용한다. 워크트리마다 포트가 다르므로 동시에 여러 작업을 돌릴 수 있다.
+description: 현재 워크트리에서 백엔드·프론트엔드를 로컬로 띄운다. "서버 띄워줘", "로컬에서 실행해줘", 변경을 실제 앱에서 확인해야 할 때 사용한다.
 ---
 
 # run-local
 
 실제 셸은 [`run.sh`](run.sh)에 있다. 이 스킬은 **언제·어떻게 부를지**만 정한다 — 셸 명령을 여기 복사하지 않는다. 두 벌이 되면 갈라진다.
 
-## 왜 스크립트를 따로 두나
+## 한 번에 한 워크트리만 띄운다
 
-막히는 지점 대부분은 Claude 전용이 아니다. 사람이 클론해도 똑같이 겪는다. 그래서 실행 로직은 저장소에 커밋된 스크립트에 두고, 이 스킬은 백그라운드 실행·로그 경로·포트 정리 같은 오케스트레이션만 맡는다.
+포트는 백엔드 `8080`·프론트 `3000` **고정**이다. 워크트리마다 포트를 달리하는 방안을 시도했으나 성립하지 않았다 — `application-local.yml`의 `web.cors.allowed-origins`·`user.oauth.frontend-redirect-uri`·`room.qr.prefix`와 `docker-compose.yml`의 호스트 포트가 전부 그 두 값으로 하드코딩돼 있다. 포트만 바꾸면 **화면은 뜨는데 API가 전부 CORS로 막히는** 형태로 반쯤 깨진다.
+
+그래서 포트가 잡혀 있으면 다른 포트로 새지 않고 `run.sh`가 **멈춘다.** 다른 워크트리에서 띄운 것을 먼저 끄면 된다.
+
+> 여러 워크트리를 정말 동시에 띄워야 하면 위 하드코딩부터 걷어내야 한다 — 별도 이슈감이다.
 
 ## 1. 최초 1회 — 워크트리 준비
 
-`.env`가 없거나 `.ports`가 없으면 먼저 돌린다. `create-issue`가 워크트리를 만들 때 이미 돌렸다면 건너뛴다.
+`.env`가 없으면 먼저 돌린다. `create-issue`가 워크트리를 만들 때 이미 돌렸다면 건너뛴다.
 
 **워크트리 안에서만 돌린다.** 주 저장소를 대상으로 주면 스크립트가 `ABORT`로 막는다 — 자기 자신을 가리키는 링크가 되어 원본 `.env`가 파괴되기 때문이다.
 
@@ -24,8 +28,6 @@ MAIN="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
 bash "$MAIN/.claude/skills/create-issue/worktree-setup.sh" "$WT"
 ```
 
-`.env` 계열을 주 저장소에서 심볼릭 링크하고, 이 워크트리 전용 포트 쌍을 `.ports`에 잡는다.
-
 ## 2. 실행
 
 **항상 백그라운드로 띄우고 로그를 파일에 남긴다.** 포그라운드로 돌리면 세션이 묶여 아무 작업도 못 한다.
@@ -35,32 +37,35 @@ bash .claude/skills/run-local/run.sh backend   > <스크래치패드>/backend.lo
 bash .claude/skills/run-local/run.sh frontend  > <스크래치패드>/frontend.log 2>&1 &
 ```
 
-포트는 `.ports`에서 읽는다. 값이 필요하면 그 파일을 보면 된다(`BACKEND_PORT`·`FRONTEND_PORT`).
-
 ## 3. 기동 확인 — 로그가 아니라 엔드포인트로
 
 컴파일 성공 메시지는 기동 완료가 아니다. 준비될 때까지 폴링한다.
 
 ```bash
-curl -sf "http://localhost:$BACKEND_PORT/actuator/health"   # status: UP
-curl -sf -o /dev/null "http://localhost:$FRONTEND_PORT/"
+curl -sf http://localhost:8080/actuator/health   # status: UP
+curl -sf -o /dev/null http://localhost:3000/
 ```
 
 기동에 실패하면 로그에서 `Application run failed` 또는 `Caused by`를 찾는다.
 
-## 4. 정리
-
-포트를 잡은 채로 다시 띄우면 `EADDRINUSE`로 죽는다. 재시작 전에 끊는다.
+**화면이 뜬 것과 동작하는 것은 다르다.** API가 실제로 오가는지 봐야 하면 프론트 origin으로 요청을 보내 확인한다.
 
 ```bash
-lsof -nP -iTCP:"$BACKEND_PORT" -sTCP:LISTEN -t | xargs -r kill
+curl -s -o /dev/null -w '%{http_code}\n' -H 'Origin: http://localhost:3000' \
+  -X OPTIONS -H 'Access-Control-Request-Method: GET' http://localhost:8080/users/me/friends
 ```
 
-`.ports`가 워크트리마다 다르므로, **다른 워크트리의 서버를 죽이지 않는다.** 여러 작업을 동시에 돌리는 것이 워크트리 분리의 목적이다.
+## 4. 정리
+
+포트를 잡은 채 다시 띄우면 `run.sh`가 멈춘다. 재시작 전에 끊는다.
+
+```bash
+lsof -nP -iTCP:8080 -sTCP:LISTEN -t | xargs -r kill
+```
 
 ## 알아둘 것
 
 - **컨테이너는 자동으로 뜬다.** `bootRun`의 작업 디렉터리가 `backend/`라 `spring.docker.compose.file`이 해석된다. Docker가 꺼져 있으면 기동이 실패한다.
+- **MySQL·Valkey는 워크트리 간 공유된다.** compose 프로젝트명이 파일 부모 디렉터리명(`backend`)이라 모든 워크트리가 같은 컨테이너를 쓴다. `ddl-auto: create`이므로 **백엔드를 띄울 때마다 스키마가 새로 만들어진다** — 다른 워크트리에서 쌓아둔 로컬 데이터는 남지 않는다.
 - **`.env`는 셸에서 소싱하지 않는다.** `springboot4-dotenv`가 `backend/.env`를 직접 읽는다. `source`는 값에 공백·따옴표가 있으면 깨진다.
-- **프론트의 `API_URL`은 스크립트가 주입한다.** 심볼릭 링크된 `.env.development`는 모든 워크트리가 공유하므로 거기 값을 따르면 다른 워크트리의 백엔드에 붙는다.
 - 로그인(OAuth)은 `backend/.env`의 실제 자격증명이 있어야 동작한다. 링크가 안 걸려 있으면 로그인만 조용히 실패한다.

--- a/.claude/skills/run-local/SKILL.md
+++ b/.claude/skills/run-local/SKILL.md
@@ -15,8 +15,13 @@ description: 현재 워크트리에서 백엔드·프론트엔드를 로컬로 �
 
 `.env`가 없거나 `.ports`가 없으면 먼저 돌린다. `create-issue`가 워크트리를 만들 때 이미 돌렸다면 건너뛴다.
 
+**워크트리 안에서만 돌린다.** 주 저장소를 대상으로 주면 스크립트가 `ABORT`로 막는다 — 자기 자신을 가리키는 링크가 되어 원본 `.env`가 파괴되기 때문이다.
+
 ```bash
-bash "$(git rev-parse --show-toplevel)/.claude/skills/create-issue/worktree-setup.sh" "$(git rev-parse --show-toplevel)"
+# 워크트리 루트에서
+WT="$(git rev-parse --show-toplevel)"
+MAIN="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
+bash "$MAIN/.claude/skills/create-issue/worktree-setup.sh" "$WT"
 ```
 
 `.env` 계열을 주 저장소에서 심볼릭 링크하고, 이 워크트리 전용 포트 쌍을 `.ports`에 잡는다.

--- a/.claude/skills/run-local/SKILL.md
+++ b/.claude/skills/run-local/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: run-local
+description: 현재 워크트리에서 백엔드·프론트엔드를 로컬로 띄운다. "서버 띄워줘", "로컬에서 실행해줘", 변경을 실제 앱에서 확인해야 할 때 사용한다. 워크트리마다 포트가 다르므로 동시에 여러 작업을 돌릴 수 있다.
+---
+
+# run-local
+
+실제 셸은 [`run.sh`](run.sh)에 있다. 이 스킬은 **언제·어떻게 부를지**만 정한다 — 셸 명령을 여기 복사하지 않는다. 두 벌이 되면 갈라진다.
+
+## 왜 스크립트를 따로 두나
+
+막히는 지점 대부분은 Claude 전용이 아니다. 사람이 클론해도 똑같이 겪는다. 그래서 실행 로직은 저장소에 커밋된 스크립트에 두고, 이 스킬은 백그라운드 실행·로그 경로·포트 정리 같은 오케스트레이션만 맡는다.
+
+## 1. 최초 1회 — 워크트리 준비
+
+`.env`가 없거나 `.ports`가 없으면 먼저 돌린다. `create-issue`가 워크트리를 만들 때 이미 돌렸다면 건너뛴다.
+
+```bash
+bash "$(git rev-parse --show-toplevel)/.claude/skills/create-issue/worktree-setup.sh" "$(git rev-parse --show-toplevel)"
+```
+
+`.env` 계열을 주 저장소에서 심볼릭 링크하고, 이 워크트리 전용 포트 쌍을 `.ports`에 잡는다.
+
+## 2. 실행
+
+**항상 백그라운드로 띄우고 로그를 파일에 남긴다.** 포그라운드로 돌리면 세션이 묶여 아무 작업도 못 한다.
+
+```bash
+bash .claude/skills/run-local/run.sh backend   > <스크래치패드>/backend.log  2>&1 &
+bash .claude/skills/run-local/run.sh frontend  > <스크래치패드>/frontend.log 2>&1 &
+```
+
+포트는 `.ports`에서 읽는다. 값이 필요하면 그 파일을 보면 된다(`BACKEND_PORT`·`FRONTEND_PORT`).
+
+## 3. 기동 확인 — 로그가 아니라 엔드포인트로
+
+컴파일 성공 메시지는 기동 완료가 아니다. 준비될 때까지 폴링한다.
+
+```bash
+curl -sf "http://localhost:$BACKEND_PORT/actuator/health"   # status: UP
+curl -sf -o /dev/null "http://localhost:$FRONTEND_PORT/"
+```
+
+기동에 실패하면 로그에서 `Application run failed` 또는 `Caused by`를 찾는다.
+
+## 4. 정리
+
+포트를 잡은 채로 다시 띄우면 `EADDRINUSE`로 죽는다. 재시작 전에 끊는다.
+
+```bash
+lsof -nP -iTCP:"$BACKEND_PORT" -sTCP:LISTEN -t | xargs -r kill
+```
+
+`.ports`가 워크트리마다 다르므로, **다른 워크트리의 서버를 죽이지 않는다.** 여러 작업을 동시에 돌리는 것이 워크트리 분리의 목적이다.
+
+## 알아둘 것
+
+- **컨테이너는 자동으로 뜬다.** `bootRun`의 작업 디렉터리가 `backend/`라 `spring.docker.compose.file`이 해석된다. Docker가 꺼져 있으면 기동이 실패한다.
+- **`.env`는 셸에서 소싱하지 않는다.** `springboot4-dotenv`가 `backend/.env`를 직접 읽는다. `source`는 값에 공백·따옴표가 있으면 깨진다.
+- **프론트의 `API_URL`은 스크립트가 주입한다.** 심볼릭 링크된 `.env.development`는 모든 워크트리가 공유하므로 거기 값을 따르면 다른 워크트리의 백엔드에 붙는다.
+- 로그인(OAuth)은 `backend/.env`의 실제 자격증명이 있어야 동작한다. 링크가 안 걸려 있으면 로그인만 조용히 실패한다.

--- a/.claude/skills/run-local/run.sh
+++ b/.claude/skills/run-local/run.sh
@@ -4,8 +4,11 @@
 # 사용: bash run.sh <backend|frontend>
 #
 # 포그라운드로 실행한다 — 백그라운드·로그 관리는 호출자(사람은 터미널, Claude 는 run-local 스킬)가 정한다.
-# 포트는 .ports 에서 읽어 환경변수로 export 한다. dotenv 계열은 이미 있는 환경변수를
-# 덮지 않으므로, 공유 심볼릭 링크된 .env 값보다 이 값이 이긴다.
+#
+# 포트는 백엔드 8080·프론트 3000 고정이다. 워크트리마다 다른 포트를 쓰려고 했으나 성립하지 않았다 —
+# CORS(allowed-origins)·OAuth 콜백·QR prefix·DB URL 이 전부 그 두 포트로 하드코딩돼 있어
+# 포트만 바꾸면 화면은 뜨는데 API 가 전부 막힌다. 그래서 한 번에 한 워크트리만 띄우고,
+# 포트가 잡혀 있으면 조용히 다른 포트로 새지 말고 시끄럽게 멈춘다.
 set -euo pipefail
 
 TARGET="${1:?ABORT: backend 또는 frontend 를 인자로 넘겨야 한다}"
@@ -13,21 +16,25 @@ TARGET="${1:?ABORT: backend 또는 frontend 를 인자로 넘겨야 한다}"
 # 워크트리 루트 (이 스크립트는 <root>/.claude/skills/run-local/ 에 있다)
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
-if [ -f "$ROOT/.ports" ]; then
-  # shellcheck disable=SC1091
-  . "$ROOT/.ports"
-else
-  echo "경고: .ports 가 없다 — 기본 포트를 쓴다. worktree-setup.sh 를 돌리면 워크트리 전용 포트가 잡힌다." >&2
-fi
+BACKEND_PORT=8080
+FRONTEND_PORT=3000
 
-BACKEND_PORT="${BACKEND_PORT:-8080}"
-FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+require_free_port() {
+  local port="$1" what="$2"
+  command -v lsof >/dev/null || return 0   # lsof 가 없으면 검사를 건너뛴다(실행은 막지 않는다)
+  lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 || return 0
+  echo "ABORT: 포트 $port 가 이미 사용 중이다 ($what)." >&2
+  echo "  다른 워크트리에서 띄운 것이라면 먼저 끈다:" >&2
+  echo "    lsof -nP -iTCP:$port -sTCP:LISTEN -t | xargs kill" >&2
+  echo "  포트를 바꿔 우회하지 않는다 — CORS·OAuth 콜백이 $BACKEND_PORT/$FRONTEND_PORT 고정이라 앱이 반쯤 깨진다." >&2
+  exit 1
+}
 
 case "$TARGET" in
   backend)
+    require_free_port "$BACKEND_PORT" "백엔드"
     cd "$ROOT/backend"
     export SPRING_PROFILES_ACTIVE="${SPRING_PROFILES_ACTIVE:-local}"
-    export SERVER_PORT="$BACKEND_PORT"
     echo "backend → http://localhost:$BACKEND_PORT"
     # 인자 없이 돈다. bootRun 의 workingDir 이 backend/ 라서
     #  - springboot4-dotenv 가 backend/.env 를 읽고
@@ -35,6 +42,7 @@ case "$TARGET" in
     exec ./gradlew :app:bootRun --console=plain
     ;;
   frontend)
+    require_free_port "$FRONTEND_PORT" "프론트엔드"
     cd "$ROOT/frontend"
     # node_modules 는 워크트리마다 따로 필요하다(gitignore 대상이라 worktree add 가 안 가져온다).
     # 워크트리 생성 때 일괄 설치하지 않는 건, 백엔드·문서만 건드리는 작업이 대부분이라
@@ -43,11 +51,7 @@ case "$TARGET" in
       echo "node_modules 가 없다 — npm ci 로 설치한다 (최초 1회)"
       npm ci
     fi
-    export PORT="$FRONTEND_PORT"
-    # 프론트가 '자기 워크트리의' 백엔드를 가리키게 한다.
-    # 이게 없으면 공유 .env.development 값을 따라가 다른 워크트리의 백엔드에 붙는다.
-    export API_URL="http://localhost:$BACKEND_PORT"
-    echo "frontend → http://localhost:$FRONTEND_PORT (API_URL=$API_URL)"
+    echo "frontend → http://localhost:$FRONTEND_PORT"
     exec npm run dev
     ;;
   *)

--- a/.claude/skills/run-local/run.sh
+++ b/.claude/skills/run-local/run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# 이 워크트리의 앱을 로컬에서 띄운다 (#1660).
+#
+# 사용: bash run.sh <backend|frontend>
+#
+# 포그라운드로 실행한다 — 백그라운드·로그 관리는 호출자(사람은 터미널, Claude 는 run-local 스킬)가 정한다.
+# 포트는 .ports 에서 읽어 환경변수로 export 한다. dotenv 계열은 이미 있는 환경변수를
+# 덮지 않으므로, 공유 심볼릭 링크된 .env 값보다 이 값이 이긴다.
+set -euo pipefail
+
+TARGET="${1:?ABORT: backend 또는 frontend 를 인자로 넘겨야 한다}"
+
+# 워크트리 루트 (이 스크립트는 <root>/.claude/skills/run-local/ 에 있다)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+if [ -f "$ROOT/.ports" ]; then
+  # shellcheck disable=SC1091
+  . "$ROOT/.ports"
+else
+  echo "경고: .ports 가 없다 — 기본 포트를 쓴다. worktree-setup.sh 를 돌리면 워크트리 전용 포트가 잡힌다." >&2
+fi
+
+BACKEND_PORT="${BACKEND_PORT:-8080}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+
+case "$TARGET" in
+  backend)
+    cd "$ROOT/backend"
+    export SPRING_PROFILES_ACTIVE="${SPRING_PROFILES_ACTIVE:-local}"
+    export SERVER_PORT="$BACKEND_PORT"
+    echo "backend → http://localhost:$BACKEND_PORT"
+    # 인자 없이 돈다. bootRun 의 workingDir 이 backend/ 라서
+    #  - springboot4-dotenv 가 backend/.env 를 읽고
+    #  - spring.docker.compose.file 이 해석돼 컨테이너가 자동 기동한다
+    exec ./gradlew :app:bootRun --console=plain
+    ;;
+  frontend)
+    cd "$ROOT/frontend"
+    # node_modules 는 워크트리마다 따로 필요하다(gitignore 대상이라 worktree add 가 안 가져온다).
+    # 워크트리 생성 때 일괄 설치하지 않는 건, 백엔드·문서만 건드리는 작업이 대부분이라
+    # 쓰지도 않을 설치에 매번 시간을 물기 때문이다. 실제로 띄울 때만 채운다.
+    if [ ! -x node_modules/.bin/webpack ]; then
+      echo "node_modules 가 없다 — npm ci 로 설치한다 (최초 1회)"
+      npm ci
+    fi
+    export PORT="$FRONTEND_PORT"
+    # 프론트가 '자기 워크트리의' 백엔드를 가리키게 한다.
+    # 이게 없으면 공유 .env.development 값을 따라가 다른 워크트리의 백엔드에 붙는다.
+    export API_URL="http://localhost:$BACKEND_PORT"
+    echo "frontend → http://localhost:$FRONTEND_PORT (API_URL=$API_URL)"
+    exec npm run dev
+    ;;
+  *)
+    echo "ABORT: 알 수 없는 대상 '$TARGET' — backend 또는 frontend"; exit 1
+    ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .env
 *.env.*
 
+# 워크트리 전용 포트 (#1660) — worktree-setup.sh 가 생성한다
+.ports
+
 .cursor/
 .claude/worktrees/
 frontend/.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@
 .env
 *.env.*
 
-# 워크트리 전용 포트 (#1660) — worktree-setup.sh 가 생성한다
-.ports
-
 .cursor/
 .claude/worktrees/
 frontend/.claude/settings.local.json

--- a/backend/app/build.gradle.kts
+++ b/backend/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.run.BootRun
+
 // :app — Spring Boot 진입점, application.yml, Flyway 마이그레이션
 
 // 루트의 subprojects{}가 bootJar=false로 설정했으므로 :app만 다시 활성화
@@ -45,6 +47,15 @@ dependencies {
     testImplementation(libs.resilience4j)
     testImplementation(libs.redisson)
     testImplementation(libs.archunit)
+}
+
+tasks.named<BootRun>("bootRun") {
+    // bootRun의 기본 작업 디렉터리는 :app이라 backend/ 기준 파일을 둘 다 놓친다.
+    //  - springboot4-dotenv 가 읽을 backend/.env
+    //  - application-local.yml 의 spring.docker.compose.file: docker-compose.yml
+    // 후자는 못 찾으면 기동 자체가 실패한다("'files' content [docker-compose.yml] must exist").
+    // local 프로파일 로깅은 콘솔 전용이고 LOG_PATH도 절대경로라 이 변경이 로그 경로에 영향을 주지 않는다.
+    workingDir = rootProject.projectDir
 }
 
 tasks.withType<Test> {

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -19,10 +19,16 @@ export default (_, argv) => {
 
   dotenv.config({ path: path.resolve(process.cwd(), `.env.${mode}`) }).parsed || {};
 
+  // .env.development 는 gitignore 대상이라 워크트리에는 없을 수 있다(#1660).
+  // 기본값이 없으면 번들에 undefined 가 박혀 REST 요청이 `undefined/...` 로 나가고,
+  // 실패가 요청 시점까지 미뤄져 원인이 드러나지 않는다. webpack.dev.js 가 devServer
+  // 프록시에 쓰는 기본값과 같은 값으로 맞춰 두 설정의 비대칭을 없앤다.
+  const devApiUrl = mode === 'development' ? 'http://localhost:8080' : undefined;
+
   const envKeys = {
     'process.env.NODE_ENV': JSON.stringify(mode),
     'process.env.VERSION': JSON.stringify(appVersion),
-    'process.env.API_URL': JSON.stringify(process.env.API_URL),
+    'process.env.API_URL': JSON.stringify(process.env.API_URL || devApiUrl),
     'process.env.ENABLE_DEVTOOLS': JSON.stringify(process.env.ENABLE_DEVTOOLS === 'true'),
     // 값이 없어도 반드시 치환한다 — 조건부로 두면 번들에 process.env.DSN_KEY가
     // 리터럴로 남아 브라우저에서 ReferenceError(process is not defined)로 앱이 죽는다.
@@ -139,7 +145,9 @@ export default (_, argv) => {
         directory: path.resolve(__dirname, 'dist'),
       },
       compress: true,
-      port: 3000,
+      // 워크트리마다 다른 포트를 써야 여러 작업을 동시에 띄울 수 있다(#1660).
+      // 고정이면 두 번째 워크트리가 EADDRINUSE 로 죽는다.
+      port: Number(process.env.PORT) || 3000,
       hot: true,
       open: true,
       historyApiFallback: true,

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -145,9 +145,7 @@ export default (_, argv) => {
         directory: path.resolve(__dirname, 'dist'),
       },
       compress: true,
-      // 워크트리마다 다른 포트를 써야 여러 작업을 동시에 띄울 수 있다(#1660).
-      // 고정이면 두 번째 워크트리가 EADDRINUSE 로 죽는다.
-      port: Number(process.env.PORT) || 3000,
+      port: 3000,
       hot: true,
       open: true,
       historyApiFallback: true,


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1660

# 🚀 작업 내용

워크트리에서 앱을 띄우려면 다섯 군데를 손으로 뚫어야 했다. #1266 작업 중 실제로 막혔고, 실패가 조용해서 진단이 오래 걸렸다. 원인은 둘이다.

1. `.env` 계열이 `.gitignore` 대상이라 `git worktree add`가 가져오지 않는다
2. `bootRun`의 작업 디렉터리가 `:app`이라 `backend/` 기준 파일을 **둘 다** 놓친다

## 1. `bootRun` 작업 디렉터리 — 한 줄 (`backend/app/build.gradle.kts`)

```kotlin
tasks.named<BootRun>("bootRun") { workingDir = rootProject.projectDir }
```

`./gradlew`는 앱을 별도 프로세스로 띄우는데, 그 프로세스가 서는 위치는 **Gradle이 정하지 명령을 친 위치를 따라가지 않는다.** 기본값이 그 태스크가 속한 모듈 폴더라 `:app:bootRun`은 `backend/app`에서 돈다. 그래서 `backend/`에 있는 파일 둘을 못 찾았다.

```
수정 전:  started by kiwook in .../backend/app     ← backend/ 에서 쳤는데도
수정 후:  started by kiwook in .../backend
```

이 한 줄이 다섯 중 넷을 없앤다.

| 그동안 손으로 하던 것 | 이유 |
| --- | --- |
| 컨테이너를 직접 띄우고 `--spring.docker.compose.enabled=false` 지정 | `spring.docker.compose.file: docker-compose.yml`을 못 찾아 **기동 자체가 실패**했다 |
| `set -a; source ./.env; set +a` | `springboot4-dotenv`가 읽을 `backend/.env`를 못 찾았다 |
| `GEMINI_ZZOL_BOT_API_KEY` 수동 주입 | 빈 값이면 컨텍스트 생성이 실패하는데, 값이 `.env`에 있다 |

**`.env`를 읽는 기능은 처음부터 있었다.** `me.paulschwarz:springboot4-dotenv`가 이미 의존성에 있었고 파일을 못 찾고 있었을 뿐이다. 셸 `source`보다 낫다 — 값에 공백·따옴표가 섞여도 셸이 아니라 라이브러리가 파싱한다.

## 2. env 자동 연결 (`worktree-setup.sh` 신규)

주 저장소의 gitignore된 env 파일을 워크트리에 **심볼릭 링크**한다. 사본이 아니라 링크라 원본이 하나만 존재하고, 오래된 사본이 남지 않으며, 비밀값이 디스크에 한 벌만 있다. 스크립트는 파일을 열지 않고 경로만 다룬다.

`create-issue` 6단계와 `issue-workflow` 2단계에서 호출한다.

## 3. 포트는 8080·3000 고정 — 잡혀 있으면 멈춘다

**처음엔 워크트리마다 다른 포트를 잡게 만들었다가 철회했다.** 리뷰에서 성립하지 않는 것이 드러났다.

- `web.cors.allowed-origins`가 `3000`·`5173` 고정이라 다른 포트 프론트는 REST가 **전부 403**이다. WebSocket은 `setAllowedOriginPatterns("*")`라 통과해서 "화면은 뜨는데 API만 안 됨"으로 헷갈리게 나온다
- `user.oauth.frontend-redirect-uri`·`room.qr.prefix`도 `3000`·`8080` 고정이다
- compose 프로젝트명은 파일 부모 디렉터리 **basename**(`backend`)이라 경로가 달라도 모든 워크트리가 **같은 컨테이너**를 공유한다. `ddl-auto: create`라 두 번째 기동이 첫 번째 스키마를 드롭한다(로그에 `drop table` 23건 실측)

즉 포트만 갈라놨을 뿐 앱이 반쯤 깨진 상태였다. 그래서 포트를 고정하고, 잡혀 있으면 **다른 포트로 새는 대신 멈춘다.**

```
$ bash run.sh backend        # 8080 이 이미 사용 중일 때
ABORT: 포트 8080 가 이미 사용 중이다 (백엔드).
  다른 워크트리에서 띄운 것이라면 먼저 끈다: ...
  포트를 바꿔 우회하지 않는다 — CORS·OAuth 콜백이 8080/3000 고정이라 앱이 반쯤 깨진다.
```

**한 번에 한 워크트리만 띄운다**는 뜻이다. 조용히 반쯤 깨지느니 시끄럽게 못 뜨는 편이 낫다고 판단했다.

## 4. 조용한 실패 제거 (`frontend/webpack.common.js`)

```js
webpack.dev.js     const API_URL = process.env.API_URL || 'http://localhost:8080';  // 프록시 — 기본값 있음
webpack.common.js  'process.env.API_URL': JSON.stringify(process.env.API_URL)      // 번들 — 기본값 없음  ← 비대칭
```

프록시는 8080으로 잘 갔지만 **번들에 박히는 값은 `undefined`**였다. `apiRequest.ts`·`authApi.ts`가 그대로 받아 REST가 `undefined/...`로 나가고, `getWebSocketUrl.ts`만 예외를 던져 실패가 요청 시점까지 미뤄졌다. dev 모드 기본값을 줘 두 설정을 맞췄다. 백엔드가 8080 고정이므로 이 값은 항상 맞는다.

## 5. 실행 — `run-local` 스킬 + `run.sh` (신규)

**실제 셸은 `run.sh`에 두고 스킬은 오케스트레이션만 맡는다.** 막히는 지점 다섯 중 넷은 Claude 전용이 아니라 사람도 똑같이 겪는다. 스킬에만 넣으면 클론한 사람이 같은 벽을 처음부터 다시 만난다.

`node_modules`도 워크트리마다 필요한데, 백엔드·문서만 건드리는 작업이 대부분이라 **프론트를 실제로 띄울 때만** 설치한다.

# 💬 리뷰 중점사항

**1. `workingDir` 변경의 영향 범위 — 실측 완료**

`bootRun`은 로컬 개발 전용이라 배포 경로에 영향이 없다. 리뷰에서 확인한 것: configuration cache 경고 0, 앱 코드의 상대 경로 사용처(`new File(`·`Paths.get(`·`user.dir` 등) **0건**, `local` 프로파일 로깅은 콘솔 전용 + `LOG_PATH` 절대경로, `spring.config.import` 11개 전부 `classpath:`, `bootJar`·`Test`·PMD·Spotless 미변경, ADR 충돌 없음.

부수효과 하나(낮음): Boot 기본 설정 탐색 위치가 `backend/`·`backend/config/`로 이동한다. 지금은 그 아래 `application*.yml`이 없어 동작 변화가 없지만, 앞으로 두면 패키징된 설정을 조용히 덮어쓰고 그 효과가 `bootRun`에서만 나타난다.

**2. 심볼릭 링크 vs 복사**

링크를 골랐다. 원본이 하나라 오래된 사본이 안 남고 비밀값도 한 벌만 있다. 대신 **워크트리에서 env를 고치면 원본이 바뀐다.** 작업별로 다른 값이 필요하면 그 링크만 `cp`로 바꾸면 되고, 스크립트는 링크가 아닌 실파일을 발견하면 덮어쓰지 않고 보존한다.

**3. 데이터 손실 가드**

`worktree-setup.sh`를 주 저장소 대상으로 돌리면 `ln -sfn`이 자기 자신을 가리키는 링크를 만들고, `ln -f`가 타깃을 먼저 지워 **원본 `.env`가 파괴된다**(복구 불가, gitignore라 백업 없음). 리뷰에서 발견돼 경로 동일성 가드를 넣었다. 재현·차단 모두 확인했다.

**4. 워크트리 동시 실행은 이 PR의 범위가 아니다**

정말 하려면 두 겹을 다 걷어내야 한다 — 인프라(compose 프로젝트명, 고정 호스트 포트, `datasource.url` 하드코딩)와 앱 설정(CORS·OAuth 콜백·QR prefix). 별도 이슈감이며 `run-local` 문서에 그렇게 적었다.

관련해서 `lifecycle-management`가 현재 `start_and_stop`이라 앱을 끄면 컨테이너가 함께 내려간다. `start_only`로 바꾸면 남겨둘 수 있는데, 이번 PR에 넣을지는 의견을 듣고 싶다.

# 확인한 것

- `./gradlew :app:bootRun`이 **인자 없이** 뜬다 (컨테이너 자동 기동)
- 셸에서 `.env`를 소싱하지 않고도 OAuth가 실제 자격증명으로 붙는다 (`/oauth2/authorization/google` → `accounts.google.com` 302)
- 포트가 잡혀 있으면 `run.sh`가 `ABORT` (exit 1)
- 정리 후 백엔드 8080·프론트 3000 기동
- **CORS preflight (`Origin: localhost:3000` → 8080) HTTP 200** — 화면이 뜨는 것과 API가 오가는 것은 다르므로 별도로 확인했다
- `worktree-setup.sh`의 주 저장소 가드가 `ABORT`하고, 정상 경로는 그대로 돌며 원본 `.env`가 무사한 것
