### PR TITLE
[chore] api-mcp typescript major 버전업 dependabot 무시

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,11 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
+    ignore:
+      # typescript-eslint가 TS 7을 런타임에서 막는다("does not support TS 7.0", typescript-eslint#10940).
+      # 지원 릴리스가 나오면 이 항목을 지운다.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- 없음 (경량 경로, `SRC_EMPTY=1`)

# 🚀 작업 내용

1. `.github/dependabot.yml`의 `/tools/api-mcp` 항목에 `typescript` **major** 업데이트 무시를 추가했다.

# 💬 리뷰 중점사항

## 왜 막는가 — #1556 CI 실패의 실제 원인

Dependabot PR #1556 (`typescript` 6.0.3 → 7.0.2, api-mcp)의 CI가 `npm ci` ERESOLVE로 죽었다. 다만 근본 원인은 peer 범위 표기가 아니라 **typescript-eslint의 명시적 런타임 차단**이다. `--legacy-peer-deps`로 강제 설치해 실제로 돌려본 결과:

```
$ npm run lint
Error: typescript-eslint does not support TS 7.0.
  at node_modules/typescript-eslint/dist/index.js:52:11
```

- `npm run typecheck`(`tsc --noEmit`)는 TS 7.0.2에서 **통과**한다. 막히는 건 lint 단계 하나뿐이다.
- typescript-eslint는 `latest` 8.67.0 은 물론 `canary` 8.67.1-alpha.23 도 peer가 `typescript: ">=4.8.4 <6.1.0"` — **TS 7 지원 릴리스가 아직 없다.**
- 추적 이슈: https://github.com/typescript-eslint/typescript-eslint/issues/10940

우회 수단은 TS 7 릴리스 노트가 안내하는 **TS 6 side-by-side 설치**(lint 전용 `typescript-6` 별칭 + 빌드는 `tsc` 7)뿐인데, devDependency 하나 올리자고 컴파일러를 두 벌 물고 가는 건 얻는 게 없다고 판단했다.

## 함께 볼 것 — frontend도 같은 벽에 부딪힌다

`frontend/package.json`은 `typescript ^5.8.3` + `@typescript-eslint/* ^8.x` 조합이다. dependabot의 major 업데이트는 최신 버전으로 바로 점프하므로, frontend에 typescript major PR이 열리는 순간 **5.8 → 7.x** 로 동일하게 실패한다.

이번 PR은 #1556이 실제로 막고 있는 api-mcp 범위만 외과적으로 고쳤다. frontend에도 같은 `ignore` 블록을 선제적으로 넣을지는 리뷰에서 정하면 좋겠다.

## 후속

- typescript-eslint가 TS ≥7 을 지원하면 이 `ignore` 항목을 지운다 (설정에 주석으로 남겨뒀다).
- PR #1556 은 이 PR과 함께 닫는다.
