### PR TITLE
[fix] 미니게임 WS 입력 3종을 Principal 기반으로 전환 — 본문 playerName 신뢰 제거

### DIFF
--- a/backend/app/src/test/resources/__fixtures__/ws-catalog.json
+++ b/backend/app/src/test/resources/__fixtures__/ws-catalog.json
@@ -327,13 +327,13 @@
   "sends" : [ {
     "destination" : "/app/room/{joinCode}/blind-timer/stop",
     "description" : "블라인드 타이머 게임 STOP 버튼",
-    "requestType" : "StopCommand",
+    "requestType" : null,
     "triggersTopics" : [ "/topic/room/{joinCode}/blind-timer/progress" ],
     "source" : {
       "className" : "BlindTimerGameWebSocketController",
       "methodName" : "stop"
     },
-    "referencedSchemas" : [ "StopCommand" ]
+    "referencedSchemas" : [ ]
   }, {
     "destination" : "/app/room/{joinCode}/block-stacking/fail",
     "description" : "블록 쌓기 실패 이벤트 — 상태 변경 브로드캐스트",
@@ -898,20 +898,9 @@
       } ],
       "values" : null
     },
-    "StopCommand" : {
-      "kind" : "record",
-      "fields" : [ {
-        "name" : "playerName",
-        "type" : "String"
-      } ],
-      "values" : null
-    },
     "TapCommand" : {
       "kind" : "record",
       "fields" : [ {
-        "name" : "playerName",
-        "type" : "String"
-      }, {
         "name" : "tapCount",
         "type" : "int"
       } ],
@@ -920,9 +909,6 @@
     "TouchCommand" : {
       "kind" : "record",
       "fields" : [ {
-        "name" : "playerName",
-        "type" : "String"
-      }, {
         "name" : "touchedNumber",
         "type" : "int"
       } ],

--- a/backend/game/src/main/java/coffeeshout/blindtimer/ui/BlindTimerGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/blindtimer/ui/BlindTimerGameWebSocketController.java
@@ -20,10 +20,6 @@ public class BlindTimerGameWebSocketController {
 
     private final StreamPublisher streamPublisher;
 
-    /**
-     * STOP 주인은 STOMP principal 에서 도출한다 — 본문으로 받으면 남의 이름을 실어 그 사람 타이머를
-     * 대신 멈출 수 있다. playerName 을 빼고 나면 본문에 남는 게 없어 request DTO 자체를 두지 않는다.
-     */
     @MessageMapping("/room/{joinCode}/blind-timer/stop")
     @WsReceive(respondsOnTopics = "/room/{joinCode}/blind-timer/progress", description = "블라인드 타이머 게임 STOP 버튼")
     public void stop(@DestinationVariable String joinCode, Principal principal) {

--- a/backend/game/src/main/java/coffeeshout/blindtimer/ui/BlindTimerGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/blindtimer/ui/BlindTimerGameWebSocketController.java
@@ -25,15 +25,13 @@ public class BlindTimerGameWebSocketController {
      * 대신 멈출 수 있다. playerName 을 빼고 나면 본문에 남는 게 없어 request DTO 자체를 두지 않는다.
      */
     @MessageMapping("/room/{joinCode}/blind-timer/stop")
-    @WsReceive(
-            respondsOnTopics = "/room/{joinCode}/blind-timer/progress",
-            description = "블라인드 타이머 게임 STOP 버튼"
-    )
+    @WsReceive(respondsOnTopics = "/room/{joinCode}/blind-timer/progress", description = "블라인드 타이머 게임 STOP 버튼")
     public void stop(@DestinationVariable String joinCode, Principal principal) {
-        final String authenticatedPlayerName = PlayerKey.parse(principal.getName()).playerName();
+        final String authenticatedPlayerName =
+                PlayerKey.parse(principal.getName()).playerName();
         final BaseEvent event = StopCommandEvent.create(joinCode, authenticatedPlayerName);
         streamPublisher.publish(BlindTimerStreamKey.EVENTS, event);
-        log.debug("STOP 이벤트 발행: joinCode={}, player={}, eventId={}",
-                joinCode, authenticatedPlayerName, event.eventId());
+        log.debug(
+                "STOP 이벤트 발행: joinCode={}, player={}, eventId={}", joinCode, authenticatedPlayerName, event.eventId());
     }
 }

--- a/backend/game/src/main/java/coffeeshout/blindtimer/ui/BlindTimerGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/blindtimer/ui/BlindTimerGameWebSocketController.java
@@ -1,17 +1,16 @@
 package coffeeshout.blindtimer.ui;
 
 import coffeeshout.blindtimer.domain.event.StopCommandEvent;
-import coffeeshout.blindtimer.ui.request.StopCommand;
-import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.blindtimer.infra.BlindTimerStreamKey;
+import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.websocket.PlayerKey;
 import coffeeshout.websocket.docs.WsReceive;
-import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
 @Slf4j
@@ -21,15 +20,20 @@ public class BlindTimerGameWebSocketController {
 
     private final StreamPublisher streamPublisher;
 
+    /**
+     * STOP 주인은 STOMP principal 에서 도출한다 — 본문으로 받으면 남의 이름을 실어 그 사람 타이머를
+     * 대신 멈출 수 있다. playerName 을 빼고 나면 본문에 남는 게 없어 request DTO 자체를 두지 않는다.
+     */
     @MessageMapping("/room/{joinCode}/blind-timer/stop")
     @WsReceive(
             respondsOnTopics = "/room/{joinCode}/blind-timer/progress",
             description = "블라인드 타이머 게임 STOP 버튼"
     )
-    public void stop(@DestinationVariable String joinCode, @Payload @Valid StopCommand command) {
-        final BaseEvent event = StopCommandEvent.create(joinCode, command.playerName());
+    public void stop(@DestinationVariable String joinCode, Principal principal) {
+        final String authenticatedPlayerName = PlayerKey.parse(principal.getName()).playerName();
+        final BaseEvent event = StopCommandEvent.create(joinCode, authenticatedPlayerName);
         streamPublisher.publish(BlindTimerStreamKey.EVENTS, event);
         log.debug("STOP 이벤트 발행: joinCode={}, player={}, eventId={}",
-                joinCode, command.playerName(), event.eventId());
+                joinCode, authenticatedPlayerName, event.eventId());
     }
 }

--- a/backend/game/src/main/java/coffeeshout/blindtimer/ui/request/StopCommand.java
+++ b/backend/game/src/main/java/coffeeshout/blindtimer/ui/request/StopCommand.java
@@ -1,8 +1,0 @@
-package coffeeshout.blindtimer.ui.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record StopCommand(
-        @NotBlank(message = "플레이어 이름은 필수입니다") String playerName
-) {
-}

--- a/backend/game/src/main/java/coffeeshout/racinggame/ui/RacingGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/ui/RacingGameWebSocketController.java
@@ -1,9 +1,11 @@
 package coffeeshout.racinggame.ui;
 
-import coffeeshout.websocket.docs.WsReceive;
 import coffeeshout.racinggame.infra.messaging.RacingGameCommandPublisher;
 import coffeeshout.racinggame.ui.request.TapCommand;
+import coffeeshout.websocket.PlayerKey;
+import coffeeshout.websocket.docs.WsReceive;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -18,12 +20,21 @@ public class RacingGameWebSocketController {
 
     private final RacingGameCommandPublisher racingGameCommandPublisher;
 
+    /**
+     * 탭 주인은 STOMP principal 에서 도출한다 — 본문으로 받으면 남의 이름을 실어 그 사람 러너를 대신
+     * 달리게 할 수 있다. 항상 principal 과 같아야 하는 값이라 대조하지 않고 아예 본문에서 뺐다.
+     */
     @MessageMapping("/room/{joinCode}/racing-game/tap")
     @WsReceive(
             respondsOnTopics = {"/room/{joinCode}/racing-game/state"},
             description = "레이싱 게임 탭"
     )
-    public void tap(@DestinationVariable String joinCode, @Payload @Valid TapCommand command) {
-        racingGameCommandPublisher.tap(joinCode, command.playerName(), command.tapCount());
+    public void tap(
+            @DestinationVariable String joinCode,
+            @Payload @Valid TapCommand command,
+            Principal principal
+    ) {
+        final String authenticatedPlayerName = PlayerKey.parse(principal.getName()).playerName();
+        racingGameCommandPublisher.tap(joinCode, authenticatedPlayerName, command.tapCount());
     }
 }

--- a/backend/game/src/main/java/coffeeshout/racinggame/ui/RacingGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/ui/RacingGameWebSocketController.java
@@ -27,14 +27,10 @@ public class RacingGameWebSocketController {
     @MessageMapping("/room/{joinCode}/racing-game/tap")
     @WsReceive(
             respondsOnTopics = {"/room/{joinCode}/racing-game/state"},
-            description = "레이싱 게임 탭"
-    )
-    public void tap(
-            @DestinationVariable String joinCode,
-            @Payload @Valid TapCommand command,
-            Principal principal
-    ) {
-        final String authenticatedPlayerName = PlayerKey.parse(principal.getName()).playerName();
+            description = "레이싱 게임 탭")
+    public void tap(@DestinationVariable String joinCode, @Payload @Valid TapCommand command, Principal principal) {
+        final String authenticatedPlayerName =
+                PlayerKey.parse(principal.getName()).playerName();
         racingGameCommandPublisher.tap(joinCode, authenticatedPlayerName, command.tapCount());
     }
 }

--- a/backend/game/src/main/java/coffeeshout/racinggame/ui/RacingGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/ui/RacingGameWebSocketController.java
@@ -7,23 +7,17 @@ import coffeeshout.websocket.docs.WsReceive;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
-@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class RacingGameWebSocketController {
 
     private final RacingGameCommandPublisher racingGameCommandPublisher;
 
-    /**
-     * 탭 주인은 STOMP principal 에서 도출한다 — 본문으로 받으면 남의 이름을 실어 그 사람 러너를 대신
-     * 달리게 할 수 있다. 항상 principal 과 같아야 하는 값이라 대조하지 않고 아예 본문에서 뺐다.
-     */
     @MessageMapping("/room/{joinCode}/racing-game/tap")
     @WsReceive(
             respondsOnTopics = {"/room/{joinCode}/racing-game/state"},

--- a/backend/game/src/main/java/coffeeshout/racinggame/ui/request/TapCommand.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/ui/request/TapCommand.java
@@ -3,5 +3,4 @@ package coffeeshout.racinggame.ui.request;
 /**
  * 탭 주인(playerName)은 본문에 없다 — STOMP principal 에서 도출한다(RacingGameWebSocketController).
  */
-public record TapCommand(int tapCount) {
-}
+public record TapCommand(int tapCount) {}

--- a/backend/game/src/main/java/coffeeshout/racinggame/ui/request/TapCommand.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/ui/request/TapCommand.java
@@ -1,6 +1,6 @@
 package coffeeshout.racinggame.ui.request;
 
-/**
- * 탭 주인(playerName)은 본문에 없다 — STOMP principal 에서 도출한다(RacingGameWebSocketController).
- */
-public record TapCommand(int tapCount) {}
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record TapCommand(
+        @PositiveOrZero(message = "탭 횟수는 0 이상이어야 합니다") int tapCount) {}

--- a/backend/game/src/main/java/coffeeshout/racinggame/ui/request/TapCommand.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/ui/request/TapCommand.java
@@ -1,9 +1,7 @@
 package coffeeshout.racinggame.ui.request;
 
-import jakarta.validation.constraints.NotBlank;
-
-public record TapCommand(
-        @NotBlank(message = "플레이어 이름은 필수입니다") String playerName,
-        int tapCount
-) {
+/**
+ * 탭 주인(playerName)은 본문에 없다 — STOMP principal 에서 도출한다(RacingGameWebSocketController).
+ */
+public record TapCommand(int tapCount) {
 }

--- a/backend/game/src/main/java/coffeeshout/speedtouch/ui/SpeedTouchGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/speedtouch/ui/SpeedTouchGameWebSocketController.java
@@ -30,19 +30,18 @@ public class SpeedTouchGameWebSocketController {
     @MessageMapping("/room/{joinCode}/speed-touch/touch")
     @WsReceive(
             respondsOnTopics = "/room/{joinCode}/speed-touch/progress",
-            description = "스피드 터치 게임 터치 — 1 to 25 스피드 터치에서 숫자를 터치하는 웹소켓 요청"
-    )
-    public void touch(
-            @DestinationVariable String joinCode,
-            @Payload @Valid TouchCommand command,
-            Principal principal
-    ) {
-        final String authenticatedPlayerName = PlayerKey.parse(principal.getName()).playerName();
-        final BaseEvent event = TouchProgressCommandEvent.create(
-                joinCode, authenticatedPlayerName, command.touchedNumber()
-        );
+            description = "스피드 터치 게임 터치 — 1 to 25 스피드 터치에서 숫자를 터치하는 웹소켓 요청")
+    public void touch(@DestinationVariable String joinCode, @Payload @Valid TouchCommand command, Principal principal) {
+        final String authenticatedPlayerName =
+                PlayerKey.parse(principal.getName()).playerName();
+        final BaseEvent event =
+                TouchProgressCommandEvent.create(joinCode, authenticatedPlayerName, command.touchedNumber());
         streamPublisher.publish(SpeedTouchStreamKey.EVENTS, event);
-        log.debug("터치 이벤트 발행: joinCode={}, player={}, number={}, eventId={}",
-                joinCode, authenticatedPlayerName, command.touchedNumber(), event.eventId());
+        log.debug(
+                "터치 이벤트 발행: joinCode={}, player={}, number={}, eventId={}",
+                joinCode,
+                authenticatedPlayerName,
+                command.touchedNumber(),
+                event.eventId());
     }
 }

--- a/backend/game/src/main/java/coffeeshout/speedtouch/ui/SpeedTouchGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/speedtouch/ui/SpeedTouchGameWebSocketController.java
@@ -1,12 +1,14 @@
 package coffeeshout.speedtouch.ui;
 
 import coffeeshout.global.redis.BaseEvent;
-import coffeeshout.speedtouch.infra.SpeedTouchStreamKey;
 import coffeeshout.global.redis.stream.StreamPublisher;
-import coffeeshout.websocket.docs.WsReceive;
 import coffeeshout.speedtouch.domain.event.TouchProgressCommandEvent;
+import coffeeshout.speedtouch.infra.SpeedTouchStreamKey;
 import coffeeshout.speedtouch.ui.request.TouchCommand;
+import coffeeshout.websocket.PlayerKey;
+import coffeeshout.websocket.docs.WsReceive;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -21,17 +23,26 @@ public class SpeedTouchGameWebSocketController {
 
     private final StreamPublisher streamPublisher;
 
+    /**
+     * 터치 주인은 STOMP principal 에서 도출한다 — 본문으로 받으면 남의 이름을 실어 그 사람 진행도를
+     * 대신 올릴 수 있다. 항상 principal 과 같아야 하는 값이라 대조하지 않고 아예 본문에서 뺐다.
+     */
     @MessageMapping("/room/{joinCode}/speed-touch/touch")
     @WsReceive(
             respondsOnTopics = "/room/{joinCode}/speed-touch/progress",
             description = "스피드 터치 게임 터치 — 1 to 25 스피드 터치에서 숫자를 터치하는 웹소켓 요청"
     )
-    public void touch(@DestinationVariable String joinCode, @Payload @Valid TouchCommand command) {
+    public void touch(
+            @DestinationVariable String joinCode,
+            @Payload @Valid TouchCommand command,
+            Principal principal
+    ) {
+        final String authenticatedPlayerName = PlayerKey.parse(principal.getName()).playerName();
         final BaseEvent event = TouchProgressCommandEvent.create(
-                joinCode, command.playerName(), command.touchedNumber()
+                joinCode, authenticatedPlayerName, command.touchedNumber()
         );
         streamPublisher.publish(SpeedTouchStreamKey.EVENTS, event);
         log.debug("터치 이벤트 발행: joinCode={}, player={}, number={}, eventId={}",
-                joinCode, command.playerName(), command.touchedNumber(), event.eventId());
+                joinCode, authenticatedPlayerName, command.touchedNumber(), event.eventId());
     }
 }

--- a/backend/game/src/main/java/coffeeshout/speedtouch/ui/SpeedTouchGameWebSocketController.java
+++ b/backend/game/src/main/java/coffeeshout/speedtouch/ui/SpeedTouchGameWebSocketController.java
@@ -23,10 +23,6 @@ public class SpeedTouchGameWebSocketController {
 
     private final StreamPublisher streamPublisher;
 
-    /**
-     * 터치 주인은 STOMP principal 에서 도출한다 — 본문으로 받으면 남의 이름을 실어 그 사람 진행도를
-     * 대신 올릴 수 있다. 항상 principal 과 같아야 하는 값이라 대조하지 않고 아예 본문에서 뺐다.
-     */
     @MessageMapping("/room/{joinCode}/speed-touch/touch")
     @WsReceive(
             respondsOnTopics = "/room/{joinCode}/speed-touch/progress",

--- a/backend/game/src/main/java/coffeeshout/speedtouch/ui/request/TouchCommand.java
+++ b/backend/game/src/main/java/coffeeshout/speedtouch/ui/request/TouchCommand.java
@@ -7,8 +7,5 @@ import jakarta.validation.constraints.Min;
  * 터치 주인(playerName)은 본문에 없다 — STOMP principal 에서 도출한다(SpeedTouchGameWebSocketController).
  */
 public record TouchCommand(
-        @Min(value = 1, message = "터치 번호는 1 이상이어야 합니다")
-        @Max(value = 25, message = "터치 번호는 25 이하여야 합니다")
-        int touchedNumber
-) {
-}
+        @Min(value = 1, message = "터치 번호는 1 이상이어야 합니다") @Max(value = 25, message = "터치 번호는 25 이하여야 합니다")
+        int touchedNumber) {}

--- a/backend/game/src/main/java/coffeeshout/speedtouch/ui/request/TouchCommand.java
+++ b/backend/game/src/main/java/coffeeshout/speedtouch/ui/request/TouchCommand.java
@@ -3,9 +3,6 @@ package coffeeshout.speedtouch.ui.request;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
-/**
- * 터치 주인(playerName)은 본문에 없다 — STOMP principal 에서 도출한다(SpeedTouchGameWebSocketController).
- */
 public record TouchCommand(
         @Min(value = 1, message = "터치 번호는 1 이상이어야 합니다") @Max(value = 25, message = "터치 번호는 25 이하여야 합니다")
         int touchedNumber) {}

--- a/backend/game/src/main/java/coffeeshout/speedtouch/ui/request/TouchCommand.java
+++ b/backend/game/src/main/java/coffeeshout/speedtouch/ui/request/TouchCommand.java
@@ -2,10 +2,11 @@ package coffeeshout.speedtouch.ui.request;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 
+/**
+ * 터치 주인(playerName)은 본문에 없다 — STOMP principal 에서 도출한다(SpeedTouchGameWebSocketController).
+ */
 public record TouchCommand(
-        @NotBlank(message = "플레이어 이름은 필수입니다") String playerName,
         @Min(value = 1, message = "터치 번호는 1 이상이어야 합니다")
         @Max(value = 25, message = "터치 번호는 25 이하여야 합니다")
         int touchedNumber

--- a/backend/game/src/test/java/coffeeshout/blindtimer/ui/BlindTimerGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/blindtimer/ui/BlindTimerGameIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.awaitility.Awaitility.await;
 import coffeeshout.GameModuleWebSocketTest;
 import coffeeshout.blindtimer.application.BlindTimerGameService;
 import coffeeshout.blindtimer.domain.BlindTimerGame;
-import coffeeshout.blindtimer.ui.request.StopCommand;
 import coffeeshout.blindtimer.ui.response.BlindTimerProgressResponse;
 import coffeeshout.blindtimer.ui.response.BlindTimerStateResponse;
 import coffeeshout.fixture.GamerFixture;
@@ -58,7 +57,7 @@ class BlindTimerGameIntegrationTest extends GameModuleWebSocketTest {
      * 단일 플로우에서 상태 전환·진행도 브로드캐스트·DONE 전환을 함께 검증한다.
      */
     @Test
-    void 게임_시작부터_전원_STOP까지_상태와_진행도가_순서대로_브로드캐스트된다() {
+    void 게임_시작부터_전원_STOP까지_상태와_진행도가_순서대로_브로드캐스트된다() throws Exception {
         // given
         final String joinCodeValue = joinCode.getValue();
         final String subscribeStateUrl = String.format("/topic/room/%s/blind-timer/state", joinCodeValue);
@@ -77,14 +76,14 @@ class BlindTimerGameIntegrationTest extends GameModuleWebSocketTest {
         progressResponses.get(6, TimeUnit.SECONDS); // PREPARE 시 초기 progress
         BlindTimerStateResponse playingState = payloadAs(stateResponses.get(10, TimeUnit.SECONDS), BlindTimerStateResponse.class);
 
-        // host STOP → 진행도 브로드캐스트
-        session.send(stopUrl, new StopCommand(host.getName()));
+        // host STOP → 진행도 브로드캐스트. STOP 주인은 본문이 아니라 세션 principal로 정해진다(#1702).
+        session.send(stopUrl);
         BlindTimerProgressResponse progressUpdate = payloadAs(progressResponses.get(3, TimeUnit.SECONDS), BlindTimerProgressResponse.class);
 
         // 전원 STOP (host 포함, 재STOP은 멱등) → DONE
         for (Gamer gamer : gamers) {
             final String playerName = gamer.getName();
-            session.send(stopUrl, new StopCommand(playerName));
+            createSession(joinCodeValue, playerName).send(stopUrl);
 
             await().atMost(Duration.ofSeconds(5))
                     .pollInterval(Duration.ofMillis(50))

--- a/backend/game/src/test/java/coffeeshout/blindtimer/ui/BlindTimerGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/blindtimer/ui/BlindTimerGameIntegrationTest.java
@@ -71,14 +71,18 @@ class BlindTimerGameIntegrationTest extends GameModuleWebSocketTest {
         startBlindTimerGame();
 
         // 상태 전환: DESCRIPTION(targetTimeMillis) → PREPARE → PLAYING
-        BlindTimerStateResponse descriptionState = payloadAs(stateResponses.get(2, TimeUnit.SECONDS), BlindTimerStateResponse.class);
-        BlindTimerStateResponse prepareState = payloadAs(stateResponses.get(6, TimeUnit.SECONDS), BlindTimerStateResponse.class);
+        BlindTimerStateResponse descriptionState =
+                payloadAs(stateResponses.get(2, TimeUnit.SECONDS), BlindTimerStateResponse.class);
+        BlindTimerStateResponse prepareState =
+                payloadAs(stateResponses.get(6, TimeUnit.SECONDS), BlindTimerStateResponse.class);
         progressResponses.get(6, TimeUnit.SECONDS); // PREPARE 시 초기 progress
-        BlindTimerStateResponse playingState = payloadAs(stateResponses.get(10, TimeUnit.SECONDS), BlindTimerStateResponse.class);
+        BlindTimerStateResponse playingState =
+                payloadAs(stateResponses.get(10, TimeUnit.SECONDS), BlindTimerStateResponse.class);
 
         // host STOP → 진행도 브로드캐스트. STOP 주인은 본문이 아니라 세션 principal로 정해진다(#1702).
         session.send(stopUrl);
-        BlindTimerProgressResponse progressUpdate = payloadAs(progressResponses.get(3, TimeUnit.SECONDS), BlindTimerProgressResponse.class);
+        BlindTimerProgressResponse progressUpdate =
+                payloadAs(progressResponses.get(3, TimeUnit.SECONDS), BlindTimerProgressResponse.class);
 
         // 전원 STOP (host 포함, 재STOP은 멱등) → DONE
         for (Gamer gamer : gamers) {
@@ -88,10 +92,10 @@ class BlindTimerGameIntegrationTest extends GameModuleWebSocketTest {
             await().atMost(Duration.ofSeconds(5))
                     .pollInterval(Duration.ofMillis(50))
                     .untilAsserted(() ->
-                            assertThat(game.findPlayer(playerName).isStopped()).isTrue()
-                    );
+                            assertThat(game.findPlayer(playerName).isStopped()).isTrue());
         }
-        BlindTimerStateResponse doneState = payloadAs(stateResponses.get(10, TimeUnit.SECONDS), BlindTimerStateResponse.class);
+        BlindTimerStateResponse doneState =
+                payloadAs(stateResponses.get(10, TimeUnit.SECONDS), BlindTimerStateResponse.class);
 
         // then
         SoftAssertions.assertSoftly(softly -> {

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -166,8 +166,9 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
          어느 라운드가 살아남는지가 부하에 따라 갈리고, 마지막 생존 탭의 경과시간이 길면 그 러너만 MIN_SPEED로
          남아 완주하지 못한다. DONE은 전원 정지가 조건이라 한 명만 뒤처져도 영영 오지 않는다.
         */
+        // 탭 주인은 본문이 아니라 세션 principal로 정해지므로(#1702) 게이머마다 자기 세션으로 보낸다.
         for (Gamer gamer : gamers) {
-            singleSession.send(tapRequestUrl, new TapCommand(gamer.getName(), 200));
+            createSession(joinCodeValue, gamer.getName()).send(tapRequestUrl, new TapCommand(200));
         }
 
         // then - DONE 상태 확인. 70틱 × move-interval(50ms) + race-finished-delay 만큼 걸리므로 상한을 넉넉히 둔다.

--- a/backend/game/src/test/java/coffeeshout/speedtouch/ui/SpeedTouchGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/speedtouch/ui/SpeedTouchGameIntegrationTest.java
@@ -91,8 +91,8 @@ class SpeedTouchGameIntegrationTest extends GameModuleWebSocketTest {
         progressResponses.get(6, TimeUnit.SECONDS); // PREPARE 시 초기 progress
         stateResponses.get(4, TimeUnit.SECONDS); // PLAYING
 
-        // when - 터치
-        session.send(touchUrl, new TouchCommand(host.getName(), 1));
+        // when - 터치. 터치 주인은 본문이 아니라 세션 principal로 정해진다(#1702) — host 세션이므로 host의 터치다.
+        session.send(touchUrl, new TouchCommand(1));
 
         // then - 진행도 응답 (blocking get으로 메시지 도착까지 대기)
         MessageResponse progressUpdate = progressResponses.get(3, TimeUnit.SECONDS);
@@ -100,7 +100,7 @@ class SpeedTouchGameIntegrationTest extends GameModuleWebSocketTest {
     }
 
     @Test
-    void 전원_완주하면_DONE_상태가_전송된다() {
+    void 전원_완주하면_DONE_상태가_전송된다() throws Exception {
         // given
         final String joinCodeValue = joinCode.getValue();
         final String subscribeStateUrl = String.format("/topic/room/%s/speed-touch/state", joinCodeValue);
@@ -127,9 +127,11 @@ class SpeedTouchGameIntegrationTest extends GameModuleWebSocketTest {
         // 각 플레이어별로 1~25를 순차 전송하되, 이전 터치 처리 완료를 Awaitility로 확인
         for (Gamer gamer : gamers) {
             final String playerName = gamer.getName();
+            // 터치 주인은 세션 principal에서 도출되므로(#1702) 플레이어마다 자기 세션으로 보낸다.
+            final TestStompSession playerSession = createSession(joinCodeValue, playerName);
             for (int i = 1; i <= 25; i++) {
                 final int expectedNext = i + 1;
-                session.send(touchUrl, new TouchCommand(playerName, i));
+                playerSession.send(touchUrl, new TouchCommand(i));
 
                 // 게임 도메인 객체의 currentNumber가 갱신될 때까지 대기
                 await().atMost(Duration.ofSeconds(5))

--- a/backend/game/src/test/java/coffeeshout/speedtouch/ui/SpeedTouchGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/speedtouch/ui/SpeedTouchGameIntegrationTest.java
@@ -61,15 +61,18 @@ class SpeedTouchGameIntegrationTest extends GameModuleWebSocketTest {
 
         // then - DESCRIPTION 상태
         MessageResponse descriptionState = stateResponses.get(2, TimeUnit.SECONDS);
-        assertThat(payloadAs(descriptionState, SpeedTouchStateResponse.class).state()).isEqualTo("DESCRIPTION");
+        assertThat(payloadAs(descriptionState, SpeedTouchStateResponse.class).state())
+                .isEqualTo("DESCRIPTION");
 
         // PREPARE 상태
         MessageResponse prepareState = stateResponses.get(6, TimeUnit.SECONDS);
-        assertThat(payloadAs(prepareState, SpeedTouchStateResponse.class).state()).isEqualTo("PREPARE");
+        assertThat(payloadAs(prepareState, SpeedTouchStateResponse.class).state())
+                .isEqualTo("PREPARE");
 
         // PLAYING 상태
         MessageResponse playingState = stateResponses.get(4, TimeUnit.SECONDS);
-        assertThat(payloadAs(playingState, SpeedTouchStateResponse.class).state()).isEqualTo("PLAYING");
+        assertThat(payloadAs(playingState, SpeedTouchStateResponse.class).state())
+                .isEqualTo("PLAYING");
     }
 
     @Test
@@ -96,7 +99,8 @@ class SpeedTouchGameIntegrationTest extends GameModuleWebSocketTest {
 
         // then - 진행도 응답 (blocking get으로 메시지 도착까지 대기)
         MessageResponse progressUpdate = progressResponses.get(3, TimeUnit.SECONDS);
-        assertThat(payloadAs(progressUpdate, SpeedTouchProgressResponse.class).players()).isNotEmpty();
+        assertThat(payloadAs(progressUpdate, SpeedTouchProgressResponse.class).players())
+                .isNotEmpty();
     }
 
     @Test
@@ -136,10 +140,9 @@ class SpeedTouchGameIntegrationTest extends GameModuleWebSocketTest {
                 // 게임 도메인 객체의 currentNumber가 갱신될 때까지 대기
                 await().atMost(Duration.ofSeconds(5))
                         .pollInterval(Duration.ofMillis(50))
-                        .untilAsserted(() ->
-                                assertThat(game.findPlayer(playerName).getCurrentNumber())
-                                        .isGreaterThanOrEqualTo(expectedNext)
-                        );
+                        .untilAsserted(
+                                () -> assertThat(game.findPlayer(playerName).getCurrentNumber())
+                                        .isGreaterThanOrEqualTo(expectedNext));
             }
         }
 

--- a/frontend/src/features/miniGame/blindTimerGame/hooks/useBlindTimerActions.ts
+++ b/frontend/src/features/miniGame/blindTimerGame/hooks/useBlindTimerActions.ts
@@ -4,13 +4,12 @@ import { useCallback } from 'react';
 
 export const useBlindTimerActions = () => {
   const { send } = useWebSocket();
-  const { joinCode, myName } = useIdentifier();
+  const { joinCode } = useIdentifier();
 
+  // playerName은 보내지 않는다 — 서버가 STOMP principal에서 도출한다.
   const sendStop = useCallback(() => {
-    send(`/room/${joinCode}/blind-timer/stop`, {
-      playerName: myName,
-    });
-  }, [send, joinCode, myName]);
+    send(`/room/${joinCode}/blind-timer/stop`);
+  }, [send, joinCode]);
 
   return { sendStop };
 };

--- a/frontend/src/features/miniGame/racingGame/components/RacingGameOverlay/RacingGameOverlay.tsx
+++ b/frontend/src/features/miniGame/racingGame/components/RacingGameOverlay/RacingGameOverlay.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const RacingGameOverlay = ({ children, isGoal }: Props) => {
-  const { joinCode, myName } = useIdentifier();
+  const { joinCode } = useIdentifier();
   const { send } = useWebSocket();
   const { racingGameState } = useRacingGame();
 
@@ -28,8 +28,8 @@ const RacingGameOverlay = ({ children, isGoal }: Props) => {
       const currentTapCount = tapCountRef.current;
       tapCountRef.current = 0;
 
+      // playerName은 보내지 않는다 — 서버가 STOMP principal에서 도출한다.
       send(`/room/${joinCode}/racing-game/tap`, {
-        playerName: myName,
         tapCount: currentTapCount,
       });
     }, 200);
@@ -38,7 +38,7 @@ const RacingGameOverlay = ({ children, isGoal }: Props) => {
         window.clearInterval(intervalRef.current);
       }
     };
-  }, [joinCode, myName, send, racingGameState, isGoal]);
+  }, [joinCode, send, racingGameState, isGoal]);
 
   return (
     <S.Overlay data-testid="racing-game-overlay" onPointerDown={handlePointerDown}>

--- a/frontend/src/features/miniGame/speedTouchGame/hooks/useSpeedTouchActions.ts
+++ b/frontend/src/features/miniGame/speedTouchGame/hooks/useSpeedTouchActions.ts
@@ -4,16 +4,16 @@ import { useCallback } from 'react';
 
 export const useSpeedTouchActions = () => {
   const { send } = useWebSocket();
-  const { joinCode, myName } = useIdentifier();
+  const { joinCode } = useIdentifier();
 
+  // playerName은 보내지 않는다 — 서버가 STOMP principal에서 도출한다.
   const sendTouch = useCallback(
     (touchedNumber: number) => {
       send(`/room/${joinCode}/speed-touch/touch`, {
-        playerName: myName,
         touchedNumber,
       });
     },
-    [send, joinCode, myName]
+    [send, joinCode]
   );
 
   return { sendTouch };


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1702

# 🚀 작업 내용

## 무엇이 달라지는가

레이싱·스피드터치·블라인드타이머에서 **다른 참가자의 입력을 대신 보낼 수 없게 된다.** 서버는 이제 누가 보냈는지를 WebSocket 연결 자체에서 확인하고, 요청 본문에 적힌 이름은 아예 읽지 않는다.

## 왜 바꿨는가

세 게임의 입력 처리기가 요청 본문의 `playerName`을 그대로 믿고 있었다. 같은 방에 들어온 사람이라면 남의 이름을 본문에 실어 보낼 수 있다. 그러면 서버는 그 사람이 탭·터치·STOP을 한 것으로 처리한다.

이 저장소의 미니게임 결과는 술값 낼 사람을 정하는 룰렛 확률로 이어진다. 남의 입력을 대신 보낼 수 있다는 건 결과 조작이 가능하다는 뜻이다.

안전한 방식은 이미 저장소 안에 있다. 블록쌓기·눈치게임·사다리는 STOMP 연결에 붙어 있는 `Principal`(연결할 때 발급한 방 토큰으로 서버가 세운 신원)에서 이름을 꺼내 쓴다. 이번 변경은 그 방식을 남은 세 게임으로 옮긴 것이다.

## 흐름 그림

```mermaid
sequenceDiagram
    participant C as 클라이언트
    participant WS as WS 컨트롤러
    participant P as 처리 파이프라인

    Note over C,WS: 이전 — 본문의 이름을 그대로 사용
    C->>WS: tap { playerName: "남의이름", tapCount }
    WS->>P: 남의이름의 탭으로 처리

    Note over C,WS: 이후 — 연결 신원에서 이름을 도출
    C->>WS: tap { tapCount }
    WS->>WS: Principal → playerName
    WS->>P: 보낸 사람 본인의 탭으로 처리
```

## 변경 목록

1. 세 컨트롤러가 `Principal`에서 플레이어 이름을 도출하도록 바꿨다. 보낸 사람을 서버가 직접 확인하지 않으면 어떤 검증을 붙여도 신뢰할 수 없기 때문이다. `RacingGameWebSocketController`·`SpeedTouchGameWebSocketController`·`BlindTimerGameWebSocketController`
2. 요청 본문에서 `playerName` 필드를 지웠다. 대조 검증을 붙이는 대신 아예 없앴다 — 항상 `Principal`과 같아야만 하는 값이라 남겨둘 이유가 없다. #1699 의 `SteerCommand`와 같은 판단이다. `TapCommand`·`TouchCommand`
3. 블라인드타이머의 요청 DTO는 파일째 삭제했다. `playerName`을 빼면 본문에 남는 필드가 없다. 본문 없는 커맨드는 눈치게임이 이미 DTO 없이 처리하고 있어 그 형태를 따랐다. `StopCommand`
4. 프론트 전송부 세 곳에서 `playerName`을 뺐다. 서버가 읽지 않는 값을 계속 보내면 다음 사람이 그 값이 쓰인다고 오해한다. `useBlindTimerActions`·`useSpeedTouchActions`·`RacingGameOverlay`
5. WS 카탈로그 fixture를 바뀐 페이로드에 맞췄다. `ws-catalog.json`

## 검증

- 세 게임 통합 테스트를 실제로 돌려 통과를 확인했다 — 레이싱 2건, 스피드터치 3건, 블라인드타이머 1건, 실패 0건.
- 프론트는 `npm run type-check`·`npm run lint:fix` 통과.
- api-mcp 의 `contract.test.ts` 통과 — 수정한 fixture 가 zod 스키마와 맞는다.

# 💬 리뷰 중점사항

**별도 회귀 테스트를 추가하지 않았다.** 대신 기존 통합 테스트를 고쳐, 플레이어마다 자기 세션으로 입력을 보내도록 바꿨다. 이렇게 하면 서버가 `Principal`에서 이름을 도출할 때만 테스트가 통과한다. 예전처럼 본문 이름을 읽는 구현으로 되돌리면 아무도 STOP·완주 처리가 되지 않아 실패한다. 이 방식이 "남의 이름을 실은 요청이 무시되는지"를 따로 확인하는 테스트보다 나은지 봐주면 좋겠다.

**`TapCommand`에 `@Valid`를 남겨뒀다.** `playerName`이 빠지면서 이 DTO 에는 제약 애너테이션이 하나도 없다. `tapCount` 자체의 범위 검증은 이번 범위 밖이라 추가하지 않았다. 지금 `@Valid`를 떼는 게 맞는지, 아니면 `tapCount` 제약을 별도로 다룰지 판단이 필요하다.

# 🙅 이번에 하지 않은 것

- `ws-catalog.json` fixture 를 손으로 고쳤다. 재생성 도구인 `WsCatalogFixtureGeneratorTest`가 `:websocket` 모듈에 있고 그 모듈 경로에 파일을 쓰는데, 실제 fixture 는 `backend/app` 아래에 있어 이 테스트로는 갱신되지 않는다(멀티모듈 전환 #1276 이후로 어긋난 것으로 보인다). 이 어긋남 자체를 고치는 건 별도 작업이다.
- `tapCount`·연타 속도 등 입력 값 범위 검증은 다루지 않았다. 이번 변경은 "누가 보냈는가"만 고친다.
