### PR TITLE
[docs] 모듈 의존 방향 다이어그램을 실측 기준으로 갱신

### DIFF
--- a/backend/docs/architecture.md
+++ b/backend/docs/architecture.md
@@ -15,6 +15,7 @@
 :web          — 공유 HTTP 인프라 (RestExceptionHandler, CORS, SpringDoc)
 :websocket    — STOMP 플랫폼 (도메인 무지)
 :game-api     — 게임 SPI (Playable, MiniGameFactory, FlowScheduler, Gamer)
+                + 도메인 간 계약 (이벤트, RoomSnapshotQuery·SeasonUserProfileQuery 포트)
 :user         — User + Auth + Friend
 :room         — Room aggregate + Player + Roulette + RoomSessionToken
 :game         — 6게임 구현체 + minigame orchestration
@@ -25,17 +26,48 @@
 :test-support — 통합/서비스 테스트 공통 인프라 (testImplementation 전용)
 ```
 
-의존 방향 (단방향, 순환 없음):
+### 의존 방향 (단방향, 순환 없음)
+
+계층은 아래에서 위로만 의존한다. 같은 계층끼리의 의존은 `:room → :user` 하나뿐이다.
 
 ```text
-:common → :infra
-        → :web       (:game-api 제외 전 도메인 모듈 공통 기반)
-        → :game-api → :room → :game → :admin
-                                    → :zzolbot
-        :infra + :web → :websocket → :user
-        :common + :infra → :profanity → :admin
-        (모두) → :app
-:test-support — testImplementation 전용
+L4  조립      :app                                        ← 모든 모듈 조합
+L3  소비자    :admin      :zzolbot
+L2  도메인    :room ──→ :user      :game      :profanity
+L1  플랫폼    :websocket  :web  :infra  :game-api  :test-support
+L0  순수      :common                                     ← Spring 무관
+```
+
+모듈별 프로덕션 의존(`implementation`/`api`)은 다음과 같다. 표의 `→`는 **"왼쪽이 오른쪽에 의존한다"**를 뜻한다.
+
+| 모듈 | 프로덕션 의존 |
+| --- | --- |
+| `:common` | 없음 |
+| `:web` | `:common` |
+| `:infra` | `:common` |
+| `:game-api` | `:common` |
+| `:test-support` | `:common` |
+| `:websocket` | `:common` `:web` |
+| `:profanity` | `:common` `:infra` |
+| `:game` | `:common` `:game-api` `:infra` `:web` `:websocket` |
+| `:user` | `:common` `:game-api` `:infra` `:web` `:websocket` |
+| `:room` | `:common` `:game-api` `:infra` `:web` `:websocket` **`:user`** |
+| `:zzolbot` | `:common` `:game-api` `:infra` `:web` + `:game` `:room` |
+| `:admin` | `:common` `:game-api` `:infra` `:web` + `:game` `:room` `:user` `:profanity` |
+| `:app` | 전 모듈 (`:test-support` 제외 — 테스트 전용) |
+
+**L2 도메인 4개 중 `:game`·`:user`·`:profanity`는 다른 도메인 모듈을 컴파일 시점에 모른다.** `:game`이 방·유저와 주고받는 것은 전부 `:game-api`의 이벤트·조회 포트를 거친다(ADR-0025, ADR-0034). ArchUnit `game_프로덕션은_room을_직접_참조할_수_없다`·`game_프로덕션은_user를_직접_참조할_수_없다`가 재유입을 CI에서 차단한다.
+
+`:room → :user`는 남아 있는 유일한 도메인 간 의존이다(인증 타입 + 닉네임 조회).
+
+#### 테스트 스코프는 위 그림과 다르다
+
+`testImplementation`/`testFixtures`로만 걸린 의존은 프로덕션 의존이 아니다. `@SpringBootTest` 컨텍스트가 전이 빈을 로드해 생긴 것으로, 위 계층 판단의 근거로 쓰지 않는다.
+
+```text
+:game → :room  :user  :profanity     (테스트 전용 — 프로덕션 의존 아님)
+:room → :profanity                   (테스트 전용)
+전 모듈 → :test-support               (테스트 전용)
 ```
 
 ---

--- a/backend/docs/architecture.md
+++ b/backend/docs/architecture.md
@@ -18,7 +18,8 @@
                 + 도메인 간 계약 (이벤트, RoomSnapshotQuery·SeasonUserProfileQuery 포트)
 :user         — User + Auth + Friend
 :room         — Room aggregate + Player + Roulette + RoomSessionToken
-:game         — 6게임 구현체 + minigame orchestration
+:game         — 미니게임 구현체(cardgame·laddergame·racinggame·blockstacking·speedtouch·blindtimer·nunchi)
+                + minigame orchestration + settlement(시즌 정산·종합 랭크)
 :profanity    — 비속어 필터 (:admin·:app 이 사용, :room·:game 은 테스트에서만)
 :admin        — dashboard + patchnote + report
 :zzolbot      — AI 운영자 어시스턴트


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1697

# 🚀 작업 내용

`backend/docs/architecture.md`가 실제 코드와 어긋나 있어 실측 기준으로 고쳤습니다. `backend/CLAUDE.md`가 이 문서를 모듈 목록·역할·의존 방향의 유일한 출처로 지정하고 있어, 틀린 내용이 그대로 작업 전제가 됩니다.

## 의존 방향 다이어그램

1. **`game → room` 표기 제거** — #1550(ADR-0034)에서 끊긴 의존입니다. 현재 `:game`의 프로덕션 의존은 `:common` `:game-api` `:infra` `:web` `:websocket` 뿐입니다.
2. **`room → user` 추가** — 실제로 존재하는데 그림에 없었습니다. 도메인 모듈끼리의 의존은 지금 이것 하나뿐이라 오히려 가장 잘 보여야 하는 화살표입니다.
3. **`:admin`·`:zzolbot`·`:user`의 누락 의존 보정** — `:admin`은 `:user`가, `:user`는 `:game-api`가 빠져 있었습니다.
4. **화살표 의미 명시 + 모듈별 의존을 표로 확정** — 기존 표기는 "A가 B에 의존"인지 반대인지 읽는 사람에 따라 갈렸습니다. 계층 그림으로 전체 모양을 보이고, 정확한 값은 13개 모듈 표로 고정했습니다.
5. **테스트 스코프를 별도 블록으로 분리** — `:game:test`가 `:room`을 끌어오는 것은 프로덕션 의존이 아닌데 섞이면 오독을 부릅니다. `@SpringBootTest`가 전이 빈을 로드해 생긴 것이라는 설명을 붙였습니다.

## 모듈 설명

6. **`:game-api`에 도메인 간 계약 역할 한 줄 추가** — `:room`·`:user`가 왜 `:game-api`에 의존하는지가 의존 표만 봐서는 안 보입니다.
7. **`:game` 설명 교정** — `6게임 구현체`로 적혀 있었으나 실제로는 **7종**입니다(`nunchi` 누락). 그리고 `settlement`(시즌 정산·종합 랭크, #1612)도 `:game` 소유인데 설명에 없었습니다.
   - **개수 대신 이름을 나열했습니다.** 개수는 게임이 늘 때마다 조용히 낡지만(실제로 6→7에서 그렇게 됐습니다), 빠진 이름은 리뷰에서 눈에 띕니다.

# 💬 리뷰 중점사항

- **표의 값은 실측입니다.** `implementation`/`api` 스코프만 추출해 만들었습니다. 검증하시려면:

  ```bash
  grep -HE '^\s*(implementation|api)\(project\(' backend/*/build.gradle.kts
  ```

- **ADR의 "6종" 표기는 손대지 않았습니다.** ADR-0011·0025·0031에도 같은 표현이 있지만, ADR은 그 시점의 결정 기록이라 소급 수정하면 기록으로서의 의미가 사라진다고 봤습니다. 레퍼런스 문서만 현재 상태를 따라갑니다.
- **문서 구조를 조금 바꿨습니다.** 기존에 평문이던 "의존 방향 (단방향, 순환 없음):"을 `###` 헤딩으로 올리고 그 아래 하위 절을 뒀습니다. 섹션이 길어져 목차상 찾기 쉬운 편이 낫다고 봤는데, 원래 평문 유지가 나으면 되돌리겠습니다.
- **6·7번은 이슈 범위를 살짝 넘습니다.** 의존 표를 만들면서 같은 파일에서 발견한 어긋남이라 함께 고쳤습니다. 이슈 범위를 엄격히 지키는 편이 좋으면 분리하겠습니다.
- Docs CI(markdownlint) 로컬 통과 확인했습니다.
