### PR TITLE
[fix] pmdTestFixtures 룰셋 누락 수정 — ./gradlew build 복구

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -120,7 +120,7 @@ jobs:
       # 린트는 컨테이너를 띄우지 않아 테스트보다 훨씬 빠르다 — 앞에 두어 fail-fast 시킨다 (ADR-0036).
       # 로컬에서는 ./gradlew spotlessApply 로 포맷을 먼저 고친다.
       - name: Run Lint (Spotless + PMD)
-        run: ./gradlew spotlessCheck pmdMain pmdTest --build-cache --no-daemon
+        run: ./gradlew spotlessCheck pmdMain pmdTest pmdTestFixtures --build-cache --no-daemon
 
       # 모듈별 test JVM이 같은 MySQL/Valkey 컨테이너를 재사용하도록 활성화 (ADR-0013)
       # 모듈별 독립 DB(zzol_test_<module>)·Redis DB 인덱스 격리로 병렬 실행 시에도 안전하다

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,10 +36,16 @@ subprojects {
 
     // 룰셋은 소스셋별로 다르다 — 테스트의 @Autowired 필드 주입은 JUnit+Spring 관용이라 금지 대상이 아니고,
     // Thread.sleep·JUnit 단언 금지는 반대로 테스트에만 의미가 있다.
-    // :test-support의 main은 프로덕션이 아니라 테스트 인프라이므로 테스트 룰셋을 적용한다.
+    // :test-support의 main과 testFixtures는 프로덕션이 아니라 테스트 인프라이므로 테스트 룰셋을 적용한다.
+    //
+    // 태스크를 이름으로 하나씩 집지 않고 withType으로 거는 이유 — PMD 플러그인은 소스셋마다 태스크를
+    // 자동 생성한다(java-test-fixtures를 쓰는 모듈은 pmdTestFixtures가 생긴다). 위에서 기본 룰셋을 껐으므로
+    // 지정에서 빠진 태스크는 룰셋이 0개가 되고, PMD는 그 상태로 "No rulesets specified"를 내며 죽는다.
     val mainRuleSet = if (name == "test-support") "ruleset-test.xml" else "ruleset-main.xml"
-    tasks.named<Pmd>("pmdMain") { ruleSetFiles = files(rootProject.file("config/pmd/$mainRuleSet")) }
-    tasks.named<Pmd>("pmdTest") { ruleSetFiles = files(rootProject.file("config/pmd/ruleset-test.xml")) }
+    tasks.withType<Pmd>().configureEach {
+        val ruleSet = if (name == "pmdMain") mainRuleSet else "ruleset-test.xml"
+        ruleSetFiles = files(rootProject.file("config/pmd/$ruleSet"))
+    }
 
     // 포맷은 Spotless가 자동 수정한다 (ADR-0036). ./gradlew spotlessApply
     extensions.configure<SpotlessExtension> {


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1694

# 🚀 작업 내용

1. **`tasks.named` 2건 → `tasks.withType<Pmd>().configureEach`로 교체** (`backend/build.gradle.kts`)

   PMD 플러그인은 **소스셋마다 태스크를 자동 생성**한다. 그런데 룰셋은 `pmdMain`·`pmdTest` 두 개에만 이름으로 지정돼 있었다.

   ```kotlin
   // before — 이름으로 하나씩
   tasks.named<Pmd>("pmdMain") { ruleSetFiles = files(...$mainRuleSet) }
   tasks.named<Pmd>("pmdTest") { ruleSetFiles = files(...ruleset-test.xml) }

   // after — 전부 걸고 분기만 유지
   tasks.withType<Pmd>().configureEach {
       val ruleSet = if (name == "pmdMain") mainRuleSet else "ruleset-test.xml"
       ruleSetFiles = files(rootProject.file("config/pmd/$ruleSet"))
   }
   ```

   `java-test-fixtures`를 쓰는 5개 모듈(`game`·`room`·`user`·`admin`·`profanity`)에 생기는 `pmdTestFixtures`가 지정에서 빠져 룰셋이 0개가 됐다. 기본 룰셋도 꺼져 있어서(`ruleSets = emptyList()`, ADR-0036) 진짜로 0개가 되고, PMD는 그 상태로 죽는다.

   ```
   Execution failed for task ':game:pmdTestFixtures'
   > No rulesets specified
   ```

   "규칙 위반이 있다"가 아니라 **"검사할 규칙을 안 줬다"**는 설정 에러다.

2. **CI 린트 스텝에 `pmdTestFixtures` 추가** (`.github/workflows/backend-ci.yml:123`)

   ```diff
   - run: ./gradlew spotlessCheck pmdMain pmdTest --build-cache --no-daemon
   + run: ./gradlew spotlessCheck pmdMain pmdTest pmdTestFixtures --build-cache --no-daemon
   ```

   CI는 태스크를 **지정 실행**해서 `pmdTestFixtures`를 안 건드렸다. 그래서 **CI는 초록인데 로컬 `./gradlew build`만 깨지는** 상태였고, 동시에 픽스처 19개가 계속 린트를 안 받았다. 1번만 고치면 로컬 빌드는 살아나지만 사각지대는 그대로라서 같이 넣었다.

## 검증

**① 원래 깨지던 태스크 5개 통과**

```
> Task :user:pmdTestFixtures
> Task :profanity:pmdTestFixtures
> Task :room:pmdTestFixtures
> Task :game:pmdTestFixtures
> Task :admin:pmdTestFixtures
BUILD SUCCESSFUL
```

**② 룰셋이 실제로 먹는지 — 일부러 위반을 넣어 확인**

"통과"가 "빈 룰셋으로 그냥 지나감"이 아닌지 확인하려고 `StubDeck`에 `Thread.sleep`·`System.out.println`을 넣고 돌렸다.

```
StubDeck.java:8: NoThreadSleep:  Thread.sleep 대신 Awaitility(통합) 또는 CapturingScheduler(오케스트레이터)를 쓴다
StubDeck.java:8: SystemPrintln:  Usage of System.out/err
> Task :game:pmdTestFixtures FAILED
   > 2 PMD rule violations were found.
```

둘 다 잡혔다. 확인 후 되돌렸다(이 PR에 포함되지 않음).

**③ 전체 빌드 — 테스트 태스크 13개 포함 통과**

```
$ ./gradlew build
BUILD SUCCESSFUL
```

**④ CI가 실제로 돌릴 명령 그대로 통과**

```
$ ./gradlew spotlessCheck pmdMain pmdTest pmdTestFixtures
BUILD SUCCESSFUL
```

# 💬 리뷰 중점사항

**1. `testFixtures`에 테스트 룰셋을 적용한 판단**

`ruleset-test.xml`(`Thread.sleep`·JUnit 단언·`System.out` 금지)을 골랐다. 픽스처는 프로덕션이 아니라 테스트 인프라이므로, 루트 `build.gradle.kts`가 이미 하고 있는 판단(`:test-support`의 **main**에 테스트 룰셋 적용)과 같은 계열로 봤다. 다르게 보시면 알려주세요.

**2. `else` 분기의 기본값**

`pmdMain`만 main 룰셋이고 나머지는 전부 테스트 룰셋이다. 현재 존재하는 PMD 태스크는 `pmdMain`/`pmdTest`/`pmdTestFixtures` 셋뿐이라 동작은 같지만, 앞으로 소스셋이 추가돼도 "룰셋 0개로 죽는" 상태가 안 생기게 하려고 화이트리스트가 아닌 기본값 방식으로 뒀다. 이게 이 PR이 고치는 버그의 재발 방지다.

**3. 후속 청소가 없다는 점**

룰셋을 붙이면 그동안 안 걸리던 지적이 쏟아질 수 있어 미리 확인했는데, **19개 파일 전부 위반 0건**이라 코드 수정이 없다. 이슈 본문의 "새로 걸리는 PMD 지적 해소" 항목은 빈 칸이다.

**4. CI 시간**

린트 스텝에 태스크 하나가 늘었다. 픽스처가 19파일뿐이고 컨테이너를 안 띄우는 단계라 체감 차이는 없을 것으로 본다(로컬에서 4개 태스크 전체 687ms).
