### PR TITLE
[refactor] Redis deprecated API 제거 — TimeUnit 대신 Duration 사용

### DIFF
--- a/backend/user/src/main/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepository.java
+++ b/backend/user/src/main/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepository.java
@@ -3,8 +3,8 @@ package coffeeshout.user.infra.redis;
 import coffeeshout.user.domain.OAuthCodeEntry;
 import coffeeshout.user.domain.TokenPair;
 import coffeeshout.user.domain.repository.OAuthCodeRepository;
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -21,7 +21,7 @@ public class RedisOAuthCodeRepository implements OAuthCodeRepository {
     @Override
     public void save(String code, TokenPair tokens, boolean isNewUser, long ttlSeconds) {
         final String value = tokens.accessToken() + DELIMITER + tokens.refreshToken() + DELIMITER + isNewUser;
-        stringRedisTemplate.opsForValue().set(KEY_PREFIX + code, value, ttlSeconds, TimeUnit.SECONDS);
+        stringRedisTemplate.opsForValue().set(KEY_PREFIX + code, value, Duration.ofSeconds(ttlSeconds));
     }
 
     @Override

--- a/backend/user/src/main/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepository.java
+++ b/backend/user/src/main/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepository.java
@@ -20,6 +20,11 @@ public class RedisOAuthCodeRepository implements OAuthCodeRepository {
 
     @Override
     public void save(String code, TokenPair tokens, boolean isNewUser, long ttlSeconds) {
+        // Duration.ZERO는 Spring Data Redis가 Expiration.persistent()로 바꿔 만료 없이 저장한다.
+        // 인가 코드가 조용히 영구 존속하는 것보다 여기서 터지는 편이 낫다.
+        if (ttlSeconds <= 0) {
+            throw new IllegalArgumentException("ttlSeconds는 양수여야 합니다: " + ttlSeconds);
+        }
         final String value = tokens.accessToken() + DELIMITER + tokens.refreshToken() + DELIMITER + isNewUser;
         stringRedisTemplate.opsForValue().set(KEY_PREFIX + code, value, Duration.ofSeconds(ttlSeconds));
     }

--- a/backend/user/src/main/java/coffeeshout/user/infra/redis/RedisRefreshTokenRepository.java
+++ b/backend/user/src/main/java/coffeeshout/user/infra/redis/RedisRefreshTokenRepository.java
@@ -2,9 +2,9 @@ package coffeeshout.user.infra.redis;
 
 import coffeeshout.user.domain.AuthenticatedUser;
 import coffeeshout.user.domain.repository.RefreshTokenRepository;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -24,9 +24,11 @@ public class RedisRefreshTokenRepository implements RefreshTokenRepository {
         final String userTokensKey = userTokensKey(userId);
         final String storedValue = userId + ":" + userCode;
 
-        stringRedisTemplate.opsForValue().set(tokenKey, storedValue, expirationSeconds, TimeUnit.SECONDS);
+        final Duration expiration = Duration.ofSeconds(expirationSeconds);
+
+        stringRedisTemplate.opsForValue().set(tokenKey, storedValue, expiration);
         stringRedisTemplate.opsForSet().add(userTokensKey, tokenId);
-        stringRedisTemplate.expire(userTokensKey, expirationSeconds, TimeUnit.SECONDS);
+        stringRedisTemplate.expire(userTokensKey, expiration);
     }
 
     @Override

--- a/backend/user/src/main/java/coffeeshout/user/infra/redis/RedisRefreshTokenRepository.java
+++ b/backend/user/src/main/java/coffeeshout/user/infra/redis/RedisRefreshTokenRepository.java
@@ -20,6 +20,11 @@ public class RedisRefreshTokenRepository implements RefreshTokenRepository {
 
     @Override
     public void save(Long userId, String userCode, String tokenId, long expirationSeconds) {
+        // Duration.ZERO는 Spring Data Redis가 Expiration.persistent()로 바꿔 만료 없이 저장한다.
+        // 리프레시 토큰이 조용히 영구 유효해지는 것보다 여기서 터지는 편이 낫다.
+        if (expirationSeconds <= 0) {
+            throw new IllegalArgumentException("expirationSeconds는 양수여야 합니다: " + expirationSeconds);
+        }
         final String tokenKey = tokenKey(tokenId);
         final String userTokensKey = userTokensKey(userId);
         final String storedValue = userId + ":" + userCode;

--- a/backend/user/src/test/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepositoryTest.java
+++ b/backend/user/src/test/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepositoryTest.java
@@ -1,0 +1,67 @@
+package coffeeshout.user.infra.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.UserModuleServiceTest;
+import coffeeshout.user.domain.OAuthCodeEntry;
+import coffeeshout.user.domain.TokenPair;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+class RedisOAuthCodeRepositoryTest extends UserModuleServiceTest {
+
+    private static final String KEY_PREFIX = "oauth:code:";
+    private static final long TTL_SECONDS = 60L;
+
+    @Autowired
+    RedisOAuthCodeRepository redisOAuthCodeRepository;
+
+    @Autowired
+    StringRedisTemplate stringRedisTemplate;
+
+    TokenPair 토큰_쌍 = new TokenPair("access-token", "refresh-token");
+
+    @Test
+    void 인가코드를_저장하면_TTL이_설정된다() {
+        redisOAuthCodeRepository.save("code-ttl", 토큰_쌍, true, TTL_SECONDS);
+
+        final Long ttl = stringRedisTemplate.getExpire(KEY_PREFIX + "code-ttl");
+
+        assertThat(ttl).isNotNull().isPositive().isLessThanOrEqualTo(TTL_SECONDS);
+    }
+
+    @Test
+    void 저장한_인가코드를_조회하면_토큰_쌍과_신규가입_여부를_돌려준다() {
+        redisOAuthCodeRepository.save("code-found", 토큰_쌍, true, TTL_SECONDS);
+
+        final OAuthCodeEntry entry =
+                redisOAuthCodeRepository.findAndDelete("code-found").orElseThrow();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(entry.tokenPair()).isEqualTo(토큰_쌍);
+            softly.assertThat(entry.isNewUser()).isTrue();
+        });
+    }
+
+    @Test
+    void 한번_조회한_인가코드는_삭제되어_다시_조회되지_않는다() {
+        redisOAuthCodeRepository.save("code-once", 토큰_쌍, false, TTL_SECONDS);
+        redisOAuthCodeRepository.findAndDelete("code-once");
+
+        assertThat(redisOAuthCodeRepository.findAndDelete("code-once")).isEmpty();
+    }
+
+    @Test
+    void 존재하지_않는_인가코드를_조회하면_빈_값이다() {
+        assertThat(redisOAuthCodeRepository.findAndDelete("code-absent")).isEmpty();
+    }
+
+    @Test
+    void 구분자_형식이_깨진_값이_저장돼_있으면_빈_값이다() {
+        stringRedisTemplate.opsForValue().set(KEY_PREFIX + "code-broken", "access-token||refresh-token");
+
+        assertThat(redisOAuthCodeRepository.findAndDelete("code-broken")).isEmpty();
+    }
+}

--- a/backend/user/src/test/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepositoryTest.java
+++ b/backend/user/src/test/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepositoryTest.java
@@ -1,6 +1,7 @@
 package coffeeshout.user.infra.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import coffeeshout.UserModuleServiceTest;
 import coffeeshout.user.domain.OAuthCodeEntry;
@@ -43,6 +44,25 @@ class RedisOAuthCodeRepositoryTest extends UserModuleServiceTest {
             softly.assertThat(entry.tokenPair()).isEqualTo(토큰_쌍);
             softly.assertThat(entry.isNewUser()).isTrue();
         });
+    }
+
+    @Test
+    void TTL이_0이면_저장하지_않고_예외를_던진다() {
+        // @Repository 예외 변환이 IllegalArgumentException을 DataAccessException으로 감싼다.
+        assertThatThrownBy(() -> redisOAuthCodeRepository.save("code-zero-ttl", 토큰_쌍, true, 0L))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class);
+
+        assertThat(stringRedisTemplate.hasKey(KEY_PREFIX + "code-zero-ttl")).isFalse();
+    }
+
+    @Test
+    void 기존_회원으로_저장한_인가코드는_신규가입_여부가_false로_돌아온다() {
+        redisOAuthCodeRepository.save("code-existing", 토큰_쌍, false, TTL_SECONDS);
+
+        final OAuthCodeEntry entry =
+                redisOAuthCodeRepository.findAndDelete("code-existing").orElseThrow();
+
+        assertThat(entry.isNewUser()).isFalse();
     }
 
     @Test

--- a/backend/user/src/test/java/coffeeshout/user/infra/redis/RedisRefreshTokenRepositoryTest.java
+++ b/backend/user/src/test/java/coffeeshout/user/infra/redis/RedisRefreshTokenRepositoryTest.java
@@ -1,6 +1,8 @@
 package coffeeshout.user.infra.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import coffeeshout.UserModuleServiceTest;
 import coffeeshout.user.domain.AuthenticatedUser;
@@ -34,6 +36,16 @@ class RedisRefreshTokenRepositoryTest extends UserModuleServiceTest {
             softly.assertThat(토큰_TTL).isNotNull().isPositive().isLessThanOrEqualTo(EXPIRATION_SECONDS);
             softly.assertThat(목록_TTL).isNotNull().isPositive().isLessThanOrEqualTo(EXPIRATION_SECONDS);
         });
+    }
+
+    @Test
+    void 만료시간이_0이면_저장하지_않고_예외를_던진다() {
+        // @Repository 예외 변환이 IllegalArgumentException을 DataAccessException으로 감싼다.
+        assertThatThrownBy(() -> redisRefreshTokenRepository.save(사용자_아이디, 사용자_코드, "token-zero-ttl", 0L))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class);
+
+        assertThat(stringRedisTemplate.hasKey(TOKEN_KEY_PREFIX + "token-zero-ttl"))
+                .isFalse();
     }
 
     @Test
@@ -78,5 +90,11 @@ class RedisRefreshTokenRepositoryTest extends UserModuleServiceTest {
             softly.assertThat(stringRedisTemplate.hasKey(USER_TOKENS_KEY_PREFIX + 사용자_아이디))
                     .isFalse();
         });
+    }
+
+    @Test
+    void 저장된_토큰이_없는_사용자를_전체_삭제해도_예외가_나지_않는다() {
+        assertThatCode(() -> redisRefreshTokenRepository.deleteAllByUserId(사용자_아이디))
+                .doesNotThrowAnyException();
     }
 }

--- a/backend/user/src/test/java/coffeeshout/user/infra/redis/RedisRefreshTokenRepositoryTest.java
+++ b/backend/user/src/test/java/coffeeshout/user/infra/redis/RedisRefreshTokenRepositoryTest.java
@@ -1,0 +1,82 @@
+package coffeeshout.user.infra.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.UserModuleServiceTest;
+import coffeeshout.user.domain.AuthenticatedUser;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+class RedisRefreshTokenRepositoryTest extends UserModuleServiceTest {
+
+    private static final String TOKEN_KEY_PREFIX = "refresh:token:";
+    private static final String USER_TOKENS_KEY_PREFIX = "refresh:user:";
+    private static final long EXPIRATION_SECONDS = 60L;
+    private static final Long 사용자_아이디 = 1L;
+    private static final String 사용자_코드 = "AB3CD";
+
+    @Autowired
+    RedisRefreshTokenRepository redisRefreshTokenRepository;
+
+    @Autowired
+    StringRedisTemplate stringRedisTemplate;
+
+    @Test
+    void 토큰과_사용자_토큰_목록_양쪽에_TTL이_설정된다() {
+        redisRefreshTokenRepository.save(사용자_아이디, 사용자_코드, "token-ttl", EXPIRATION_SECONDS);
+
+        final Long 토큰_TTL = stringRedisTemplate.getExpire(TOKEN_KEY_PREFIX + "token-ttl");
+        final Long 목록_TTL = stringRedisTemplate.getExpire(USER_TOKENS_KEY_PREFIX + 사용자_아이디);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(토큰_TTL).isNotNull().isPositive().isLessThanOrEqualTo(EXPIRATION_SECONDS);
+            softly.assertThat(목록_TTL).isNotNull().isPositive().isLessThanOrEqualTo(EXPIRATION_SECONDS);
+        });
+    }
+
+    @Test
+    void 저장한_토큰으로_사용자를_조회한다() {
+        redisRefreshTokenRepository.save(사용자_아이디, 사용자_코드, "token-found", EXPIRATION_SECONDS);
+
+        final AuthenticatedUser 조회된_사용자 =
+                redisRefreshTokenRepository.findByTokenId("token-found").orElseThrow();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(조회된_사용자.userId()).isEqualTo(사용자_아이디);
+            softly.assertThat(조회된_사용자.userCode()).isEqualTo(사용자_코드);
+        });
+    }
+
+    @Test
+    void 존재하지_않는_토큰을_조회하면_빈_값이다() {
+        assertThat(redisRefreshTokenRepository.findByTokenId("token-absent")).isEmpty();
+    }
+
+    @Test
+    void 삭제한_토큰은_조회되지_않는다() {
+        redisRefreshTokenRepository.save(사용자_아이디, 사용자_코드, "token-deleted", EXPIRATION_SECONDS);
+
+        redisRefreshTokenRepository.delete("token-deleted");
+
+        assertThat(redisRefreshTokenRepository.findByTokenId("token-deleted")).isEmpty();
+    }
+
+    @Test
+    void 사용자의_토큰을_모두_삭제하면_토큰과_목록이_함께_사라진다() {
+        redisRefreshTokenRepository.save(사용자_아이디, 사용자_코드, "token-first", EXPIRATION_SECONDS);
+        redisRefreshTokenRepository.save(사용자_아이디, 사용자_코드, "token-second", EXPIRATION_SECONDS);
+
+        redisRefreshTokenRepository.deleteAllByUserId(사용자_아이디);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(redisRefreshTokenRepository.findByTokenId("token-first"))
+                    .isEmpty();
+            softly.assertThat(redisRefreshTokenRepository.findByTokenId("token-second"))
+                    .isEmpty();
+            softly.assertThat(stringRedisTemplate.hasKey(USER_TOKENS_KEY_PREFIX + 사용자_아이디))
+                    .isFalse();
+        });
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1700

# 🚀 작업 내용

## 무엇이 달라지는가

빌드 로그에서 Redis 관련 deprecation 경고 3건이 사라진다. 로그인·토큰 발급 동작은 그대로다.

덤으로 그동안 테스트가 하나도 없던 Redis 리포지토리 두 개에 회귀 테스트가 생긴다.

## 왜 바꿨는가

`:user` 모듈의 Redis 리포지토리 두 곳이 Spring Data Redis에서 deprecate된 API를 쓰고 있었다. 그래서 CI가 돌 때마다 아래 경고 3건이 항상 찍혔다.

- `RedisOAuthCodeRepository:24` — `ValueOperations.set(K,V,long,TimeUnit)`
- `RedisRefreshTokenRepository:27` — `ValueOperations.set(K,V,long,TimeUnit)`
- `RedisRefreshTokenRepository:29` — `RedisTemplate.expire(K,long,TimeUnit)`

상시로 깔린 경고는 새로 생긴 경고를 묻는다. 이번에 새로 들어온 경고인지 원래 있던 것인지 구분하려면 매번 로그를 거슬러 올라가 확인해야 한다.

교체 대상이 3줄뿐이고 대체 API가 같은 인터페이스에 이미 있다. 지금 없애는 비용이 가장 싸다.

## 이 교체는 완전히 무해하지 않았다 — TTL 0에서 갈린다

리뷰 과정에서 두 오버로드의 동작이 `0`에서 갈리는 것을 발견했다. Spring Data Redis가 `Duration.ZERO`를 `Expiration.persistent()`로 치환하기 때문이다.

실제 Redis(Testcontainers)로 측정한 결과다.

| 호출 | 결과 |
| --- | --- |
| `set(key, value, 0L, TimeUnit.SECONDS)` | `RedisSystemException` — 저장 실패 |
| `set(key, value, Duration.ZERO)` | **저장 성공, ttl=-1 (만료 없음)** |
| `set(key, value, Duration.ofSeconds(-5))` | `RedisSystemException` — 저장 실패 |

즉 교체만 하면 TTL이 0일 때 실패 모드가 "시끄러운 예외"에서 "조용한 영구 토큰"으로 바뀐다. OAuth 인가 코드와 리프레시 토큰을 다루는 자리라 그대로 둘 수 없다고 판단했다.

지금 호출부는 상수 30초(`AuthTokenService.OAUTH_CODE_TTL_SECONDS`)와 `@Positive`로 검증되는 프로퍼티(`JwtProperties`)뿐이라 실제로 0이 들어오지는 않는다. 다만 리포지토리가 스스로 막지 않으면 새 호출부가 생겼을 때 조용히 깨진다. 그래서 `save()`에서 TTL이 양수가 아니면 예외로 막았다.

## 변경 목록

1. TTL을 넘기는 방식을 `long` + `TimeUnit` 두 인자에서 `Duration` 한 인자로 바꿨다. 같은 인터페이스의 `set(K,V,Duration)`·`expire(K,Duration)` 오버로드가 대체 API다. — `RedisOAuthCodeRepository`, `RedisRefreshTokenRepository`

2. `RedisRefreshTokenRepository.save()`는 `Duration`을 지역 변수로 한 번만 만들어 두 호출에 넘긴다. 토큰 키와 사용자 토큰 목록 키에 같은 만료 시간이 걸린다는 사실을 코드에서 바로 읽게 하려는 의도다. — `RedisRefreshTokenRepository:27`

3. 두 `save()`에 TTL 양수 가드를 넣었다. 위에서 설명한 대로, `Duration.ZERO`가 만료 없는 저장으로 새는 것을 막는다. 음수는 교체 전에도 Redis가 거부했으므로 이 가드로 동작이 바뀌지 않는다. — `RedisOAuthCodeRepository:22`, `RedisRefreshTokenRepository:25`

4. 두 리포지토리의 회귀 테스트를 새로 작성했다. deprecated API 교체 **전에** 먼저 작성해 기존 동작을 고정한 뒤 교체했다. — `RedisOAuthCodeRepositoryTest`, `RedisRefreshTokenRepositoryTest`

## 검증

deprecated API 교체 전후로 같은 테스트가 모두 통과한다. 커밋도 그 순서로 나눠 두었다.

- `ca2b631` `[test]` 회귀 테스트 10건 — 교체 **전** 코드에서 통과
- `efc0d1d` `[refactor]` Duration 교체 — 같은 10건 그대로 통과
- `551a7a8` `[fix]` TTL 0 가드 + 테스트 4건 추가 — 총 14건 통과

<details>
<summary>테스트 케이스 14개</summary>

**RedisOAuthCodeRepositoryTest** (7)

- 인가코드를 저장하면 TTL이 설정된다
- TTL이 0이면 저장하지 않고 예외를 던진다
- 기존 회원으로 저장한 인가코드는 신규가입 여부가 false로 돌아온다
- 저장한 인가코드를 조회하면 토큰 쌍과 신규가입 여부를 돌려준다
- 한번 조회한 인가코드는 삭제되어 다시 조회되지 않는다
- 존재하지 않는 인가코드를 조회하면 빈 값이다
- 구분자 형식이 깨진 값이 저장돼 있으면 빈 값이다

**RedisRefreshTokenRepositoryTest** (7)

- 토큰과 사용자 토큰 목록 양쪽에 TTL이 설정된다
- 만료시간이 0이면 저장하지 않고 예외를 던진다
- 저장한 토큰으로 사용자를 조회한다
- 존재하지 않는 토큰을 조회하면 빈 값이다
- 삭제한 토큰은 조회되지 않는다
- 사용자의 토큰을 모두 삭제하면 토큰과 목록이 함께 사라진다
- 저장된 토큰이 없는 사용자를 전체 삭제해도 예외가 나지 않는다

</details>

그 밖에 확인한 것:

- `./gradlew :user:test :user:pmdMain :user:pmdTest :user:spotlessCheck` 통과
- 백엔드 **전 모듈** `compileJava --rerun-tasks`에서 deprecation 경고 0건 (`-Xlint:deprecation`은 모든 서브프로젝트에 켜져 있다)

# 💬 리뷰 중점사항

**TTL 0 가드의 예외 타입.** `IllegalArgumentException`을 던지지만 `@Repository`의 예외 변환이 이를 `InvalidDataAccessApiUsageException`으로 감싼다. 교체 전 `RedisSystemException`도 같은 `DataAccessException` 계열이라 호출부가 보는 예외 계열은 그대로다. 도메인 예외(`CoffeeShoutException`)를 쓰지 않은 것은 이게 사용자에게 보여줄 오류가 아니라 호출부의 프로그래밍 오류라고 봤기 때문이다. 다른 의견이 있으면 알려주면 좋겠다.

**TTL 검증을 범위로 한 것.** `0 < ttl <= 설정값`으로 단언했다. Redis의 `getExpire()`는 저장 직후에도 설정값보다 작은 값을 돌려줄 수 있어 정확히 같은 값인지로 단언하면 간헐적으로 깨진다. 범위 단언이면 TTL이 아예 안 걸린 경우(`-1`)와 키가 없는 경우(`-2`)를 모두 잡는다.

# 🙅 이번에 하지 않은 것

`OAuthCodeRepository`·`RefreshTokenRepository` 포트의 파라미터 타입은 `long ttlSeconds` 그대로 뒀다. `Duration`으로 바꾸면 호출하는 서비스와 설정 바인딩까지 따라 움직여야 해서, deprecated 경고를 없앤다는 이번 범위를 벗어난다.
