### PR TITLE
[chore] pre-push 훅에 프론트 ESLint·백엔드 PMD 추가하고 훅 자동 활성화

### DIFF
--- a/.claude/skills/create-issue/worktree-setup.sh
+++ b/.claude/skills/create-issue/worktree-setup.sh
@@ -55,3 +55,13 @@ while IFS= read -r f; do
 done <<< "$env_files"
 
 [ "$linked" -gt 0 ] || echo "  (연결할 env 파일 없음)"
+
+# ── 2. frontend/node_modules 링크 ─────────────────────────────────────
+# gitignore 대상이라 워크트리에 딸려오지 않는다. 없으면 pre-push 훅의 ESLint 가
+# 조용히 건너뛰어(#1659) 로컬 검증이 프론트에서만 사라진다. 워크트리마다 npm install 을
+# 다시 도는 건 수 분이 들므로 주 저장소 것을 링크해 쓴다.
+# 의존성이 바뀐 브랜치라면 워크트리에서 npm install 을 돌려 링크를 실제 디렉터리로 바꾼다.
+if [ -d "$MAIN/frontend/node_modules" ] && [ ! -e "$WT/frontend/node_modules" ]; then
+  ln -sfn "$MAIN/frontend/node_modules" "$WT/frontend/node_modules"
+  echo "  link: frontend/node_modules"
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,12 +1,41 @@
 #!/bin/sh
-# push 전 backend Spotless 포맷 검사 — CI의 :spotlessJavaCheck가 깨지기 전에 로컬에서 잡는다.
-# 켜기: git config core.hooksPath .githooks   /   한 번 건너뛰기: git push --no-verify
+# push 전 로컬 lint 검증 — CI의 lint 단계가 깨지기 전에 잡는다 (#1659).
+#
+# 켜기: git config core.hooksPath .githooks
+#       (frontend `npm install` 또는 `./gradlew build` 가 자동으로 설정한다)
+# 한 번 건너뛰기: git push --no-verify
+#       — CI에서 같은 검사가 다시 도므로, 건너뛴 책임은 push한 사람에게 있다.
+#
+# 검사 범위는 CI와 같다(backend-ci.yml / frontend-ci.yml). 다르면 로컬에서 통과하고 CI가 깨진다.
 
 git fetch -q origin dev 2>/dev/null
-git diff --name-only origin/dev...HEAD | grep -q '^backend/.*\.java$' || exit 0
 
-echo "[pre-push] spotlessCheck…"
-backend/gradlew -p backend spotlessCheck -q && exit 0
+# 삭제된 파일은 제외한다(ACMR) — 없는 경로를 lint에 넘기면 그것만으로 실패한다.
+CHANGED=$(git diff --name-only --diff-filter=ACMR origin/dev...HEAD)
 
-echo "[pre-push] 포맷 위반 — 'backend/gradlew -p backend spotlessApply' 후 다시 커밋하세요."
-exit 1
+# 백엔드 — Spotless는 ratchetFrom("origin/dev")라 변경 파일만 본다. PMD 대상도 CI와 맞춘다.
+if printf '%s\n' "$CHANGED" | grep -q '^backend/.*\.java$'; then
+    echo "[pre-push] backend lint (spotless + pmd)…"
+    if ! backend/gradlew -p backend --console=plain spotlessCheck pmdMain pmdTest pmdTestFixtures; then
+        echo "[pre-push] backend lint 실패 — 포맷은 'backend/gradlew -p backend spotlessApply',"
+        echo "           PMD 지적은 위 리포트를 보고 직접 고치세요."
+        exit 1
+    fi
+fi
+
+# 프론트 — 변경된 파일만 ESLint. 경로에서 frontend/ 를 떼야 frontend/ 안에서 실행할 수 있다.
+FE=$(printf '%s\n' "$CHANGED" | sed -n 's|^frontend/\(.*\.[cm]\{0,1\}[jt]sx\{0,1\}\)$|\1|p')
+if [ -n "$FE" ]; then
+    if [ ! -d frontend/node_modules ]; then
+        echo "[pre-push] frontend/node_modules 없음 — eslint를 건너뛴다. 'npm install' 후 다시 push하세요."
+    else
+        echo "[pre-push] frontend eslint…"
+        # --no-warn-ignored: eslint.config.js 가 무시하는 파일을 명시로 넘길 때 나는 경고를 죽인다.
+        if ! printf '%s\n' "$FE" | tr '\n' '\0' | (cd frontend && xargs -0 npx eslint --no-warn-ignored); then
+            echo "[pre-push] eslint 실패 — 'cd frontend && npm run lint:fix' 후 다시 커밋하세요."
+            exit 1
+        fi
+    fi
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@
 - **외과적 변경**: 요청 범위 밖 코드·주석·포맷은 건드리지 않는다.
 - 20줄 이상 대량 출력이 예상되는 탐색·분석은 서브에이전트에 위임한다.
 
+## 로컬 lint 훅 (pre-push)
+
+`.githooks/pre-push`가 push 전에 **변경된 파일만** 검사한다 — backend는 Spotless+PMD, frontend는 ESLint. 검사 범위는 CI(`backend-ci.yml`·`frontend-ci.yml`)와 같게 맞춰 둔다.
+
+훅은 `core.hooksPath=.githooks`로 켜지며, `npm install`(frontend `prepare`)이나 `./gradlew build`(`installGitHooks`)가 자동으로 설정한다. 수동으로 켜려면 `git config core.hooksPath .githooks`.
+
+급할 때는 `git push --no-verify`로 건너뛸 수 있다. **건너뛴 책임은 push한 사람에게 있다** — 같은 검사가 CI에서 다시 돌아 실패하며, 그때는 포맷 전용 커밋이 PR에 남는다.
+
 ## git push 안전
 
 보호 브랜치(`dev`·`prod`·`main`·`master`)에는 **직접 push·commit하지 않는다.** 작업 브랜치 upstream을 보호 브랜치로 두지 않고(`git branch --unset-upstream`), push는 명시 refspec(`git push -u origin HEAD:{type}/{N}-{slug}`)으로 한다. 전문은 [.claude/rules/git-push-safety.md](.claude/rules/git-push-safety.md).

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -12,6 +12,15 @@ version = "0.0.1-SNAPSHOT"
 val springBootVersion: String = libs.versions.spring.boot.get()
 val pmdVersion: String = libs.versions.pmd.get()
 
+// pre-push 훅 자동 활성화 — 클론 후 별도 지식 없이 켜지게 한다 (#1659).
+// 프론트만 만지는 사람은 frontend/package.json 의 prepare 스크립트가 같은 일을 한다.
+tasks.register<Exec>("installGitHooks") {
+    group = "build setup"
+    description = "core.hooksPath 를 .githooks 로 설정해 pre-push 훅을 켠다."
+    commandLine("git", "config", "core.hooksPath", ".githooks")
+    isIgnoreExitValue = true // git 이 없거나 저장소가 아니어도 빌드를 막지 않는다
+}
+
 tasks.register<Exec>("pruneStaleTestContainers") {
     group = "verification"
     description = "종료된 Testcontainers 컨테이너를 제거한다. reuse 캐시 초기화 시 사용."
@@ -113,6 +122,10 @@ subprojects {
                 fileTree(dir) { exclude("**/event/*Event.class") }
             }
         )
+    }
+
+    tasks.named("build") {
+        dependsOn(rootProject.tasks.named("installGitHooks"))
     }
 
     tasks.withType<Test> {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "dev": "webpack serve --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "build:dev": "webpack --config webpack.dev.js",


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1659

# 🚀 작업 내용

정적 분석이 CI에서만 돌아 push 후에야 깨진 걸 알게 되는 문제(#1659)를 pre-push 훅으로 막는다.
이미 있던 `.githooks/pre-push`(백엔드 Spotless 전용)를 CI lint 범위와 같게 넓히고, 훅이 실제로 켜지도록 자동 활성화를 붙였다.

1. **`.githooks/pre-push` — 검사 범위를 CI와 일치시켰다**
   - 백엔드: `spotlessCheck` → `spotlessCheck pmdMain pmdTest pmdTestFixtures` (backend-ci.yml과 동일)
   - 프론트: 변경된 `.ts/.tsx/.js/.mjs`만 ESLint (frontend-ci.yml의 `npm run lint`와 같은 룰셋). `type-check`는 CI에 없어 넣지 않았다
   - 변경 경로에 해당 영역이 없으면 그 도구를 아예 띄우지 않는다 — 문서만 고친 커밋은 **0.55초**에 끝난다
   - 삭제된 파일은 `--diff-filter=ACMR`로 제외한다. 없는 경로를 lint에 넘기면 그것만으로 실패한다

2. **훅 자동 활성화 — 클론 후 별도 지식 없이 켜진다**
   - `frontend/package.json`에 `prepare` 스크립트 → `npm install` 시 `core.hooksPath` 설정
   - `backend/build.gradle.kts`에 `installGitHooks` 태스크 → `./gradlew build`가 의존
   - 프론트·백엔드 개발자가 각각 반드시 한 번은 돌리는 명령에 붙였다

3. **`worktree-setup.sh`에 `frontend/node_modules` 링크 추가**
   - 이 저장소는 작업마다 워크트리를 새로 판다(issue-workflow 2단계). `node_modules`는 gitignore 대상이라 워크트리에 딸려오지 않아, **이걸 안 하면 프론트 ESLint가 항상 조용히 건너뛰어진다**
   - `.env`와 같은 방식(주 저장소 심볼릭 링크). 의존성이 다른 브랜치라면 워크트리에서 `npm install`을 돌려 실제 디렉터리로 바꾸면 된다

4. **`CLAUDE.md`에 훅 사용법·우회 책임 명시** — 활성화 방법, `--no-verify`로 건너뛸 때의 책임

## 🧪 실제로 돌려서 확인한 것

| 상황 | 결과 |
| --- | --- |
| 문서·설정만 변경 | exit 0, **0.55초** (JVM·eslint 미기동) |
| 프론트 ESLint 위반 (`no-unused-vars`·`prettier/prettier`·`no-empty`) | exit 1, 위반 리포트 + `npm run lint:fix` 안내 |
| 백엔드 Spotless 위반 | exit 1, diff 리포트 + `spotlessApply` 안내 — **실제로 제 실수를 잡았다** (빈 생성자 스타일) |
| 백엔드 정상 코드 | exit 0. 캐시 미스 17초 / 워밍업 후 **1.0초** |

# 💬 리뷰 중점사항

**1. 이슈 성공 기준과 어긋난 항목 — "커밋 전"이 아니라 "push 전"이다**

이슈 성공 기준은 `커밋 전에 … 자동으로 검출된다`인데, 구현은 **pre-push**다. 의도한 이탈이고 근거는 이렇다.

- 막으려는 건 "CI가 깨지는 것"이다. push를 막으면 CI가 애초에 돌지 않으므로 목적은 그대로 달성된다
- 커밋마다 JVM(gradle)을 띄우면 훅이 느려 사람들이 꺼버린다 — 훅이 꺼지면 0을 얻는다
- 이미 있는 `.githooks/pre-push`를 늘리는 게 pre-commit을 새로 만드는 것보다 짧다

pre-commit이 꼭 필요하다고 보시면 말씀해 주세요. 되돌리기 어려운 결정은 아닙니다.

**2. 보류한 것 — B안(`.claude/settings.json` Claude Code hook)**

이슈 TODO의 `.claude/settings.json`에 Claude용 hook 추가는 **넣지 않았다.** 성공 기준에 없고, PreToolUse 훅이 stdin JSON을 파싱해야 해서 `jq` 의존이나 깨지기 쉬운 grep이 팀 공용 설정에 들어간다(이 PR 본문처럼 `--no-verify`를 언급하는 명령까지 오탐으로 막힌다). A안(git 훅)이 Claude의 push에도 그대로 적용되므로 실효 손실이 없다고 봤다. 필요하면 별도 이슈로 빼는 게 낫다.

**3. `node_modules` 심볼릭 링크가 과한지**

`worktree-setup.sh` 변경은 원래 #1660 소관이라 범위를 넘는 면이 있다. 다만 이걸 안 하면 이 PR의 프론트 절반이 워크트리에서 동작하지 않아 같이 넣었다. 분리하는 게 낫다면 빼겠다.

**4. `git config core.hooksPath`를 무조건 덮어쓴다**

`installGitHooks`·`prepare` 둘 다 기존 설정을 확인하지 않고 덮어쓴다. 이 저장소에 husky 등 다른 훅 체계가 없어 그렇게 뒀는데, 개인이 `.git/hooks`에 따로 둔 훅이 있으면 비활성화된다. 조건부로 바꿀지 의견 주세요.
