### PR TITLE
[chore] CI 워크플로우에 concurrency 추가 — 새 커밋 push 시 이전 실행 취소

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -28,6 +28,14 @@ on:
         description: "Docker image tag"
         value: ${{ jobs.ci-build.outputs.image_tag }}
 
+# 같은 PR에 새 커밋을 push하면 직전 실행을 취소한다 (회당 4~8분).
+# CD가 workflow_call로 부른 실행에서 github 컨텍스트는 호출자(CD) 값이라
+# 그룹이 "Backend Deploy (CD)-refs/heads/dev"가 된다 — CD 자신의 그룹
+# (backend-deploy-dev)과 겹치지 않으므로 배포를 끊지 않는다.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -9,6 +9,13 @@ on:
       - 'frontend/**/*.stories.*'
       - 'frontend/.storybook/**'
 
+# 스냅샷 단위 과금이라 중복 실행이 그대로 요금이다.
+# 기준선을 굽는 chromatic-base(dev push)는 일부러 제외했다 — 취소되면
+# 그 커밋의 기준선 빌드가 남지 않는다.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -15,6 +15,13 @@ on:
         description: "Build completion status"
         value: ${{ jobs.ci.outputs.build-success }}
 
+# 같은 PR에 새 커밋을 push하면 직전 실행을 취소한다.
+# CD가 workflow_call로 부른 실행은 그룹이 호출자 이름으로 잡혀
+# (frontend-deploy-dev와 다르다) 배포를 끊지 않는다 — backend-ci.yml 주석 참고.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1670

# 🚀 작업 내용

1. `backend-ci`·`frontend-ci`·`chromatic-pr`에 `concurrency` 추가 — 기존 9개 워크플로우와 같은 형태(`${{ github.workflow }}-${{ github.ref }}` / `cancel-in-progress: true`)
2. `chromatic-base`는 제외 — dev push 기준선 빌드가 취소되면 그 커밋의 기준선이 남지 않는다
3. `close-issue`·`be-delete-merged-branch`도 제외 — 초 단위로 끝나고, 끊기면 이슈가 안 닫힌 채 남는 부작용이 있다

# 💬 리뷰 중점사항

## `workflow_call`이 CD를 취소하지 않는 근거

재사용 워크플로우 안에서 `github` 컨텍스트는 **호출자 값**으로 평가된다. 그래서 그룹 문자열이 겹치지 않는다.

| | 그룹 |
| --- | --- |
| `backend-cd` 자신 | `backend-deploy-${{ github.ref_name }}` → `backend-deploy-dev` |
| `backend-cd`가 부른 `backend-ci` | `${{ github.workflow }}-${{ github.ref }}` → `Backend Deploy (CD)-refs/heads/dev` |
| `frontend-cd` 자신 | `frontend-deploy-${{ github.ref_name }}` → `frontend-deploy-dev` |
| `frontend-cd`가 부른 `frontend-ci` | `Frontend Deploy (CD)-refs/heads/dev` |

CI에 붙인 그룹이 CD 그룹과 문자열이 다르므로 배포를 끊지 않는다. 이벤트로 `cancel-in-progress`를 가를 필요가 없다.

## 실측 검증

이 PR에서 커밋을 둘로 나눠 push해 취소 동작을 확인한다(결과는 아래 코멘트에).

`frontend-ci`·`chromatic-pr`은 이 PR에서 실행되지 않는다 — path 필터가 각각 `frontend/**`, `frontend/**/*.stories.*`라 이 PR diff에 걸리는 파일이 없다. 문법은 `backend-ci`와 동일하다.

`backend-cd`의 path 필터에는 `backend-ci.yml`이 없어서(`frontend-cd`에는 있다) 이 PR이 merge돼도 backend 쪽 `workflow_call` 경로는 돌지 않는다. `dev`→`prod` 승격 때 확인된다.
