### PR TITLE
[fix] 레이싱게임 결과가 저장되지 않던 문제 수정 — stopAutoMove의 자기-인터럽트 제거

### DIFF
--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
@@ -1,11 +1,11 @@
 package coffeeshout.racinggame.domain;
 
+import coffeeshout.gamecommon.Gamer;
+import coffeeshout.gamecommon.Playable;
 import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.minigame.domain.MiniGameResult;
 import coffeeshout.minigame.domain.MiniGameScore;
 import coffeeshout.minigame.domain.MiniGameType;
-import coffeeshout.gamecommon.Gamer;
-import coffeeshout.gamecommon.Playable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -56,7 +56,7 @@ public class RacingGame implements Playable {
 
     public void stopAutoMove() {
         if (autoMoveFuture != null && !autoMoveFuture.isDone()) {
-            autoMoveFuture.cancel(true);
+            autoMoveFuture.cancel(false);
         }
     }
 
@@ -67,10 +67,7 @@ public class RacingGame implements Playable {
 
     private void validatePlaying() {
         if (state != RacingGameState.PLAYING) {
-            throw new BusinessException(
-                    RacingGameErrorCode.NOT_PLAYING_STATE,
-                    "현재 게임 상태가 플레이 중이 아닙니다: " + state
-            );
+            throw new BusinessException(RacingGameErrorCode.NOT_PLAYING_STATE, "현재 게임 상태가 플레이 중이 아닙니다: " + state);
         }
     }
 

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
@@ -2,6 +2,7 @@ package coffeeshout.racinggame.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import coffeeshout.fixture.PlayerFixture;
 import coffeeshout.global.exception.custom.BusinessException;
@@ -172,10 +173,16 @@ class RacingGameTest {
         racingGame.setAutoMoveFuture(autoMoveFuture);
         futureAssigned.countDown();
 
-        // then
+        // then — 취소는 하되 인터럽트는 하지 않는다. 인터럽트만 검증하면 stopAutoMove()가
+        // 통째로 no-op이 돼도(자동 이동이 영원히 도는 더 큰 회귀) 통과한다.
         try {
             assertThat(stopped.await(3, TimeUnit.SECONDS)).as("자동 이동 태스크 실행 완료").isTrue();
-            assertThat(interrupted).isFalse();
+            assertSoftly(softly -> {
+                softly.assertThat(interrupted).as("실행 스레드 인터럽트 여부").isFalse();
+                softly.assertThat(autoMoveFuture.isCancelled())
+                        .as("자동 이동 취소 여부")
+                        .isTrue();
+            });
         } finally {
             scheduler.shutdownNow();
         }

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
@@ -9,6 +9,12 @@ import coffeeshout.room.domain.player.Player;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 class RacingGameTest {
@@ -129,5 +135,49 @@ class RacingGameTest {
         assertThat(result).isNotNull();
         assertThat(result.getRank().get(players.getFirst().toGamer())).isEqualTo(2);
         assertThat(result.getRank().get(players.get(1).toGamer())).isEqualTo(1);
+    }
+
+    /**
+     * 회귀 가드: {@code stopAutoMove()}는 자동 이동 태스크 자신의 스레드에서 호출된다
+     * (RacingGameService.handleRaceFinished ← executeAutoMove). {@code cancel(true)}로 취소하면
+     * 실행 중인 그 스레드가 스스로를 인터럽트하고, 곧이어 같은 스레드에서 발행되는
+     * MiniGameFinishedEvent의 결과 저장 리스너가 @RedisLock의 tryLock에서
+     * InterruptedException으로 실패한다 — 레이싱 기록이 한 건도 저장되지 않는다.
+     */
+    @Test
+    void 자동_이동_태스크_안에서_정지시켜도_실행_스레드가_인터럽트되지_않는다() throws InterruptedException {
+        // given
+        racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
+        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        final CountDownLatch futureAssigned = new CountDownLatch(1);
+        final CountDownLatch stopped = new CountDownLatch(1);
+        final AtomicBoolean interrupted = new AtomicBoolean();
+
+        // when — 태스크가 자기 자신을 취소한 뒤 같은 스레드에서 이어지는 구간을 재현한다
+        final ScheduledFuture<?> autoMoveFuture = scheduler.scheduleAtFixedRate(
+                () -> {
+                    try {
+                        futureAssigned.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    racingGame.stopAutoMove();
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                    stopped.countDown();
+                },
+                0,
+                100,
+                TimeUnit.MILLISECONDS);
+        racingGame.setAutoMoveFuture(autoMoveFuture);
+        futureAssigned.countDown();
+
+        // then
+        try {
+            assertThat(stopped.await(3, TimeUnit.SECONDS)).as("자동 이동 태스크 실행 완료").isTrue();
+            assertThat(interrupted).isFalse();
+        } finally {
+            scheduler.shutdownNow();
+        }
     }
 }

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -29,8 +29,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 class RacingGameIntegrationTest extends GameModuleWebSocketTest {
 
@@ -51,6 +54,10 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
 
     @Autowired
     JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    @Qualifier("racingGameScheduler")
+    TaskScheduler racingGameScheduler;
 
     JoinCode joinCode;
     Gamer host;
@@ -76,10 +83,19 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
      * 테스트가 남긴 레이스는 무탭 최소 속도(3)로 약 50초 뒤 혼자 완주해, 그때 진행 중인 다른 테스트의 방·
      * 미니게임 엔티티에 결과를 덧쓴다(joinCode·플레이어 픽스처가 같고 eventId는 매번 UUID라 @RedisLock
      * 중복 마커도 막지 못한다). 저장 건수를 세는 검증이 그 유령 완주에 오염되지 않도록 여기서 세워둔다.
+     * <p>
+     * stopAutoMove()만으로는 부족하다 — autoMoveFuture는 시작 +1s(description 500ms + prepare 500ms)에
+     * startAutoMove에서야 대입되고, 그 전에 테스트가 실패하면 null이라 즉시 리턴한다. 그 앞의
+     * description·prepare 예약 태스크는 어디에도 보관되지 않아 취소할 대상 자체가 없고, teardown 뒤에
+     * 레이스를 새로 시작한다. 그래서 취소(재예약 차단) 후 스케줄러 예약 큐를 비운다.
      */
     @AfterEach
     void 자동이동_정리() {
         racingGame.stopAutoMove();
+        ((ThreadPoolTaskScheduler) racingGameScheduler)
+                .getScheduledThreadPoolExecutor()
+                .getQueue()
+                .clear();
     }
 
     @Test

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -24,7 +24,6 @@ import coffeeshout.support.TestStompSession;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -160,25 +159,20 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
         stateResponses.get(3, TimeUnit.SECONDS); // PLAYING (2초 후)
 
         /*
-         IT 가속: move-interval=50ms(application-test-game.yml)로 자동이동이 돌고, 속도는 rate 기반이라
-         최고속도 유지를 위해 ~50ms마다 탭한다. 결승(3000) 도달·감속·정지하면 DONE.
-         고정 대기(Thread.sleep)는 컨벤션상 금지이므로 Awaitility 폴링으로 탭을 송신하고,
-         충분한 탭 라운드(120회 ≈ 6s) 후 종료한다. (racingGame.state는 비휘발성이라 폴링 조건으로 쓰지 않고,
-         종료 판정은 아래의 신뢰 가능한 DONE 브로드캐스트로 한다.) 프로덕션 100ms 기준 ~10s 구간이 ~6s로 단축된다.
+         탭은 플레이어당 한 번만 보낸다. 속도는 감쇠하지 않고(Runner.speed는 탭 또는 완주 후 감속으로만 변한다)
+         `tapCount / 경과시간`을 MAX_SPEED(60)로 clamp한 값이므로, 큰 tapCount 한 발이면 전원이 최고속도에
+         고정된 채 결승(3000)까지 간다 — 50틱 주행 + 감속 20틱(SLOW_DOWN_STEP 3) 뒤 전원 정지하면 DONE.
+         연타로 유지하면 안 된다: WS Rate Limiter가 세션당 초당 20건 초과분을 조용히 드롭하므로(#1664 CI 실패)
+         어느 라운드가 살아남는지가 부하에 따라 갈리고, 마지막 생존 탭의 경과시간이 길면 그 러너만 MIN_SPEED로
+         남아 완주하지 못한다. DONE은 전원 정지가 조건이라 한 명만 뒤처져도 영영 오지 않는다.
         */
-        final AtomicInteger tapRounds = new AtomicInteger();
-        await().atMost(Duration.ofSeconds(8))
-                .pollInterval(Duration.ofMillis(50))
-                .until(() -> {
-                    for (Gamer gamer : gamers) {
-                        singleSession.send(tapRequestUrl, new TapCommand(gamer.getName(), 10));
-                    }
-                    return tapRounds.incrementAndGet() >= 120;
-                });
+        for (Gamer gamer : gamers) {
+            singleSession.send(tapRequestUrl, new TapCommand(gamer.getName(), 200));
+        }
 
-        // then - DONE 상태 확인
+        // then - DONE 상태 확인. 70틱 × move-interval(50ms) + race-finished-delay 만큼 걸리므로 상한을 넉넉히 둔다.
         RacingGameStateResponse finishedState =
-                payloadAs(stateResponses.get(5, TimeUnit.SECONDS), RacingGameStateResponse.class);
+                payloadAs(stateResponses.get(10, TimeUnit.SECONDS), RacingGameStateResponse.class);
         assertThat(finishedState.state()).isEqualTo(RacingGameState.DONE);
 
         // then - 종료 결과가 실제로 저장된다. DONE 브로드캐스트는 결과 저장보다 앞서 예약되므로(#1662)

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +69,17 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
         gameSessionService.getSession(joinCode).replaceGames(host, List.of(racingGame));
 
         session = createSession(joinCode.getValue(), host.getName());
+    }
+
+    /**
+     * 자동 이동은 컨텍스트 수명의 스케줄러 빈에 걸리므로 테스트 메서드가 끝나도 계속 돈다. 완주까지 가지 않는
+     * 테스트가 남긴 레이스는 무탭 최소 속도(3)로 약 50초 뒤 혼자 완주해, 그때 진행 중인 다른 테스트의 방·
+     * 미니게임 엔티티에 결과를 덧쓴다(joinCode·플레이어 픽스처가 같고 eventId는 매번 UUID라 @RedisLock
+     * 중복 마커도 막지 못한다). 저장 건수를 세는 검증이 그 유령 완주에 오염되지 않도록 여기서 세워둔다.
+     */
+    @AfterEach
+    void 자동이동_정리() {
+        racingGame.stopAutoMove();
     }
 
     @Test
@@ -121,8 +133,9 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
 
         var stateResponses = singleSession.subscribe(subscribeStateUrl);
 
-        // 게임 시작 - 프로덕션과 같은 진입점(GameStartReadyEvent)으로 시작해야 MiniGameEntity·플레이어 스냅샷까지
-        // 만들어져 종료 시 결과가 저장될 수 있다. startRacingGame()은 그 앞단을 건너뛴다.
+        // 게임 시작 - :game 모듈 경계(:room의 MiniGameStartConsumer가 발행하는 GameStartReadyEvent)부터 태운다.
+        // 그래야 MiniGameEntity·플레이어 스냅샷이 만들어져 종료 시 결과가 저장될 수 있다. startRacingGame()은
+        // 서비스를 직접 불러 이 앞단을 건너뛴다. 그 앞의 STOMP→Redis Stream 구간은 이 테스트 범위 밖이다.
         eventPublisher.publishEvent(
                 new GameStartReadyEvent("evt-" + joinCodeValue, joinCodeValue, host.getName(), gamers));
 

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -5,15 +5,21 @@ import static org.awaitility.Awaitility.await;
 
 import coffeeshout.GameModuleWebSocketTest;
 import coffeeshout.fixture.GamerFixture;
+import coffeeshout.fixture.RoomFixture;
 import coffeeshout.gamecommon.Gamer;
 import coffeeshout.gamecommon.JoinCode;
 import coffeeshout.minigame.application.GameSessionService;
+import coffeeshout.minigame.event.GameStartReadyEvent;
 import coffeeshout.racinggame.application.RacingGameService;
 import coffeeshout.racinggame.domain.RacingGame;
 import coffeeshout.racinggame.domain.RacingGameState;
 import coffeeshout.racinggame.ui.request.TapCommand;
 import coffeeshout.racinggame.ui.response.RacingGameRunnersStateResponse;
 import coffeeshout.racinggame.ui.response.RacingGameStateResponse;
+import coffeeshout.room.application.port.RoomEntityRepository;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.repository.RoomRepository;
+import coffeeshout.room.infra.persistence.RoomEntity;
 import coffeeshout.support.TestStompSession;
 import java.time.Duration;
 import java.util.List;
@@ -22,6 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 class RacingGameIntegrationTest extends GameModuleWebSocketTest {
 
@@ -30,6 +38,18 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
 
     @Autowired
     RacingGameService racingGameService;
+
+    @Autowired
+    RoomRepository roomRepository;
+
+    @Autowired
+    RoomEntityRepository roomEntityRepository;
+
+    @Autowired
+    ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
 
     JoinCode joinCode;
     Gamer host;
@@ -86,7 +106,14 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
     }
 
     @Test
-    void 게임이_완주되면_FINISHED_상태가_전송된다() throws Exception {
+    void 게임이_완주되면_DONE_상태가_전송되고_결과가_저장된다() throws Exception {
+        // given - 결과 저장 리스너가 요구하는 방·플레이어 기반. 도메인 Room은 인메모리, RoomEntity는 DB라 둘 다 채워야
+        // room_session·player id가 해석된다(RoomSnapshotQueryAdapter).
+        final Room room = RoomFixture.호스트_꾹이(joinCode);
+        room.getPlayers().forEach(player -> player.updateReadyState(true));
+        roomRepository.save(room);
+        roomEntityRepository.save(new RoomEntity(joinCode.getValue()));
+
         TestStompSession singleSession = createSession(joinCode.getValue(), host.getName());
         String joinCodeValue = joinCode.getValue();
         String subscribeStateUrl = String.format("/topic/room/%s/racing-game/state", joinCodeValue);
@@ -94,8 +121,10 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
 
         var stateResponses = singleSession.subscribe(subscribeStateUrl);
 
-        // 게임 시작
-        startRacingGame();
+        // 게임 시작 - 프로덕션과 같은 진입점(GameStartReadyEvent)으로 시작해야 MiniGameEntity·플레이어 스냅샷까지
+        // 만들어져 종료 시 결과가 저장될 수 있다. startRacingGame()은 그 앞단을 건너뛴다.
+        eventPublisher.publishEvent(
+                new GameStartReadyEvent("evt-" + joinCodeValue, joinCodeValue, host.getName(), gamers));
 
         stateResponses.get(1, TimeUnit.SECONDS); // DESCRIPTION
         stateResponses.get(5, TimeUnit.SECONDS); // PREPARE (4초 후)
@@ -122,6 +151,16 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
         RacingGameStateResponse finishedState =
                 payloadAs(stateResponses.get(5, TimeUnit.SECONDS), RacingGameStateResponse.class);
         assertThat(finishedState.state()).isEqualTo(RacingGameState.DONE);
+
+        // then - 종료 결과가 실제로 저장된다. DONE 브로드캐스트는 결과 저장보다 앞서 예약되므로(#1662)
+        // 종료 신호만 검증하면 저장이 통째로 실패해도 이 테스트는 초록으로 남는다.
+        await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(저장된_레이싱_결과_수()).isEqualTo(gamers.size()));
+    }
+
+    private Integer 저장된_레이싱_결과_수() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mini_game_result WHERE mini_game_type = 'RACING_GAME'", Integer.class);
     }
 
     private void startRacingGame() {

--- a/backend/game/src/testFixtures/resources/application-test-game.yml
+++ b/backend/game/src/testFixtures/resources/application-test-game.yml
@@ -28,7 +28,7 @@ racing-game:
   timing:
     description: 500ms
     prepare: 500ms
-    race-finished-delay: 500ms
+    race-finished-delay: 10ms   # IT 가속(DONE 브로드캐스트 지연 — 경쟁 상대가 없는 순수 지연이라 최소로)
     # IT 가속: 프로덕션 100ms 대비 자동이동 주기를 절반으로 줄여 완주(거리 3000) 도달을 ~2.5s로 단축.
     # 도메인 Runner.finishTime 정밀도는 static MOVE_INTERVAL_MILLIS(100ms)를 그대로 쓰지만,
     # 완주 IT는 DONE 상태만 검증하고 순위/완주시간은 검증하지 않으므로 영향 없음.


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1662
- 후속 이슈 #1663 (나머지 6종 게임의 "종료 → 저장" 이음매 테스트)

# 🚀 작업 내용

1. **`RacingGame.stopAutoMove()`의 `cancel(true)` → `cancel(false)`** — 결과가 저장되지 않던 원인 제거.

   `handleRaceFinished`는 자동 이동 태스크(`executeAutoMove`)를 실행 중인 스레드에서 돈다. 그 안에서 `autoMoveFuture.cancel(true)`를 부르면 취소 대상 future를 실행 중인 스레드가 곧 호출자 자신이라, `FutureTask.cancel`이 **현재 스레드에 인터럽트를 건다**. 바로 다음 줄의 `eventPublisher.publishEvent(MiniGameFinishedEvent)`는 동기 호출이라 같은 스레드에서 결과 저장 리스너가 실행되고, `@RedisLock` 애스펙트의 `lock.tryLock()`이 `InterruptedException`으로 실패한다. 이 예외는 `executeAutoMove`의 `catch (Exception)`이 삼켜 로그만 남는다.

   결과적으로 `mini_game_result`에 `RACING_GAME` 행이 한 건도 쌓이지 않았다. 홈 랭킹의 레이싱게임 최단 기록이 빈 것이 이 증상이고, 같은 리스너가 기록하는 **시즌 정산 Outbox도 함께 유실**되고 있었다.

   `cancel(false)`로 충분한 이유: 자동 이동 태스크는 100ms마다 끝나는 짧은 작업이라 강제로 끊어야 할 블로킹 구간이 없고, 앞선 `updateState(DONE)`와 `executeAutoMove`의 `isStarted()` 가드가 잔여 tick을 막는다. 다른 게임(스피드터치·블라인드타이머·눈치)은 모두 `cancel(false)`를 쓰며, 레이싱만 예외였다.

2. **도메인 회귀 가드 추가** (`RacingGameTest`) — 자동 이동 태스크 안에서 `stopAutoMove()`를 호출해도 실행 스레드가 인터럽트되지 않는지 검증한다. 수정 전에는 `AtomicBoolean(true)`로 빨갛다.

3. **완주 통합 테스트를 결과 저장까지 확장** (`RacingGameIntegrationTest`) — 기존 `게임이_완주되면_FINISHED_상태가_전송된다`를 `게임이_완주되면_DONE_상태가_전송되고_결과가_저장된다`로 확장했다. 검증하던 DONE 브로드캐스트는 `handleRaceFinished`에서 결과 저장보다 **앞줄**에 예약되므로, 종료 신호만 보는 기존 테스트는 저장이 통째로 실패해도 초록이었다. 실제로 수정을 되돌려 확인하면 `expected: 4 but was: 0`으로 빨개진다.

4. `RacingGame.java`의 import 정렬·줄바꿈 변경은 Spotless(`ratchetFrom("origin/dev")`) 때문이다. 이 파일을 건드리면 전체가 포맷 대상이 되어 CI가 요구한다. 기능 변경은 `cancel` 한 줄뿐이다.

# 💬 리뷰 중점사항

- **`cancel(false)`로 충분한지**가 핵심 판단 지점이다. 인터럽트로 끊어야 할 블로킹 작업이 태스크 안에 없다는 근거로 `false`를 골랐다. `executeAutoMove`는 `moveAll()` + 브로드캐스트 발행뿐이고, 상태 가드(`isStarted()`)가 이미 있다.

- **통합 테스트가 시작 경로를 바꿨다.** 저장을 검증하려면 리스너가 요구하는 `MiniGameEntity`·플레이어 스냅샷이 있어야 하는데, 기존 `startRacingGame()`은 `gameSessionService.startGame`을 직접 불러 그 앞단을 건너뛴다. 그래서 이 테스트만 프로덕션과 같은 진입점인 `GameStartReadyEvent` 발행으로 시작하고, 방(도메인 `Room` + `RoomEntity`)을 실제로 저장한다. 다른 테스트(`레이싱_게임을_시작한다`)는 기존 경로 그대로 두었다.

- 저장 건수 확인에 `JdbcTemplate` 카운트 쿼리를 썼다. `MiniGameResultJpaRepository`에 조회 메서드가 없어 프로덕션 코드를 건드리지 않으려는 선택이다. 조회 메서드를 추가하는 편이 낫다면 알려달라.

- 배포 후 확인 방법: 레이싱 한 판을 끝낸 뒤 `GET /dashboard/racing-game-top-players`가 값을 반환하는지 본다. 이번 달 이전 기록은 소급 복구가 불가능하다(종료 시점에만 기록 가능).
