### PR TITLE
[fix] 게임 페이지 리프레시 시 참가자 명단 복구 — GET /rooms/{joinCode}/players

### DIFF
--- a/backend/app/src/test/java/coffeeshout/room/RoomRestControllerTest.java
+++ b/backend/app/src/test/java/coffeeshout/room/RoomRestControllerTest.java
@@ -1,6 +1,7 @@
 package coffeeshout.room;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -27,6 +28,7 @@ import coffeeshout.room.ui.request.RoomEnterRequest;
 import coffeeshout.room.ui.request.UpdateRoomSettingsRequest;
 import coffeeshout.room.ui.response.GuestNameExistResponse;
 import coffeeshout.room.ui.response.JoinCodeExistResponse;
+import coffeeshout.room.ui.response.PlayerResponse;
 import coffeeshout.room.ui.response.RoomCreateResponse;
 import coffeeshout.room.ui.response.RoomEnterResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -579,6 +581,44 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이어 목록 조회 테스트")
+    class GetPlayersTest {
+
+        @Test
+        void 방의_플레이어_목록을_colorIndex와_함께_조회한다() throws Exception {
+            // given
+            Room 호스트_꾹이 = RoomFixture.호스트_꾹이();
+            roomRepository.save(호스트_꾹이);
+            String joinCode = 호스트_꾹이.getJoinCode().toString();
+
+            // when
+            String response = mockMvc.perform(get("/rooms/{joinCode}/players", joinCode))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString();
+
+            List<PlayerResponse> players = objectMapper.readValue(response,
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, PlayerResponse.class));
+
+            // then - 로비와 같은 명단·색(colorIndex)이 그대로 내려온다
+            assertThat(players)
+                    .extracting(PlayerResponse::playerName, PlayerResponse::colorIndex)
+                    .containsExactlyElementsOf(호스트_꾹이.getPlayers().stream()
+                            .map(player -> tuple(player.getName().value(), player.getColorIndex()))
+                            .toList());
+        }
+
+        @Test
+        void 존재하지_않는_방의_플레이어_목록_조회_시_404_에러를_반환한다() throws Exception {
+            // when & then
+            mockMvc.perform(get("/rooms/{joinCode}/players", INVALID_JOIN_CODE))
+                    .andExpect(status().isNotFound());
         }
     }
 

--- a/backend/app/src/test/java/coffeeshout/room/RoomRestControllerTest.java
+++ b/backend/app/src/test/java/coffeeshout/room/RoomRestControllerTest.java
@@ -12,10 +12,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import coffeeshout.cardgame.domain.CardGame;
 import coffeeshout.cardgame.domain.card.CardGameRandomDeckGenerator;
+import coffeeshout.fixture.RoomFixture;
 import coffeeshout.gamecommon.Gamer;
 import coffeeshout.gamecommon.JoinCode;
-import coffeeshout.support.app.IntegrationTestSupport;
-import coffeeshout.fixture.RoomFixture;
 import coffeeshout.minigame.domain.GameSession;
 import coffeeshout.minigame.domain.GameSessionRepository;
 import coffeeshout.minigame.domain.MiniGameType;
@@ -31,6 +30,7 @@ import coffeeshout.room.ui.response.JoinCodeExistResponse;
 import coffeeshout.room.ui.response.PlayerResponse;
 import coffeeshout.room.ui.response.RoomCreateResponse;
 import coffeeshout.room.ui.response.RoomEnterResponse;
+import coffeeshout.support.app.IntegrationTestSupport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -83,7 +83,8 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .getContentAsString();
 
             RoomCreateResponse roomCreateResponse = objectMapper.readValue(response, RoomCreateResponse.class);
-            assertThat(roomRepository.existsByJoinCode(new JoinCode(roomCreateResponse.joinCode()))).isTrue();
+            assertThat(roomRepository.existsByJoinCode(new JoinCode(roomCreateResponse.joinCode())))
+                    .isTrue();
             assertThat(roomCreateResponse.roomSessionToken()).isNotBlank();
         }
 
@@ -178,8 +179,7 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .andExpect(request().asyncStarted())
                     .andReturn();
 
-            mockMvc.perform(asyncDispatch(result))
-                    .andExpect(status().isNotFound());
+            mockMvc.perform(asyncDispatch(result)).andExpect(status().isNotFound());
         }
 
         @Test
@@ -208,10 +208,8 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .andExpect(request().asyncStarted())
                     .andReturn();
 
-            mockMvc.perform(asyncDispatch(result))
-                    .andExpect(status().isConflict());
+            mockMvc.perform(asyncDispatch(result)).andExpect(status().isConflict());
         }
-
 
         @Test
         void 방이_가득_찬_경우_입장_시도_시_409_에러를_반환한다() throws Exception {
@@ -239,8 +237,7 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                         .andExpect(request().asyncStarted())
                         .andReturn();
 
-                mockMvc.perform(asyncDispatch(result))
-                        .andExpect(status().isOk());
+                mockMvc.perform(asyncDispatch(result)).andExpect(status().isOk());
             }
 
             // given - 9번째 게스트 입장 시도 (정원 초과: 호스트 1명 + 게스트 9명 = 총 10명)
@@ -253,8 +250,7 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .andExpect(request().asyncStarted())
                     .andReturn();
 
-            mockMvc.perform(asyncDispatch(result))
-                    .andExpect(status().isConflict());
+            mockMvc.perform(asyncDispatch(result)).andExpect(status().isConflict());
         }
     }
 
@@ -279,8 +275,7 @@ class RoomRestControllerTest extends IntegrationTestSupport {
             String joinCode = roomCreateResponse.joinCode();
 
             // when & then
-            String response = mockMvc.perform(get("/rooms/check-joinCode")
-                            .param("joinCode", joinCode))
+            String response = mockMvc.perform(get("/rooms/check-joinCode").param("joinCode", joinCode))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.exist").value(true))
                     .andReturn()
@@ -294,8 +289,7 @@ class RoomRestControllerTest extends IntegrationTestSupport {
         @Test
         void 존재하지_않는_방_코드_확인_시_false를_반환한다() throws Exception {
             // when & then
-            String response = mockMvc.perform(get("/rooms/check-joinCode")
-                            .param("joinCode", INVALID_JOIN_CODE))
+            String response = mockMvc.perform(get("/rooms/check-joinCode").param("joinCode", INVALID_JOIN_CODE))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.exist").value(false))
                     .andReturn()
@@ -337,8 +331,8 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .getResponse()
                     .getContentAsString();
 
-            GuestNameExistResponse guestNameExistResponse = objectMapper.readValue(response,
-                    GuestNameExistResponse.class);
+            GuestNameExistResponse guestNameExistResponse =
+                    objectMapper.readValue(response, GuestNameExistResponse.class);
             assertThat(guestNameExistResponse.exist()).isFalse();
         }
 
@@ -368,8 +362,8 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .getResponse()
                     .getContentAsString();
 
-            GuestNameExistResponse guestNameExistResponse = objectMapper.readValue(response,
-                    GuestNameExistResponse.class);
+            GuestNameExistResponse guestNameExistResponse =
+                    objectMapper.readValue(response, GuestNameExistResponse.class);
             assertThat(guestNameExistResponse.exist()).isTrue();
         }
     }
@@ -388,11 +382,10 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .getResponse()
                     .getContentAsString();
 
-            List<MiniGameType> miniGameTypes = objectMapper.readValue(response,
-                    objectMapper.getTypeFactory().constructCollectionType(List.class, MiniGameType.class));
+            List<MiniGameType> miniGameTypes = objectMapper.readValue(
+                    response, objectMapper.getTypeFactory().constructCollectionType(List.class, MiniGameType.class));
 
-            assertThat(miniGameTypes).isNotEmpty()
-                    .contains(MiniGameType.CARD_GAME);
+            assertThat(miniGameTypes).isNotEmpty().contains(MiniGameType.CARD_GAME);
         }
 
         @Test
@@ -406,16 +399,15 @@ class RoomRestControllerTest extends IntegrationTestSupport {
             String joinCode = 호스트_꾹이.getJoinCode().toString();
 
             // when & then
-            String response = mockMvc.perform(get("/rooms/minigames/selected")
-                            .param("joinCode", joinCode))
+            String response = mockMvc.perform(get("/rooms/minigames/selected").param("joinCode", joinCode))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$").isArray())
                     .andReturn()
                     .getResponse()
                     .getContentAsString();
 
-            List<MiniGameType> selectedGames = objectMapper.readValue(response,
-                    objectMapper.getTypeFactory().constructCollectionType(List.class, MiniGameType.class));
+            List<MiniGameType> selectedGames = objectMapper.readValue(
+                    response, objectMapper.getTypeFactory().constructCollectionType(List.class, MiniGameType.class));
 
             assertThat(selectedGames).isNotNull();
         }
@@ -423,8 +415,7 @@ class RoomRestControllerTest extends IntegrationTestSupport {
         @Test
         void 존재하지_않는_방의_선택된_미니게임_조회_시_404_에러를_반환한다() throws Exception {
             // when & then
-            mockMvc.perform(get("/rooms/minigames/selected")
-                            .param("joinCode", INVALID_JOIN_CODE))
+            mockMvc.perform(get("/rooms/minigames/selected").param("joinCode", INVALID_JOIN_CODE))
                     .andExpect(status().isNotFound());
         }
     }
@@ -443,8 +434,7 @@ class RoomRestControllerTest extends IntegrationTestSupport {
         @ParameterizedTest
         @ValueSource(strings = {"", "   "})
         void joinCode가_빈값이거나_공백이면_호스트용_닉네임을_반환한다(String blankJoinCode) throws Exception {
-            mockMvc.perform(get("/rooms/nickname/random")
-                            .param("joinCode", blankJoinCode))
+            mockMvc.perform(get("/rooms/nickname/random").param("joinCode", blankJoinCode))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.nickname").exists());
         }
@@ -461,11 +451,12 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .getResponse()
                     .getContentAsString();
 
-            String joinCode = objectMapper.readValue(createResponse, RoomCreateResponse.class).joinCode();
+            String joinCode = objectMapper
+                    .readValue(createResponse, RoomCreateResponse.class)
+                    .joinCode();
 
             // when & then
-            mockMvc.perform(get("/rooms/nickname/random")
-                            .param("joinCode", joinCode))
+            mockMvc.perform(get("/rooms/nickname/random").param("joinCode", joinCode))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.nickname").exists());
         }
@@ -603,8 +594,8 @@ class RoomRestControllerTest extends IntegrationTestSupport {
                     .getResponse()
                     .getContentAsString();
 
-            List<PlayerResponse> players = objectMapper.readValue(response,
-                    objectMapper.getTypeFactory().constructCollectionType(List.class, PlayerResponse.class));
+            List<PlayerResponse> players = objectMapper.readValue(
+                    response, objectMapper.getTypeFactory().constructCollectionType(List.class, PlayerResponse.class));
 
             // then - 로비와 같은 명단·색(colorIndex)이 그대로 내려온다
             assertThat(players)
@@ -617,8 +608,7 @@ class RoomRestControllerTest extends IntegrationTestSupport {
         @Test
         void 존재하지_않는_방의_플레이어_목록_조회_시_404_에러를_반환한다() throws Exception {
             // when & then
-            mockMvc.perform(get("/rooms/{joinCode}/players", INVALID_JOIN_CODE))
-                    .andExpect(status().isNotFound());
+            mockMvc.perform(get("/rooms/{joinCode}/players", INVALID_JOIN_CODE)).andExpect(status().isNotFound());
         }
     }
 
@@ -631,20 +621,18 @@ class RoomRestControllerTest extends IntegrationTestSupport {
         // 게임 대기열은 GameSession이 소유한다(ADR-0025)
         Gamer host = Gamer.guest(호스트_꾹이.getHost().getName().value());
         GameSession session = new GameSession(호스트_꾹이.getJoinCode(), host);
-        session.replaceGames(host, List.of(
-                new CardGame(new CardGameRandomDeckGenerator(), 0),
-                new RacingGame()
-        ));
+        session.replaceGames(host, List.of(new CardGame(new CardGameRandomDeckGenerator(), 0), new RacingGame()));
         gameSessionRepository.save(session);
 
         // when
-        var remainingMiniGamesResponse = objectMapper.readValue(mockMvc.perform(
-                        (get("/rooms/{joinCode}/miniGames/remaining", 호스트_꾹이.getJoinCode())
+        var remainingMiniGamesResponse = objectMapper.readValue(
+                mockMvc.perform((get("/rooms/{joinCode}/miniGames/remaining", 호스트_꾹이.getJoinCode())
                                 .contentType(MediaType.APPLICATION_JSON)))
-                .andExpect(status().isOk())
-                .andReturn()
-                .getResponse()
-                .getContentAsString(), RemainingMiniGameResponse.class);
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString(),
+                RemainingMiniGameResponse.class);
 
         // then
         assertThat(remainingMiniGamesResponse.remaining()).containsExactly("CARD_GAME", "RACING_GAME");

--- a/backend/room/src/main/java/coffeeshout/room/ui/RoomApi.java
+++ b/backend/room/src/main/java/coffeeshout/room/ui/RoomApi.java
@@ -28,44 +28,35 @@ public interface RoomApi {
     CompletableFuture<ResponseEntity<RoomEnterResponse>> enterRoom(
             @Parameter(description = "방 입장 코드", required = true) String joinCode,
             Optional<AuthenticatedUser> authUser,
-            RoomEnterRequest request
-    );
+            RoomEnterRequest request);
 
     @Operation(summary = "랜덤 닉네임 생성", description = "랜덤 닉네임을 생성합니다. joinCode를 전달하면 방 내 중복을 제외합니다.")
     ResponseEntity<RandomNicknameResponse> generateRandomNickname(
-            @Parameter(description = "방 입장 코드 (선택)") String joinCode
-    );
+            @Parameter(description = "방 입장 코드 (선택)") String joinCode);
 
     @Operation(summary = "방 코드 존재 확인", description = "joinCode가 유효한지 확인합니다.")
     ResponseEntity<JoinCodeExistResponse> checkJoinCode(
-            @Parameter(description = "방 입장 코드", required = true) String joinCode
-    );
+            @Parameter(description = "방 입장 코드", required = true) String joinCode);
 
     @Operation(summary = "게스트 이름 중복 확인", description = "방 내에서 게스트 이름이 중복되는지 확인합니다.")
     ResponseEntity<GuestNameExistResponse> checkGuestName(
             @Parameter(description = "방 입장 코드", required = true) String joinCode,
-            @Parameter(description = "게스트 이름", required = true) String guestName
-    );
+            @Parameter(description = "게스트 이름", required = true) String guestName);
 
     @Operation(summary = "확률 조회", description = "방의 모든 플레이어 당첨 확률을 조회합니다.")
     ResponseEntity<List<ProbabilityResponse>> getProbabilities(
-            @Parameter(description = "방 입장 코드", required = true) String joinCode
-    );
+            @Parameter(description = "방 입장 코드", required = true) String joinCode);
 
     @Operation(summary = "방 설정 변경", description = "호스트가 룰렛 가중치 등 방 설정을 변경합니다.")
     ResponseEntity<Void> updateRoomSettings(
-            @Parameter(description = "방 입장 코드", required = true) String joinCode,
-            UpdateRoomSettingsRequest request
-    );
+            @Parameter(description = "방 입장 코드", required = true) String joinCode, UpdateRoomSettingsRequest request);
 
     @Operation(summary = "플레이어 목록 조회", description = "방의 현재 플레이어 목록(colorIndex 포함)을 조회합니다. 게임 페이지 리프레시 시 명단 복구용.")
     ResponseEntity<List<PlayerResponse>> getPlayers(
-            @Parameter(description = "방 입장 코드", required = true) String joinCode
-    );
+            @Parameter(description = "방 입장 코드", required = true) String joinCode);
 
     @Operation(summary = "플레이어 강퇴", description = "방에서 특정 플레이어를 강퇴합니다.")
     ResponseEntity<Void> kickPlayer(
             @Parameter(description = "방 입장 코드", required = true) String joinCode,
-            @Parameter(description = "플레이어 이름", required = true) String playerName
-    );
+            @Parameter(description = "플레이어 이름", required = true) String playerName);
 }

--- a/backend/room/src/main/java/coffeeshout/room/ui/RoomApi.java
+++ b/backend/room/src/main/java/coffeeshout/room/ui/RoomApi.java
@@ -4,6 +4,7 @@ import coffeeshout.room.ui.request.RoomEnterRequest;
 import coffeeshout.room.ui.request.UpdateRoomSettingsRequest;
 import coffeeshout.room.ui.response.GuestNameExistResponse;
 import coffeeshout.room.ui.response.JoinCodeExistResponse;
+import coffeeshout.room.ui.response.PlayerResponse;
 import coffeeshout.room.ui.response.ProbabilityResponse;
 import coffeeshout.room.ui.response.RandomNicknameResponse;
 import coffeeshout.room.ui.response.RoomCreateResponse;
@@ -55,6 +56,11 @@ public interface RoomApi {
     ResponseEntity<Void> updateRoomSettings(
             @Parameter(description = "방 입장 코드", required = true) String joinCode,
             UpdateRoomSettingsRequest request
+    );
+
+    @Operation(summary = "플레이어 목록 조회", description = "방의 현재 플레이어 목록(colorIndex 포함)을 조회합니다. 게임 페이지 리프레시 시 명단 복구용.")
+    ResponseEntity<List<PlayerResponse>> getPlayers(
+            @Parameter(description = "방 입장 코드", required = true) String joinCode
     );
 
     @Operation(summary = "플레이어 강퇴", description = "방에서 특정 플레이어를 강퇴합니다.")

--- a/backend/room/src/main/java/coffeeshout/room/ui/RoomApi.java
+++ b/backend/room/src/main/java/coffeeshout/room/ui/RoomApi.java
@@ -51,7 +51,7 @@ public interface RoomApi {
     ResponseEntity<Void> updateRoomSettings(
             @Parameter(description = "방 입장 코드", required = true) String joinCode, UpdateRoomSettingsRequest request);
 
-    @Operation(summary = "플레이어 목록 조회", description = "방의 현재 플레이어 목록(colorIndex 포함)을 조회합니다. 게임 페이지 리프레시 시 명단 복구용.")
+    @Operation(summary = "플레이어 목록 조회", description = "방의 현재 플레이어 목록(colorIndex 포함)을 조회합니다.")
     ResponseEntity<List<PlayerResponse>> getPlayers(
             @Parameter(description = "방 입장 코드", required = true) String joinCode);
 

--- a/backend/room/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/room/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -46,8 +46,7 @@ public class RoomRestController implements RoomApi {
     @PostMapping
     public ResponseEntity<RoomCreateResponse> createRoom(
             @AuthUser Optional<AuthenticatedUser> authUser,
-            @RequestBody(required = false) @Valid RoomEnterRequest request
-    ) {
+            @RequestBody(required = false) @Valid RoomEnterRequest request) {
         final RoomCreateResult result = authUser.isPresent()
                 ? roomService.createRoom(authUser.get())
                 : roomService.createRoom(requirePlayerName(request));
@@ -59,14 +58,12 @@ public class RoomRestController implements RoomApi {
     public CompletableFuture<ResponseEntity<RoomEnterResponse>> enterRoom(
             @PathVariable String joinCode,
             @AuthUser Optional<AuthenticatedUser> authUser,
-            @RequestBody(required = false) @Valid RoomEnterRequest request
-    ) {
+            @RequestBody(required = false) @Valid RoomEnterRequest request) {
         final CompletableFuture<RoomEnterResult> future = authUser.isPresent()
                 ? roomService.enterRoomAsync(joinCode, authUser.get())
                 : roomService.enterRoomAsync(joinCode, requirePlayerName(request));
 
-        return future
-                .thenApply(result -> ResponseEntity.ok(RoomEnterResponse.of(result)))
+        return future.thenApply(result -> ResponseEntity.ok(RoomEnterResponse.of(result)))
                 .exceptionally(throwable -> {
                     final Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
                     if (cause instanceof RuntimeException runtimeException) {
@@ -77,7 +74,9 @@ public class RoomRestController implements RoomApi {
     }
 
     private String requirePlayerName(RoomEnterRequest request) {
-        if (request == null || request.playerName() == null || request.playerName().isBlank()) {
+        if (request == null
+                || request.playerName() == null
+                || request.playerName().isBlank()) {
             throw new BusinessException(RoomErrorCode.PLAYER_NAME_BLANK, "플레이어 이름이 없습니다.");
         }
         return request.playerName();
@@ -85,8 +84,7 @@ public class RoomRestController implements RoomApi {
 
     @GetMapping("/nickname/random")
     public ResponseEntity<RandomNicknameResponse> generateRandomNickname(
-            @RequestParam(required = false) String joinCode
-    ) {
+            @RequestParam(required = false) String joinCode) {
         final String nickname = (joinCode != null && !joinCode.isBlank())
                 ? roomService.generateRandomNicknameForGuest(joinCode)
                 : roomService.generateRandomNicknameForHost();
@@ -103,9 +101,7 @@ public class RoomRestController implements RoomApi {
 
     @GetMapping("/check-guestName")
     public ResponseEntity<GuestNameExistResponse> checkGuestName(
-            @RequestParam String joinCode,
-            @RequestParam String guestName
-    ) {
+            @RequestParam String joinCode, @RequestParam String guestName) {
         final boolean isDuplicated = roomService.isGuestNameDuplicated(joinCode, guestName);
 
         return ResponseEntity.ok(GuestNameExistResponse.from(isDuplicated));
@@ -120,9 +116,7 @@ public class RoomRestController implements RoomApi {
 
     @PatchMapping("/{joinCode}/settings")
     public ResponseEntity<Void> updateRoomSettings(
-            @PathVariable String joinCode,
-            @Valid @RequestBody UpdateRoomSettingsRequest request
-    ) {
+            @PathVariable String joinCode, @Valid @RequestBody UpdateRoomSettingsRequest request) {
         roomService.updateAdjustmentWeight(joinCode, request.hostName(), request.adjustmentWeight());
         return ResponseEntity.noContent().build();
     }
@@ -137,10 +131,7 @@ public class RoomRestController implements RoomApi {
     }
 
     @DeleteMapping("/{joinCode}/players/{playerName}")
-    public ResponseEntity<Void> kickPlayer(
-            @PathVariable String joinCode,
-            @PathVariable String playerName
-    ) {
+    public ResponseEntity<Void> kickPlayer(@PathVariable String joinCode, @PathVariable String playerName) {
         final boolean exists = playerService.checkAndKickPlayer(joinCode, playerName);
 
         if (exists) {

--- a/backend/room/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/room/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -10,6 +10,7 @@ import coffeeshout.room.ui.request.RoomEnterRequest;
 import coffeeshout.room.ui.request.UpdateRoomSettingsRequest;
 import coffeeshout.room.ui.response.GuestNameExistResponse;
 import coffeeshout.room.ui.response.JoinCodeExistResponse;
+import coffeeshout.room.ui.response.PlayerResponse;
 import coffeeshout.room.ui.response.ProbabilityResponse;
 import coffeeshout.room.ui.response.RandomNicknameResponse;
 import coffeeshout.room.ui.response.RoomCreateResponse;
@@ -124,6 +125,15 @@ public class RoomRestController implements RoomApi {
     ) {
         roomService.updateAdjustmentWeight(joinCode, request.hostName(), request.adjustmentWeight());
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{joinCode}/players")
+    public ResponseEntity<List<PlayerResponse>> getPlayers(@PathVariable String joinCode) {
+        final List<PlayerResponse> responses = playerService.getPlayers(joinCode).stream()
+                .map(PlayerResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(responses);
     }
 
     @DeleteMapping("/{joinCode}/players/{playerName}")

--- a/backend/room/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/room/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -123,11 +123,9 @@ public class RoomRestController implements RoomApi {
 
     @GetMapping("/{joinCode}/players")
     public ResponseEntity<List<PlayerResponse>> getPlayers(@PathVariable String joinCode) {
-        final List<PlayerResponse> responses = playerService.getPlayers(joinCode).stream()
+        return ResponseEntity.ok(playerService.getPlayers(joinCode).stream()
                 .map(PlayerResponse::from)
-                .toList();
-
-        return ResponseEntity.ok(responses);
+                .toList());
     }
 
     @DeleteMapping("/{joinCode}/players/{playerName}")

--- a/backend/room/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/room/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -43,6 +43,7 @@ public class RoomRestController implements RoomApi {
     private final RoomService roomService;
     private final PlayerService playerService;
 
+    @Override
     @PostMapping
     public ResponseEntity<RoomCreateResponse> createRoom(
             @AuthUser Optional<AuthenticatedUser> authUser,
@@ -54,6 +55,7 @@ public class RoomRestController implements RoomApi {
         return ResponseEntity.ok(RoomCreateResponse.of(result));
     }
 
+    @Override
     @PostMapping("/{joinCode}")
     public CompletableFuture<ResponseEntity<RoomEnterResponse>> enterRoom(
             @PathVariable String joinCode,
@@ -82,6 +84,7 @@ public class RoomRestController implements RoomApi {
         return request.playerName();
     }
 
+    @Override
     @GetMapping("/nickname/random")
     public ResponseEntity<RandomNicknameResponse> generateRandomNickname(
             @RequestParam(required = false) String joinCode) {
@@ -92,6 +95,7 @@ public class RoomRestController implements RoomApi {
         return ResponseEntity.ok(RandomNicknameResponse.from(nickname));
     }
 
+    @Override
     @GetMapping("/check-joinCode")
     public ResponseEntity<JoinCodeExistResponse> checkJoinCode(@RequestParam String joinCode) {
         final boolean exists = roomService.roomExists(joinCode);
@@ -99,6 +103,7 @@ public class RoomRestController implements RoomApi {
         return ResponseEntity.ok(JoinCodeExistResponse.from(exists));
     }
 
+    @Override
     @GetMapping("/check-guestName")
     public ResponseEntity<GuestNameExistResponse> checkGuestName(
             @RequestParam String joinCode, @RequestParam String guestName) {
@@ -107,6 +112,7 @@ public class RoomRestController implements RoomApi {
         return ResponseEntity.ok(GuestNameExistResponse.from(isDuplicated));
     }
 
+    @Override
     @GetMapping("/{joinCode}/probabilities")
     public ResponseEntity<List<ProbabilityResponse>> getProbabilities(@PathVariable String joinCode) {
         final List<ProbabilityResponse> responses = roomService.getProbabilities(joinCode);
@@ -114,6 +120,7 @@ public class RoomRestController implements RoomApi {
         return ResponseEntity.ok(responses);
     }
 
+    @Override
     @PatchMapping("/{joinCode}/settings")
     public ResponseEntity<Void> updateRoomSettings(
             @PathVariable String joinCode, @Valid @RequestBody UpdateRoomSettingsRequest request) {
@@ -121,6 +128,7 @@ public class RoomRestController implements RoomApi {
         return ResponseEntity.noContent().build();
     }
 
+    @Override
     @GetMapping("/{joinCode}/players")
     public ResponseEntity<List<PlayerResponse>> getPlayers(@PathVariable String joinCode) {
         return ResponseEntity.ok(playerService.getPlayers(joinCode).stream()
@@ -128,6 +136,7 @@ public class RoomRestController implements RoomApi {
                 .toList());
     }
 
+    @Override
     @DeleteMapping("/{joinCode}/players/{playerName}")
     public ResponseEntity<Void> kickPlayer(@PathVariable String joinCode, @PathVariable String playerName) {
         final boolean exists = playerService.checkAndKickPlayer(joinCode, playerName);

--- a/frontend/src/features/miniGame/context/MiniGameProviders.tsx
+++ b/frontend/src/features/miniGame/context/MiniGameProviders.tsx
@@ -1,26 +1,11 @@
-import useFetch from '@/apis/rest/useFetch';
-import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
-import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import { useBackButtonConfirm } from '@/hooks/useBackButtonConfirm';
 import { MiniGameType } from '@/types/miniGame/common';
-import { Player } from '@/types/player';
 import { PropsWithChildren } from 'react';
 import { useParams } from 'react-router-dom';
 import { GAME_CONFIGS } from '../config/gameConfigs';
 
 const MiniGameProviders = ({ children }: PropsWithChildren) => {
   useBackButtonConfirm();
-
-  // 명단(colorIndex 포함)은 로비 WS 구독으로만 채워진다. 게임 페이지 하드 리프레시·직접 진입 시엔
-  // 비어 있어 색이 전원 0 이 되므로 한 번만 HTTP 로 복구한다(#1688). 실시간 변경은 로비 책임.
-  const { joinCode } = useIdentifier();
-  const { participants, setParticipants } = useParticipants();
-  useFetch<Player[]>({
-    endpoint: `/rooms/${joinCode}/players`,
-    enabled: participants.length === 0 && joinCode !== '',
-    errorDisplayMode: 'toast',
-    onSuccess: setParticipants,
-  });
 
   const { miniGameType } = useParams();
   if (!miniGameType || !(miniGameType in GAME_CONFIGS)) {

--- a/frontend/src/features/miniGame/context/MiniGameProviders.tsx
+++ b/frontend/src/features/miniGame/context/MiniGameProviders.tsx
@@ -1,11 +1,26 @@
+import useFetch from '@/apis/rest/useFetch';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import { useBackButtonConfirm } from '@/hooks/useBackButtonConfirm';
 import { MiniGameType } from '@/types/miniGame/common';
+import { Player } from '@/types/player';
 import { PropsWithChildren } from 'react';
 import { useParams } from 'react-router-dom';
 import { GAME_CONFIGS } from '../config/gameConfigs';
 
 const MiniGameProviders = ({ children }: PropsWithChildren) => {
   useBackButtonConfirm();
+
+  // 명단(colorIndex 포함)은 로비 WS 구독으로만 채워진다. 게임 페이지 하드 리프레시·직접 진입 시엔
+  // 비어 있어 색이 전원 0 이 되므로 한 번만 HTTP 로 복구한다(#1688). 실시간 변경은 로비 책임.
+  const { joinCode } = useIdentifier();
+  const { participants, setParticipants } = useParticipants();
+  useFetch<Player[]>({
+    endpoint: `/rooms/${joinCode}/players`,
+    enabled: participants.length === 0 && joinCode !== '',
+    errorDisplayMode: 'toast',
+    onSuccess: setParticipants,
+  });
 
   const { miniGameType } = useParams();
   if (!miniGameType || !(miniGameType in GAME_CONFIGS)) {

--- a/frontend/src/features/miniGame/nunchiGame/components/NunchiCrowd/NunchiCrowd.tsx
+++ b/frontend/src/features/miniGame/nunchiGame/components/NunchiCrowd/NunchiCrowd.tsx
@@ -27,15 +27,19 @@ const nameColor = (state: NunchiPersonState, isMe: boolean): ColorKey => {
  * 번호는 stand 이벤트로 라이브 수집한 standNumbers 에서 읽는다. 재접속 전에 일어선 사람은 번호를
  * 모를 수 있으므로(스냅샷 stood 는 이름만) 그 경우만 숫자 대신 중립 표시('•')로 폴백한다.
  *
- * 명단(participants)은 로비에서 채워지고, 하드 리프레시·직접 진입 시엔 MiniGameProviders 가
- * HTTP 로 복구한다(#1688). 색은 명단의 colorIndex(서버 원천)만 쓴다.
+ * 명단(participants)은 로비에서 채워지고, 하드 리프레시·직접 진입 시엔 RoomLayout 의
+ * useRestoreParticipants 가 HTTP 로 복구한다(#1688). 색은 명단의 colorIndex(서버 원천)만 쓴다.
+ * 복구 응답 전·실패 시엔 게임 메시지로 드러난 사람(일어선·탈락)만이라도 그리고, 남은 인원은 알 수 없으니 숨긴다.
  */
 const NunchiCrowd = () => {
   const { myName } = useIdentifier();
   const { participants, getParticipantColorIndex } = useParticipants();
   const { stood, standNumbers, collided, lastStand } = useNunchiGameContext();
 
-  const roster = participants.map((participant) => participant.playerName);
+  const hasRoster = participants.length > 0;
+  const roster = hasRoster
+    ? participants.map((participant) => participant.playerName)
+    : Array.from(new Set([...stood, ...collided]));
 
   const getState = (name: string): NunchiPersonState => {
     if (collided.includes(name)) return 'out';
@@ -70,9 +74,11 @@ const NunchiCrowd = () => {
           );
         })}
       </S.Row>
-      <S.Remaining>
-        남은 사람 <S.RemainingCount>{seatedCount}</S.RemainingCount>명
-      </S.Remaining>
+      {hasRoster && (
+        <S.Remaining>
+          남은 사람 <S.RemainingCount>{seatedCount}</S.RemainingCount>명
+        </S.Remaining>
+      )}
     </S.Crowd>
   );
 };

--- a/frontend/src/features/miniGame/nunchiGame/components/NunchiCrowd/NunchiCrowd.tsx
+++ b/frontend/src/features/miniGame/nunchiGame/components/NunchiCrowd/NunchiCrowd.tsx
@@ -16,16 +16,6 @@ const nameColor = (state: NunchiPersonState, isMe: boolean): ColorKey => {
   return 'gray-700';
 };
 
-// 명단이 없을 때(하드 리프레시·직접 진입)는 getParticipantColorIndex 가 모두 0 을 반환해 전원이
-// 같은 색이 된다. 이름 해시로 안정적인 색 인덱스를 만들어 사람마다 구분되게 폴백한다.
-const fallbackColorIndex = (name: string): number => {
-  let hash = 0;
-  for (let i = 0; i < name.length; i += 1) {
-    hash = (hash * 31 + name.charCodeAt(i)) % colorList.length;
-  }
-  return hash;
-};
-
 /**
  * 눈치게임 무대 위 사람들(방향 A — "무대 위 사람들").
  *
@@ -37,19 +27,15 @@ const fallbackColorIndex = (name: string): number => {
  * 번호는 stand 이벤트로 라이브 수집한 standNumbers 에서 읽는다. 재접속 전에 일어선 사람은 번호를
  * 모를 수 있으므로(스냅샷 stood 는 이름만) 그 경우만 숫자 대신 중립 표시('•')로 폴백한다.
  *
- * 명단(participants)은 로비에서 채워져 게임까지 유지된다. 하드 리프레시·플레이 직접 진입 시엔
- * 비어 있을 수 있으므로 graceful degradation: 명단이 없으면 일어선/탈락한 사람만 그리고
- * "남은 N명" 은 숨긴다(앉은 군중을 알 수 없으므로).
+ * 명단(participants)은 로비에서 채워지고, 하드 리프레시·직접 진입 시엔 MiniGameProviders 가
+ * HTTP 로 복구한다(#1688). 색은 명단의 colorIndex(서버 원천)만 쓴다.
  */
 const NunchiCrowd = () => {
   const { myName } = useIdentifier();
   const { participants, getParticipantColorIndex } = useParticipants();
   const { stood, standNumbers, collided, lastStand } = useNunchiGameContext();
 
-  const hasRoster = participants.length > 0;
-  const roster = hasRoster
-    ? participants.map((participant) => participant.playerName)
-    : Array.from(new Set([...stood, ...collided]));
+  const roster = participants.map((participant) => participant.playerName);
 
   const getState = (name: string): NunchiPersonState => {
     if (collided.includes(name)) return 'out';
@@ -64,8 +50,7 @@ const NunchiCrowd = () => {
       <S.Row>
         {roster.map((name) => {
           const state = getState(name);
-          const colorIndex = hasRoster ? getParticipantColorIndex(name) : fallbackColorIndex(name);
-          const color = colorList[colorIndex] ?? colorList[0];
+          const color = colorList[getParticipantColorIndex(name)] ?? colorList[0];
           const isMe = name === myName;
           const pressedNumber = standNumbers[name];
           return (
@@ -85,11 +70,9 @@ const NunchiCrowd = () => {
           );
         })}
       </S.Row>
-      {hasRoster && (
-        <S.Remaining>
-          남은 사람 <S.RemainingCount>{seatedCount}</S.RemainingCount>명
-        </S.Remaining>
-      )}
+      <S.Remaining>
+        남은 사람 <S.RemainingCount>{seatedCount}</S.RemainingCount>명
+      </S.Remaining>
     </S.Crowd>
   );
 };

--- a/frontend/src/features/room/RoomLayout.tsx
+++ b/frontend/src/features/room/RoomLayout.tsx
@@ -1,10 +1,13 @@
 import { useNavigationGuard } from '@/hooks/useNavigateGuard';
 import { useRoomAccessGuard } from '@/hooks/useRoomAccessGuard';
 import { Outlet } from 'react-router-dom';
+import { useRestoreParticipants } from './hooks/useRestoreParticipants';
 
 const RoomLayout = () => {
   useNavigationGuard();
   useRoomAccessGuard();
+  // 로비·게임·룰렛 전부 이 레이아웃 아래라 리프레시 복구를 한 곳에서 처리한다(#1688)
+  useRestoreParticipants();
   return <Outlet />;
 };
 

--- a/frontend/src/features/room/hooks/useRestoreParticipants.ts
+++ b/frontend/src/features/room/hooks/useRestoreParticipants.ts
@@ -1,0 +1,36 @@
+import useFetch from '@/apis/rest/useFetch';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
+import { Player } from '@/types/player';
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * 참가자 명단(colorIndex 포함) 복구 — #1688.
+ *
+ * 명단은 로비 WS 구독으로만 채워져, 게임·룰렛 페이지에서 하드 리프레시·직접 진입하면 비어 있고
+ * 색이 전원 0 이 된다. 방 라우트 진입 시 명단이 비어 있으면 HTTP 로 한 번만 받아 채운다.
+ * 실시간 변경(입장·퇴장·레디)은 계속 로비 WS 책임이다.
+ */
+export const useRestoreParticipants = () => {
+  const { joinCode } = useIdentifier();
+  const { participants, setParticipants } = useParticipants();
+
+  // useFetch 는 취소 가드가 없어 응답이 늦게 올 수 있다 — 그 사이 WS 로 채워진 최신 명단은 덮지 않는다
+  const participantsRef = useRef(participants);
+  useEffect(() => {
+    participantsRef.current = participants;
+  }, [participants]);
+  const restore = useCallback(
+    (players: Player[]) => {
+      if (participantsRef.current.length === 0) setParticipants(players);
+    },
+    [setParticipants]
+  );
+
+  useFetch<Player[]>({
+    endpoint: `/rooms/${joinCode}/players`,
+    enabled: participants.length === 0 && joinCode !== '',
+    errorDisplayMode: 'toast',
+    onSuccess: restore,
+  });
+};


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1688

# 🚀 작업 내용

1. **BE** `RoomRestController`·`RoomApi`에 `GET /rooms/{joinCode}/players` 추가. 기존 `PlayerService.getPlayers`(로비 WS 명단과 같은 경로)를 그대로 써서 `PlayerResponse[]`(colorIndex 포함)로 내려준다. 없는 방은 기존 규약대로 404.
2. **BE 테스트** `RoomRestControllerTest`에 `GetPlayersTest` 2건 — 명단·colorIndex가 픽스처 그대로 내려오는지, 없는 방 404.
3. **FE** `RoomLayout`의 `useRestoreParticipants` 훅(로비·게임·룰렛 전부 거침)에서 명단이 비어 있을 때만 `useFetch`로 한 번 조회해(늦은 응답은 비어 있을 때만 반영) `ParticipantsProvider`를 채운다. 로비 WS 구독은 그대로.
4. **FE** `NunchiCrowd`의 이름 해시 색 폴백(`fallbackColorIndex`)과 `hasRoster` 분기 제거 — 색은 서버 `colorIndex`만 쓴다.
5. `[chore]` 커밋은 pre-push 훅이 요구한 `spotlessApply` 결과(건드린 3개 Java 파일의 import 순서·줄바꿈 정리).

# 💬 리뷰 중점사항

- **HTTP 일회성 조회를 택한 이유**: WS `update-players`는 방 전원 브로드캐스트라 한 명의 리프레시 때문에 전원에게 쏘는 건 과하다. `enabled: participants.length === 0`이라 로비에서 정상 진입한 경우엔 요청이 나가지 않는다.
- `errorDisplayMode: 'toast'` — `useFetch`에 조용히 삼키는 모드가 없어(`fallback|toast|text`) 없는 방이면 토스트만 띄우고 게임 화면은 유지한다. ErrorBoundary로 던지는 게 낫다고 보면 알려주세요.
- `NunchiCrowd`: 명단이 비어 있는 동안(복구 응답 전 아주 잠깐)은 아무도 안 그려진다. 예전의 "일어선 사람만 그리기" 폴백도 함께 제거했다 — 이제 명단이 곧 채워지므로.
- 다른 게임(레이싱·블록쌓기)은 `getParticipantColorIndex`만 쓰고 있어 이 PR로 자동 복구된다. 코드는 건드리지 않았다.
- deep-review 완료 — 코멘트 참조. `NunchiCrowd`는 명단이 비면 일어선·탈락자만 그리고 인원 카운트는 숨긴다.

