### PR TITLE
[fix] 레이싱게임 — 탭 신호가 끊겨도 최고 속도로 자동 완주하지 않도록 감속 도입

### DIFF
--- a/backend/game/src/main/java/coffeeshout/racinggame/application/RacingGameService.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/application/RacingGameService.java
@@ -2,10 +2,10 @@ package coffeeshout.racinggame.application;
 
 import coffeeshout.gamecommon.JoinCode;
 import coffeeshout.minigame.application.GameSessionService;
-import coffeeshout.racinggame.config.RacingGameTimingProperties;
 import coffeeshout.minigame.domain.MiniGameService;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.minigame.event.dto.MiniGameFinishedEvent;
+import coffeeshout.racinggame.config.RacingGameTimingProperties;
 import coffeeshout.racinggame.domain.RacingGame;
 import coffeeshout.racinggame.domain.RacingGameState;
 import coffeeshout.racinggame.domain.SpeedCalculator;
@@ -35,8 +35,7 @@ public class RacingGameService implements MiniGameService {
             @Qualifier("racingGameScheduler") TaskScheduler taskScheduler,
             ApplicationEventPublisher eventPublisher,
             SpeedCalculator speedCalculator,
-            RacingGameTimingProperties timing
-    ) {
+            RacingGameTimingProperties timing) {
         this.gameSessionService = gameSessionService;
         this.taskScheduler = taskScheduler;
         this.eventPublisher = eventPublisher;
@@ -76,22 +75,23 @@ public class RacingGameService implements MiniGameService {
 
     private void processDescription(String joinCode, RacingGame racingGame) {
         racingGame.updateState(RacingGameState.DESCRIPTION);
-        taskScheduler.schedule(() -> {
-            processPrepare(racingGame, joinCode);
-            eventPublisher.publishEvent(RaceStateChangedEvent.of(racingGame, joinCode));
-        }, Instant.now().plus(timing.description()));
+        taskScheduler.schedule(
+                () -> {
+                    processPrepare(racingGame, joinCode);
+                    eventPublisher.publishEvent(RaceStateChangedEvent.of(racingGame, joinCode));
+                },
+                Instant.now().plus(timing.description()));
     }
 
     private void processPrepare(RacingGame racingGame, String joinCode) {
         racingGame.updateState(RacingGameState.PREPARE);
         eventPublisher.publishEvent(RunnersMovedEvent.of(racingGame, joinCode));
-        taskScheduler.schedule(() -> startAutoMove(racingGame, joinCode),
-                Instant.now().plus(timing.prepare()));
+        taskScheduler.schedule(
+                () -> startAutoMove(racingGame, joinCode), Instant.now().plus(timing.prepare()));
     }
 
     private ScheduledFuture<?> scheduleAutoMoveTask(RacingGame racingGame, String joinCode) {
-        return taskScheduler.scheduleAtFixedRate(() -> executeAutoMove(racingGame, joinCode),
-                timing.moveInterval());
+        return taskScheduler.scheduleAtFixedRate(() -> executeAutoMove(racingGame, joinCode), timing.moveInterval());
     }
 
     private void executeAutoMove(RacingGame racingGame, String joinCode) {
@@ -99,7 +99,7 @@ public class RacingGameService implements MiniGameService {
             if (!racingGame.isStarted()) {
                 return;
             }
-            racingGame.moveAll();
+            racingGame.moveAll(Instant.now());
             publishRunnersMoved(racingGame, joinCode);
 
             if (racingGame.isAllStopped()) {
@@ -114,13 +114,17 @@ public class RacingGameService implements MiniGameService {
         racingGame.updateState(RacingGameState.DONE);
         // 순서 불변식(ADR-0025 결정 5): finishGame()으로 roundCount를 먼저 확정·상태 복귀시킨다.
         final int roundCount = gameSessionService.finishGame(new JoinCode(joinCode));
-        taskScheduler.schedule(() -> eventPublisher.publishEvent(RaceFinishedEvent.of(racingGame, joinCode)),
+        taskScheduler.schedule(
+                () -> eventPublisher.publishEvent(RaceFinishedEvent.of(racingGame, joinCode)),
                 Instant.now().plus(timing.raceFinishedDelay()));
         racingGame.stopAutoMove();
         // 확률 조정·결과 저장을 유발하는 이벤트는 종료 알림·정리를 모두 끝낸 뒤 마지막에 발행한다 —
         // 저장 리스너(@Transactional/@RedisLock) 실패가 게임 종료 알림·자동이동 정지를 막지 않도록.
         eventPublisher.publishEvent(new MiniGameFinishedEvent(
-                joinCode, MiniGameType.RACING_GAME.name(), racingGame.getResult().toRankMap(), roundCount));
+                joinCode,
+                MiniGameType.RACING_GAME.name(),
+                racingGame.getResult().toRankMap(),
+                roundCount));
         log.info("레이싱 게임 종료: joinCode={}", joinCode);
     }
 
@@ -134,7 +138,6 @@ public class RacingGameService implements MiniGameService {
     }
 
     private RacingGame getRacingGame(JoinCode joinCode) {
-        return (RacingGame) gameSessionService.getSession(joinCode)
-                .findCompletedGame(MiniGameType.RACING_GAME);
+        return (RacingGame) gameSessionService.getSession(joinCode).findCompletedGame(MiniGameType.RACING_GAME);
     }
 }

--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
@@ -22,8 +22,16 @@ public class RacingGame implements Playable {
     public static final int MIN_SPEED = 3;
     public static final int MAX_SPEED = 60;
     public static final int CLICK_PER_SPEED_SCALE = 1;
-    // 주행 중 감속률 — 탭이 없으면 매 틱 이 비율로 줄어든다. 고속일수록 크게 깎여
-    // '몰아치고 손 떼기'를 초반에 강하게 응징한다. MIN_SPEED가 하한이라 완전히 멈추지는 않는다.
+    // 주행 중 감속률 — 매 틱 이 비율로 줄어든다.
+    //
+    // 막는 것은 손을 떼는 게 아니라 '탭 메시지가 끊긴 채 이전 속도로 자동 주행하는 것'이다.
+    // 손만 떼면 여기까지 오지 않는다 — 프론트는 안 눌러도 200ms마다 tapCount 0을 보내고,
+    // TapPerSecondSpeedCalculator가 그걸 MIN_SPEED로 환산한다. 메시지 자체가 끊기면
+    // (백그라운드 탭·화면 꺼짐·WS 끊김·변조 클라이언트) lastSpeedUpdateTime이 멈춰
+    // 이전 speed가 굳으므로, 서버가 시간으로 깎지 않으면 조작 없이 최고 속도로 완주한다.
+    //
+    // 틱당 비율이라 틱 길이에 의존한다. racing-game.timing.move-interval(운영 100ms)을
+    // 전제로 잡았으므로 주기를 바꾸면 이 값도 같이 봐야 한다.
     public static final double SPEED_DECAY_RATE = 0.9;
     public static final int FINISH_LINE = 3000;
     public static final int START_LINE = 0;

--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
@@ -46,8 +46,8 @@ public class RacingGame implements Playable {
         this.runners.initialLastTapTime(startTime);
     }
 
-    public void moveAll() {
-        runners.moveAll(Instant.now());
+    public void moveAll(Instant now) {
+        runners.moveAll(now);
     }
 
     public boolean isStarted() {

--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
@@ -22,6 +22,9 @@ public class RacingGame implements Playable {
     public static final int MIN_SPEED = 3;
     public static final int MAX_SPEED = 60;
     public static final int CLICK_PER_SPEED_SCALE = 1;
+    // 주행 중 감속률 — 탭이 없으면 매 틱 이 비율로 줄어든다. 고속일수록 크게 깎여
+    // '몰아치고 손 떼기'를 초반에 강하게 응징한다. MIN_SPEED가 하한이라 완전히 멈추지는 않는다.
+    public static final double SPEED_DECAY_RATE = 0.9;
     public static final int FINISH_LINE = 3000;
     public static final int START_LINE = 0;
 

--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/Runner.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/Runner.java
@@ -63,6 +63,10 @@ public class Runner {
     /**
      * 주행 중 감속. 무엇을 막는 값인지는 {@link RacingGame#SPEED_DECAY_RATE} 주석 참고.
      *
+     * <p>결승선을 넘는 그 틱에도 한 번 걸린다 — {@code isSlowingDown()}이 position 대입 전에
+     * 평가되므로 아직 완주로 보이지 않는다. finishTime은 그 전에 확정되므로 순위·기록에는
+     * 영향이 없고, 완주 후 관성이 한 틱 짧아질 뿐이다.
+     *
      * <p>MIN_SPEED가 하한인 이유는 속도가 0이 되면 {@code isStopped()}로 영영 못 움직여
      * 완주하지 못한 채 경주가 끝나기 때문이다. 그러면 finishTime이 null로 남아
      * {@code RacingGame#convertScore}의 {@code Duration.between(startTime, null)}이 터진다.

--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/Runner.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/Runner.java
@@ -22,7 +22,14 @@ public class Runner {
         this.lastSpeedUpdateTime = Instant.now();
     }
 
-    public void updateSpeed(int tapCount, SpeedCalculator speedCalculator, Instant now) {
+    /**
+     * 탭(WS 인바운드 스레드)과 자동 이동(스케줄러 스레드)이 같은 {@code speed}를 쓴다.
+     * 주행 중 감속이 생기기 전에는 두 스레드의 쓰기 구간이 겹치지 않았지만
+     * ({@code slowDown()}은 완주 후에만 돌고 그때 updateSpeed는 조기 반환한다),
+     * {@code decay()}가 경주 내내 돌면서 겹치게 됐다. 러너 단위 락으로 막는다 —
+     * 틱은 초당 10회, 탭은 초당 5회라 경합 비용은 무시할 수 있다.
+     */
+    public synchronized void updateSpeed(int tapCount, SpeedCalculator speedCalculator, Instant now) {
         if (isFinished()) {
             return;
         }
@@ -34,7 +41,8 @@ public class Runner {
         this.speed = nextSpeed;
     }
 
-    public void move(Instant now) {
+    /** 락 이유는 {@link #updateSpeed} 주석 참고. 한 틱 안에서 speed를 여러 번 읽으므로 값이 흔들리면 안 된다. */
+    public synchronized void move(Instant now) {
         if (isStopped()) {
             return;
         }
@@ -53,10 +61,11 @@ public class Runner {
     }
 
     /**
-     * 주행 중 감속. 속도 갱신이 탭에서만 일어나면 최고 속도를 찍고 손을 떼도 그 속도가 굳어
-     * 조작 없이 완주한다. 매 틱 줄여 두고 탭이 다시 올려주게 해야 계속 누르는 쪽이 빠르다.
-     * MIN_SPEED가 하한인 이유는 속도가 0이 되면 isStopped()로 영영 못 움직여
-     * 완주하지 못한 채 경주가 끝나기 때문이다(finishTime이 null로 남는다).
+     * 주행 중 감속. 무엇을 막는 값인지는 {@link RacingGame#SPEED_DECAY_RATE} 주석 참고.
+     *
+     * <p>MIN_SPEED가 하한인 이유는 속도가 0이 되면 {@code isStopped()}로 영영 못 움직여
+     * 완주하지 못한 채 경주가 끝나기 때문이다. 그러면 finishTime이 null로 남아
+     * {@code RacingGame#convertScore}의 {@code Duration.between(startTime, null)}이 터진다.
      */
     private void decay() {
         this.speed = Math.max(RacingGame.MIN_SPEED, (int) (speed * RacingGame.SPEED_DECAY_RATE));

--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/Runner.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/Runner.java
@@ -27,7 +27,8 @@ public class Runner {
             return;
         }
         final int nextSpeed = speedCalculator.calculateSpeed(lastSpeedUpdateTime, now, tapCount);
-        isTrue(nextSpeed >= RacingGame.MIN_SPEED && nextSpeed <= RacingGame.MAX_SPEED,
+        isTrue(
+                nextSpeed >= RacingGame.MIN_SPEED && nextSpeed <= RacingGame.MAX_SPEED,
                 String.format("스피드는 0 ~ %d이어야 합니다.", RacingGame.MAX_SPEED));
         this.lastSpeedUpdateTime = now;
         this.speed = nextSpeed;
@@ -39,13 +40,26 @@ public class Runner {
         }
         final int nextPosition = position + speed;
         if (crossesFinishLine(nextPosition)) {
-            final long remainingMillis = (long) (calculateDistanceToFinishLine(nextPosition) * calculateMillisPerPosition());
+            final long remainingMillis =
+                    (long) (calculateDistanceToFinishLine(nextPosition) * calculateMillisPerPosition());
             finishTime = now.minusMillis(RacingGame.MOVE_INTERVAL_MILLIS).plusMillis(remainingMillis);
         }
         if (isSlowingDown()) {
             slowDown();
+        } else {
+            decay();
         }
         this.position = nextPosition;
+    }
+
+    /**
+     * 주행 중 감속. 속도 갱신이 탭에서만 일어나면 최고 속도를 찍고 손을 떼도 그 속도가 굳어
+     * 조작 없이 완주한다. 매 틱 줄여 두고 탭이 다시 올려주게 해야 계속 누르는 쪽이 빠르다.
+     * MIN_SPEED가 하한인 이유는 속도가 0이 되면 isStopped()로 영영 못 움직여
+     * 완주하지 못한 채 경주가 끝나기 때문이다(finishTime이 null로 남는다).
+     */
+    private void decay() {
+        this.speed = Math.max(RacingGame.MIN_SPEED, (int) (speed * RacingGame.SPEED_DECAY_RATE));
     }
 
     private boolean isSlowingDown() {

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
@@ -125,12 +125,12 @@ class RacingGameTest {
     class 주행_중_감속 {
 
         @Test
-        void 최고_속도를_찍고_탭을_멈추면_결승선까지_자동_주행하지_않는다() {
+        void 탭_메시지가_끊겨도_결승선까지_자동_주행하지_않는다() {
             // given — 한 틱 만에 최고 속도에 올린다
             경주를_시작한다();
             달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED));
 
-            // when — 속도가 굳어 있다면 3000 / 60 = 50 틱이면 완주한다
+            // when — 탭이 한 건도 도착하지 않는다. 속도가 굳어 있다면 3000 / 60 = 50 틱이면 완주한다
             달린다(2, 50, Map.of());
 
             // then
@@ -138,7 +138,7 @@ class RacingGameTest {
         }
 
         @Test
-        void 탭을_멈추면_속도가_줄어든다() {
+        void 탭_메시지가_끊기면_속도가_줄어든다() {
             // given
             경주를_시작한다();
             달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED));
@@ -167,12 +167,12 @@ class RacingGameTest {
         }
 
         @Test
-        void 계속_탭한_러너가_몰아치고_멈춘_러너보다_앞선다() {
+        void 계속_탭한_러너가_탭이_끊긴_러너보다_앞선다() {
             // given — 둘 다 최고 속도에서 출발한다
             경주를_시작한다();
             달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED, 꾹이, RacingGame.MAX_SPEED));
 
-            // when — 한스만 계속 탭한다
+            // when — 한스만 계속 탭하고, 꾹이는 탭 메시지가 끊긴다
             달린다(2, 40, Map.of(한스, RacingGame.MAX_SPEED));
 
             // then

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
@@ -1,11 +1,11 @@
 package coffeeshout.racinggame.domain;
 
+import static coffeeshout.support.ExceptionAssertions.assertCoffeeShoutException;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import coffeeshout.fixture.PlayerFixture;
-import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.minigame.domain.MiniGameResult;
 import coffeeshout.room.domain.player.Player;
 import java.time.Instant;
 import java.util.List;
@@ -16,172 +16,194 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class RacingGameTest {
 
     final RacingGame racingGame = new RacingGame();
-    final List<Player> players = List.of(PlayerFixture.호스트한스(), PlayerFixture.게스트꾹이());
+    final Player 한스 = PlayerFixture.호스트한스();
+    final Player 꾹이 = PlayerFixture.게스트꾹이();
 
-    @Test
-    void 게임_시작을_위해_준비한다() {
-        // when
-        racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
-
-        // then
-        assertThat(racingGame.getState()).isEqualTo(RacingGameState.DESCRIPTION);
-        assertThat(racingGame.getPositions()).hasSize(2);
+    @BeforeEach
+    void setUp() {
+        racingGame.setUp(List.of(한스.toGamer(), 꾹이.toGamer()));
     }
 
-    @Test
-    void 모든_러너를_이동시킬_수_있다() {
-        // given
-        racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
-        racingGame.updateState(RacingGameState.PLAYING);
+    @Nested
+    class 게임_준비 {
 
-        racingGame.updateSpeed(
-                players.getFirst().getName().value(), 10, (lastTapedTime, now, tapCount) -> 10, Instant.now());
-        racingGame.updateSpeed(
-                players.get(1).getName().value(), 10, (lastTapedTime, now, tapCount) -> 10, Instant.now());
-
-        // when
-        racingGame.moveAll(Instant.now());
-
-        // then
-        final Map<Runner, Integer> positions = racingGame.getPositions();
-        assertThat(positions.values()).allMatch(position -> position == 10);
+        @Test
+        void 준비를_마치면_설명_상태로_모든_러너가_출발선에_선다() {
+            assertSoftly(softly -> {
+                softly.assertThat(racingGame.getState()).isEqualTo(RacingGameState.DESCRIPTION);
+                softly.assertThat(racingGame.getPositions()).hasSize(2);
+                softly.assertThat(racingGame.getPositions().values())
+                        .allMatch(position -> position == RacingGame.START_LINE);
+            });
+        }
     }
 
-    @Test
-    void 모든_러너가_결승선에_도착한다() {
-        // given
-        racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
-        racingGame.updateState(RacingGameState.PLAYING);
+    @Nested
+    class 러너_이동 {
 
-        racingGame.updateSpeed(
-                players.getFirst().getName().value(), 10, (lastTapedTime, now, tapCount) -> 30, Instant.now());
-        racingGame.updateSpeed(
-                players.get(1).getName().value(), 10, (lastTapedTime, now, tapCount) -> 30, Instant.now());
+        @Test
+        void 한_틱을_지나면_속도만큼_전진한다() {
+            // given
+            경주를_시작한다();
 
-        // when
-        for (int i = 0; i < 101; ++i) {
-            racingGame.moveAll(Instant.now());
+            // when
+            달린다(1, 1, Map.of(한스, 10, 꾹이, 10));
+
+            // then
+            assertThat(racingGame.getPositions().values()).allMatch(position -> position == 10);
         }
 
-        // then
-        assertThat(racingGame.isFinished()).isTrue();
+        @Test
+        void 계속_탭하면_모든_러너가_결승선에_도착한다() {
+            // given
+            경주를_시작한다();
+
+            // when — 결승선 3000 을 속도 30 으로 넘기려면 100 틱이 필요하다
+            달린다(1, 101, Map.of(한스, 30, 꾹이, 30));
+
+            // then
+            assertThat(racingGame.isFinished()).isTrue();
+        }
     }
 
-    @Test
-    void 러너의_속도를_조절한다() {
-        // given
-        racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
-        racingGame.updateState(RacingGameState.PLAYING);
+    @Nested
+    class 속도_조절 {
 
-        racingGame.updateSpeed(
-                players.getFirst().getName().value(), 10, (lastTapedTime, now, tapCount) -> 10, Instant.now());
-        racingGame.updateSpeed(
-                players.get(1).getName().value(), 10, (lastTapedTime, now, tapCount) -> 10, Instant.now());
+        @Test
+        void 탭하면_계산된_속도가_반영된다() {
+            // given
+            경주를_시작한다();
 
-        // then
-        assertThat(racingGame.getRunners().getSpeeds().values()).allMatch(value -> value == 10);
+            // when
+            탭한다(Map.of(한스, 10, 꾹이, 10), 틱_시각(1));
+
+            // then
+            assertThat(racingGame.getRunners().getSpeeds().values()).allMatch(speed -> speed == 10);
+        }
+
+        @Test
+        void 게임이_진행_중이_아니면_속도_조정시_예외가_발생한다() {
+            // given — setUp 직후는 DESCRIPTION 상태다
+            final SpeedCalculator speedCalculator = (lastTapedTime, now, tapCount) -> 10;
+
+            // when & then
+            assertCoffeeShoutException(
+                    () -> racingGame.updateSpeed(한스.getName().value(), 10, speedCalculator, Instant.now()),
+                    RacingGameErrorCode.NOT_PLAYING_STATE);
+        }
     }
 
-    @Test
-    void 게임이_진행_중이_아니면_속도_조정시_예외가_발생한다() {
-        // given
-        final SpeedCalculator speedCalculator = (lastTapedTime, now, tapCount) -> 10;
-        racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
+    @Nested
+    class 게임_결과 {
 
-        // when && then
-        assertThatThrownBy(() -> racingGame.updateSpeed(
-                        players.getFirst().getName().value(), 10, speedCalculator, Instant.now()))
-                .isInstanceOf(BusinessException.class);
+        @Test
+        void 먼저_완주한_러너가_1등이다() {
+            // given
+            경주를_시작한다();
+
+            // when — 꾹이는 속도 30 으로 100 틱에, 한스는 속도 10 으로 300 틱에 완주한다
+            달린다(1, 100, Map.of(꾹이, 30, 한스, 10));
+            달린다(101, 300, Map.of(한스, 10));
+
+            // then
+            final MiniGameResult result = racingGame.getResult();
+            assertSoftly(softly -> {
+                softly.assertThat(result.getRank().get(꾹이.toGamer())).isEqualTo(1);
+                softly.assertThat(result.getRank().get(한스.toGamer())).isEqualTo(2);
+            });
+        }
     }
 
-    // 완주 순서는 tick 시각으로만 갈린다. 점수는 밀리초로 절삭되므로(RacingGame#convertScore)
-    // 실제 시각으로 돌리면 300틱이 같은 밀리초에 들어가 동률이 되고 순위가 뒤집힌다.
-    // startTime을 기준으로 MOVE_INTERVAL_MILLIS 간격의 가짜 tick을 주입해 결정적으로 만든다.
-    @Test
-    void 게임_결과를_조회할_수_있다() {
-        // given
-        racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
+    @Nested
+    class 자동_이동_정지 {
+
+        /**
+         * 회귀 가드: {@code stopAutoMove()}는 자동 이동 태스크 자신의 스레드에서 호출된다
+         * (RacingGameService.handleRaceFinished ← executeAutoMove). {@code cancel(true)}로 취소하면
+         * 실행 중인 그 스레드가 스스로를 인터럽트하고, 곧이어 같은 스레드에서 발행되는
+         * MiniGameFinishedEvent의 결과 저장 리스너가 @RedisLock의 tryLock에서
+         * InterruptedException으로 실패한다 — 레이싱 기록이 한 건도 저장되지 않는다.
+         */
+        @Test
+        void 자동_이동_태스크_안에서_정지시켜도_실행_스레드가_인터럽트되지_않는다() throws InterruptedException {
+            // given
+            final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+            final CountDownLatch futureAssigned = new CountDownLatch(1);
+            final CountDownLatch stopped = new CountDownLatch(1);
+            final AtomicBoolean interrupted = new AtomicBoolean();
+
+            // when — 태스크가 자기 자신을 취소한 뒤 같은 스레드에서 이어지는 구간을 재현한다
+            final ScheduledFuture<?> autoMoveFuture = scheduler.scheduleAtFixedRate(
+                    () -> {
+                        try {
+                            futureAssigned.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                        racingGame.stopAutoMove();
+                        interrupted.set(Thread.currentThread().isInterrupted());
+                        stopped.countDown();
+                    },
+                    0,
+                    100,
+                    TimeUnit.MILLISECONDS);
+            racingGame.setAutoMoveFuture(autoMoveFuture);
+            futureAssigned.countDown();
+
+            // then — 취소는 하되 인터럽트는 하지 않는다. 인터럽트만 검증하면 stopAutoMove()가
+            // 통째로 no-op이 돼도(자동 이동이 영원히 도는 더 큰 회귀) 통과한다.
+            try {
+                assertThat(stopped.await(3, TimeUnit.SECONDS))
+                        .as("자동 이동 태스크 실행 완료")
+                        .isTrue();
+                assertSoftly(softly -> {
+                    softly.assertThat(interrupted).as("실행 스레드 인터럽트 여부").isFalse();
+                    softly.assertThat(autoMoveFuture.isCancelled())
+                            .as("자동 이동 취소 여부")
+                            .isTrue();
+                });
+            } finally {
+                scheduler.shutdownNow();
+            }
+        }
+    }
+
+    private void 경주를_시작한다() {
         racingGame.updateState(RacingGameState.PLAYING);
         racingGame.setUpStart();
-        racingGame.setAutoMoveFuture(null);
-
-        final Instant startTime = racingGame.getStartTime();
-        int tick = 0;
-
-        for (int i = 0; i < 100; i++) {
-            final Instant now = startTime.plusMillis(++tick * RacingGame.MOVE_INTERVAL_MILLIS);
-            racingGame.updateSpeed(players.get(1).getName().value(), 10, (lastTapedTime, at, tapCount) -> 30, now);
-            racingGame.updateSpeed(players.getFirst().getName().value(), 10, (lastTapedTime, at, tapCount) -> 10, now);
-            racingGame.moveAll(now);
-        }
-
-        for (int i = 0; i < 200; i++) {
-            final Instant now = startTime.plusMillis(++tick * RacingGame.MOVE_INTERVAL_MILLIS);
-            racingGame.updateSpeed(players.getFirst().getName().value(), 10, (lastTapedTime, at, tapCount) -> 10, now);
-            racingGame.moveAll(now);
-        }
-
-        // when
-        final var result = racingGame.getResult();
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getRank().get(players.getFirst().toGamer())).isEqualTo(2);
-        assertThat(result.getRank().get(players.get(1).toGamer())).isEqualTo(1);
     }
 
     /**
-     * 회귀 가드: {@code stopAutoMove()}는 자동 이동 태스크 자신의 스레드에서 호출된다
-     * (RacingGameService.handleRaceFinished ← executeAutoMove). {@code cancel(true)}로 취소하면
-     * 실행 중인 그 스레드가 스스로를 인터럽트하고, 곧이어 같은 스레드에서 발행되는
-     * MiniGameFinishedEvent의 결과 저장 리스너가 @RedisLock의 tryLock에서
-     * InterruptedException으로 실패한다 — 레이싱 기록이 한 건도 저장되지 않는다.
+     * 자동 이동 스케줄러를 대신해 tick 구간을 돌린다. {@code speeds}에 담긴 러너는 매 틱 탭한 것으로 보고,
+     * 빠진 러너는 탭을 멈춘 것으로 본다.
      */
-    @Test
-    void 자동_이동_태스크_안에서_정지시켜도_실행_스레드가_인터럽트되지_않는다() throws InterruptedException {
-        // given
-        racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
-        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-        final CountDownLatch futureAssigned = new CountDownLatch(1);
-        final CountDownLatch stopped = new CountDownLatch(1);
-        final AtomicBoolean interrupted = new AtomicBoolean();
-
-        // when — 태스크가 자기 자신을 취소한 뒤 같은 스레드에서 이어지는 구간을 재현한다
-        final ScheduledFuture<?> autoMoveFuture = scheduler.scheduleAtFixedRate(
-                () -> {
-                    try {
-                        futureAssigned.await();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        return;
-                    }
-                    racingGame.stopAutoMove();
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    stopped.countDown();
-                },
-                0,
-                100,
-                TimeUnit.MILLISECONDS);
-        racingGame.setAutoMoveFuture(autoMoveFuture);
-        futureAssigned.countDown();
-
-        // then — 취소는 하되 인터럽트는 하지 않는다. 인터럽트만 검증하면 stopAutoMove()가
-        // 통째로 no-op이 돼도(자동 이동이 영원히 도는 더 큰 회귀) 통과한다.
-        try {
-            assertThat(stopped.await(3, TimeUnit.SECONDS)).as("자동 이동 태스크 실행 완료").isTrue();
-            assertSoftly(softly -> {
-                softly.assertThat(interrupted).as("실행 스레드 인터럽트 여부").isFalse();
-                softly.assertThat(autoMoveFuture.isCancelled())
-                        .as("자동 이동 취소 여부")
-                        .isTrue();
-            });
-        } finally {
-            scheduler.shutdownNow();
+    private void 달린다(int 시작틱, int 끝틱, Map<Player, Integer> speeds) {
+        for (int tick = 시작틱; tick <= 끝틱; tick++) {
+            final Instant now = 틱_시각(tick);
+            탭한다(speeds, now);
+            racingGame.moveAll(now);
         }
+    }
+
+    private void 탭한다(Map<Player, Integer> speeds, Instant now) {
+        speeds.forEach((player, speed) ->
+                racingGame.updateSpeed(player.getName().value(), 10, (lastTapedTime, at, tapCount) -> speed, now));
+    }
+
+    /**
+     * 실제 시계 대신 startTime 기준 {@code MOVE_INTERVAL_MILLIS} 간격의 고정 시각을 쓴다.
+     * 완주 시각은 밀리초로 절삭되므로(RacingGame#convertScore), 실제 시계로 돌리면 수백 틱이
+     * 같은 밀리초에 몰려 순위가 비결정적이 된다.
+     */
+    private Instant 틱_시각(int tick) {
+        return racingGame.getStartTime().plusMillis(tick * RacingGame.MOVE_INTERVAL_MILLIS);
     }
 }

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
@@ -65,7 +65,7 @@ class RacingGameTest {
             // given
             경주를_시작한다();
 
-            // when — 결승선 3000 을 속도 30 으로 넘기려면 100 틱이 필요하다
+            // when — 결승선 3000 을 속도 30 으로 넘기려면 100 틱이다. 1 틱은 완주 후에도 멈추지 않는지 보는 여유분
             달린다(1, 101, Map.of(한스, 30, 꾹이, 30));
 
             // then
@@ -122,7 +122,10 @@ class RacingGameTest {
     }
 
     @Nested
-    class 주행_중_감속 {
+    class 탭이_끊긴_러너 {
+
+        // 감속 자체의 경계·불변식은 RunnerTest 담당(ADR-0033 결정 6 — 더 적은 컨텍스트로 내린다).
+        // 여기서는 러너 둘이 얽히는 결과만 본다.
 
         @Test
         void 탭_메시지가_끊겨도_결승선까지_자동_주행하지_않는다() {
@@ -131,39 +134,10 @@ class RacingGameTest {
             달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED));
 
             // when — 탭이 한 건도 도착하지 않는다. 속도가 굳어 있다면 3000 / 60 = 50 틱이면 완주한다
-            달린다(2, 50, Map.of());
+            달린다(2, 50, 탭이_끊긴다);
 
             // then
             assertThat(러너(한스).getPosition()).isLessThan(RacingGame.FINISH_LINE);
-        }
-
-        @Test
-        void 탭_메시지가_끊기면_속도가_줄어든다() {
-            // given
-            경주를_시작한다();
-            달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED));
-
-            // when
-            달린다(2, 6, Map.of());
-
-            // then
-            assertThat(러너(한스).getSpeed()).isLessThan(RacingGame.MAX_SPEED);
-        }
-
-        @Test
-        void 속도는_최저_속도_아래로는_떨어지지_않는다() {
-            // given — 최저 속도 아래로 떨어지면 isStopped()가 되어 완주하지 못한 채 경주가 끝난다
-            경주를_시작한다();
-            달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED));
-
-            // when
-            달린다(2, 200, Map.of());
-
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(러너(한스).getSpeed()).isEqualTo(RacingGame.MIN_SPEED);
-                softly.assertThat(러너(한스).isStopped()).isFalse();
-            });
         }
 
         @Test
@@ -177,23 +151,6 @@ class RacingGameTest {
 
             // then
             assertThat(러너(한스).getPosition()).isGreaterThan(러너(꾹이).getPosition());
-        }
-
-        @Test
-        void 완주한_러너는_주행_중_감속이_아니라_완주_후_감속으로_멈춘다() {
-            // given — 완주 직후의 속도를 확인한다
-            경주를_시작한다();
-            달린다(1, 50, Map.of(한스, RacingGame.MAX_SPEED));
-            final int 완주_직후_속도 = 러너(한스).getSpeed();
-
-            // when — 완주 후에는 탭이 무시되므로 한 틱만 더 돌린다
-            달린다(51, 51, Map.of(한스, RacingGame.MAX_SPEED));
-
-            // then — 완주 후 감속은 비율이 아니라 SLOW_DOWN_STEP 만큼 줄어든다
-            assertSoftly(softly -> {
-                softly.assertThat(러너(한스).isFinished()).isTrue();
-                softly.assertThat(러너(한스).getSpeed()).isEqualTo(완주_직후_속도 - Runner.SLOW_DOWN_STEP);
-            });
         }
     }
 
@@ -251,6 +208,9 @@ class RacingGameTest {
             }
         }
     }
+
+    /** 탭 메시지가 한 건도 도착하지 않는 상태. */
+    private static final Map<Player, Integer> 탭이_끊긴다 = Map.of();
 
     private Runner 러너(Player player) {
         return racingGame.getRunners().stream()

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
@@ -45,7 +45,7 @@ class RacingGameTest {
                 players.get(1).getName().value(), 10, (lastTapedTime, now, tapCount) -> 10, Instant.now());
 
         // when
-        racingGame.moveAll();
+        racingGame.moveAll(Instant.now());
 
         // then
         final Map<Runner, Integer> positions = racingGame.getPositions();
@@ -65,7 +65,7 @@ class RacingGameTest {
 
         // when
         for (int i = 0; i < 101; ++i) {
-            racingGame.moveAll();
+            racingGame.moveAll(Instant.now());
         }
 
         // then
@@ -99,34 +99,31 @@ class RacingGameTest {
                 .isInstanceOf(BusinessException.class);
     }
 
-    // PMD.NoThreadSleep 억제 — 아래 Thread.sleep은 테스트 편의가 아니라 프로덕션 제약이다.
-    // RacingGame.moveAll()이 내부에서 Instant.now()를 읽고(RacingGame:50) getResult()가 그
-    // finishTime으로 순위를 매기므로, 두 주자의 완주 시각을 벌리지 않으면 순위가 비결정적이 된다.
-    // 근본 해결은 moveAll()이 Instant를 주입받는 것(컨벤션: 시간은 파라미터로 주입)이며,
-    // 프로덕션 API 변경이라 별도 이슈로 분리한다.
-    @SuppressWarnings("PMD.NoThreadSleep")
+    // 완주 순서는 tick 시각으로만 갈린다. 점수는 밀리초로 절삭되므로(RacingGame#convertScore)
+    // 실제 시각으로 돌리면 300틱이 같은 밀리초에 들어가 동률이 되고 순위가 뒤집힌다.
+    // startTime을 기준으로 MOVE_INTERVAL_MILLIS 간격의 가짜 tick을 주입해 결정적으로 만든다.
     @Test
-    void 게임_결과를_조회할_수_있다() throws InterruptedException {
+    void 게임_결과를_조회할_수_있다() {
         // given
         racingGame.setUp(players.stream().map(p -> p.toGamer()).toList());
         racingGame.updateState(RacingGameState.PLAYING);
         racingGame.setUpStart();
         racingGame.setAutoMoveFuture(null);
 
+        final Instant startTime = racingGame.getStartTime();
+        int tick = 0;
+
         for (int i = 0; i < 100; i++) {
-            racingGame.updateSpeed(
-                    players.get(1).getName().value(), 10, (lastTapedTime, now, tapCount) -> 30, Instant.now());
-            racingGame.updateSpeed(
-                    players.getFirst().getName().value(), 10, (lastTapedTime, now, tapCount) -> 10, Instant.now());
-            racingGame.moveAll();
+            final Instant now = startTime.plusMillis(++tick * RacingGame.MOVE_INTERVAL_MILLIS);
+            racingGame.updateSpeed(players.get(1).getName().value(), 10, (lastTapedTime, at, tapCount) -> 30, now);
+            racingGame.updateSpeed(players.getFirst().getName().value(), 10, (lastTapedTime, at, tapCount) -> 10, now);
+            racingGame.moveAll(now);
         }
 
-        Thread.sleep(2);
-
         for (int i = 0; i < 200; i++) {
-            racingGame.updateSpeed(
-                    players.getFirst().getName().value(), 10, (lastTapedTime, now, tapCount) -> 10, Instant.now());
-            racingGame.moveAll();
+            final Instant now = startTime.plusMillis(++tick * RacingGame.MOVE_INTERVAL_MILLIS);
+            racingGame.updateSpeed(players.getFirst().getName().value(), 10, (lastTapedTime, at, tapCount) -> 10, now);
+            racingGame.moveAll(now);
         }
 
         // when

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RacingGameTest.java
@@ -122,6 +122,82 @@ class RacingGameTest {
     }
 
     @Nested
+    class 주행_중_감속 {
+
+        @Test
+        void 최고_속도를_찍고_탭을_멈추면_결승선까지_자동_주행하지_않는다() {
+            // given — 한 틱 만에 최고 속도에 올린다
+            경주를_시작한다();
+            달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED));
+
+            // when — 속도가 굳어 있다면 3000 / 60 = 50 틱이면 완주한다
+            달린다(2, 50, Map.of());
+
+            // then
+            assertThat(러너(한스).getPosition()).isLessThan(RacingGame.FINISH_LINE);
+        }
+
+        @Test
+        void 탭을_멈추면_속도가_줄어든다() {
+            // given
+            경주를_시작한다();
+            달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED));
+
+            // when
+            달린다(2, 6, Map.of());
+
+            // then
+            assertThat(러너(한스).getSpeed()).isLessThan(RacingGame.MAX_SPEED);
+        }
+
+        @Test
+        void 속도는_최저_속도_아래로는_떨어지지_않는다() {
+            // given — 최저 속도 아래로 떨어지면 isStopped()가 되어 완주하지 못한 채 경주가 끝난다
+            경주를_시작한다();
+            달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED));
+
+            // when
+            달린다(2, 200, Map.of());
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(러너(한스).getSpeed()).isEqualTo(RacingGame.MIN_SPEED);
+                softly.assertThat(러너(한스).isStopped()).isFalse();
+            });
+        }
+
+        @Test
+        void 계속_탭한_러너가_몰아치고_멈춘_러너보다_앞선다() {
+            // given — 둘 다 최고 속도에서 출발한다
+            경주를_시작한다();
+            달린다(1, 1, Map.of(한스, RacingGame.MAX_SPEED, 꾹이, RacingGame.MAX_SPEED));
+
+            // when — 한스만 계속 탭한다
+            달린다(2, 40, Map.of(한스, RacingGame.MAX_SPEED));
+
+            // then
+            assertThat(러너(한스).getPosition()).isGreaterThan(러너(꾹이).getPosition());
+        }
+
+        @Test
+        void 완주한_러너는_주행_중_감속이_아니라_완주_후_감속으로_멈춘다() {
+            // given — 완주 직후의 속도를 확인한다
+            경주를_시작한다();
+            달린다(1, 50, Map.of(한스, RacingGame.MAX_SPEED));
+            final int 완주_직후_속도 = 러너(한스).getSpeed();
+
+            // when — 완주 후에는 탭이 무시되므로 한 틱만 더 돌린다
+            달린다(51, 51, Map.of(한스, RacingGame.MAX_SPEED));
+
+            // then — 완주 후 감속은 비율이 아니라 SLOW_DOWN_STEP 만큼 줄어든다
+            assertSoftly(softly -> {
+                softly.assertThat(러너(한스).isFinished()).isTrue();
+                softly.assertThat(러너(한스).getSpeed()).isEqualTo(완주_직후_속도 - Runner.SLOW_DOWN_STEP);
+            });
+        }
+    }
+
+    @Nested
     class 자동_이동_정지 {
 
         /**
@@ -174,6 +250,14 @@ class RacingGameTest {
                 scheduler.shutdownNow();
             }
         }
+    }
+
+    private Runner 러너(Player player) {
+        return racingGame.getRunners().stream()
+                .filter(runner ->
+                        runner.getGamer().getName().equals(player.getName().value()))
+                .findFirst()
+                .orElseThrow();
     }
 
     private void 경주를_시작한다() {

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnerTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnerTest.java
@@ -122,9 +122,7 @@ class RunnerTest {
         runner.updateSpeed(10, speedCalculator, now);
 
         // when
-        runner.move(now);
-        runner.move(now);
-        runner.move(now);
+        달린다(runner, speedCalculator, now, 3);
 
         // then
         assertThat(runner.getPosition()).isEqualTo(30);
@@ -150,10 +148,8 @@ class RunnerTest {
         final Instant now = Instant.now();
         runner.updateSpeed(10, speedCalculator, now);
 
-        // when
-        for (int i = 0; i < 100; i++) {
-            runner.move(now);
-        }
+        // when — 완주(50틱) 후에도 계속 돌려 완주 후 감속이 0까지 떨어지는지 본다
+        달린다(runner, speedCalculator, now, 100);
 
         // then
         assertThat(runner.getSpeed()).isEqualTo(RacingGame.INITIAL_SPEED);
@@ -166,9 +162,7 @@ class RunnerTest {
         final SpeedCalculator speedCalculator = (lastTapedTime, now, tapCount) -> RacingGame.MAX_SPEED;
         final Instant now = Instant.now();
         runner.updateSpeed(10, speedCalculator, now);
-        for (int i = 0; i < 100; i++) {
-            runner.move(now);
-        }
+        달린다(runner, speedCalculator, now, 100);
         final int finishPosition = runner.getPosition();
 
         // when
@@ -188,9 +182,7 @@ class RunnerTest {
         runner.updateSpeed(10, speedCalculator, now);
 
         // when
-        for (int i = 0; i < 100; i++) {
-            runner.move(now);
-        }
+        달린다(runner, speedCalculator, now, 100);
 
         // then
         assertThat(runner.isFinished()).isTrue();
@@ -211,13 +203,10 @@ class RunnerTest {
         final Runner runner = new Runner(PlayerFixture.게스트한스().toGamer());
         final SpeedCalculator speedCalculator = (lastTapedTime, now, tapCount) -> RacingGame.MAX_SPEED;
         final Instant now = Instant.now();
-        runner.updateSpeed(10, speedCalculator, now);
-        for (int i = 0; i < 99; i++) {
-            runner.move(now);
-        }
+        달린다(runner, speedCalculator, now, 49); // 최고 속도 60 × 49틱 = 2940, 아직 결승선 앞이다
 
         // when
-        runner.move(now);
+        달린다(runner, speedCalculator, now, 1);
 
         // then
         assertThat(runner.getFinishTime()).isNotNull();
@@ -238,18 +227,14 @@ class RunnerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "2950, 60, 83",     // 2950 + 60 = 3010, 10 초과
-            "2980, 30, 66",     // 2980 + 30 = 3010, 10 초과
-            "2990, 20, 50",     // 2990 + 20 = 3010, 10 초과
-            "2995, 10, 50",      // 2995 + 10 = 3005, 5 초과
-            "2997, 5, 60",       // 2997 + 5 = 3002, 2 초과
-            "2999, 3, 33",      // 2999 + 3 = 3002, 2 초과
+        "2950, 60, 83", // 2950 + 60 = 3010, 10 초과
+        "2980, 30, 66", // 2980 + 30 = 3010, 10 초과
+        "2990, 20, 50", // 2990 + 20 = 3010, 10 초과
+        "2995, 10, 50", // 2995 + 10 = 3005, 5 초과
+        "2997, 5, 60", // 2997 + 5 = 3002, 2 초과
+        "2999, 3, 33", // 2999 + 3 = 3002, 2 초과
     })
-    void 결승선을_초과하여_도착하면_남은_거리_비율만큼_시간이_보정된다(
-            int startPosition,
-            int speed,
-            int expectedTicksToFinish
-    ) {
+    void 결승선을_초과하여_도착하면_남은_거리_비율만큼_시간이_보정된다(int startPosition, int speed, int expectedTicksToFinish) {
         // given
         final Runner runner = new Runner(PlayerFixture.게스트한스().toGamer());
         final SpeedCalculator speedCalculator = (lastTapedTime, now, tapCount) -> speed;
@@ -261,11 +246,22 @@ class RunnerTest {
 
         // when
         runner.move(tickStartTime);
-        final Instant expectFinishTime = tickStartTime.minusMillis(RacingGame.MOVE_INTERVAL_MILLIS)
-                .plusMillis(expectedTicksToFinish);
+        final Instant expectFinishTime =
+                tickStartTime.minusMillis(RacingGame.MOVE_INTERVAL_MILLIS).plusMillis(expectedTicksToFinish);
 
         // then
         assertThat(runner.isFinished()).isTrue();
         assertThat(runner.getFinishTime()).isEqualTo(expectFinishTime);
+    }
+
+    /**
+     * 매 틱 탭하며 달린다. 주행 중 감속이 있으므로 속도를 한 번만 주고 반복 이동하면
+     * 속도가 계속 줄어 완주하지 못한다 — 실제 플레이(계속 누르기)와 같은 조건을 만든다.
+     */
+    private void 달린다(Runner runner, SpeedCalculator speedCalculator, Instant now, int ticks) {
+        for (int i = 0; i < ticks; i++) {
+            runner.updateSpeed(10, speedCalculator, now);
+            runner.move(now);
+        }
     }
 }

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnerTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnerTest.java
@@ -2,6 +2,7 @@ package coffeeshout.racinggame.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import coffeeshout.fixture.PlayerFixture;
 import java.time.Instant;
@@ -209,8 +210,88 @@ class RunnerTest {
         달린다(runner, speedCalculator, now, 1);
 
         // then
-        assertThat(runner.getFinishTime()).isNotNull();
-        assertThat(runner.isFinished()).isTrue();
+        assertSoftly(softly -> {
+            softly.assertThat(runner.getFinishTime()).isNotNull();
+            softly.assertThat(runner.isFinished()).isTrue();
+        });
+    }
+
+    @Test
+    void 탭이_없으면_이동할_때마다_속도가_줄어든다() {
+        // given
+        final Runner runner = 최고_속도로_달리는_러너();
+
+        // when — 탭 없이 이동만 한다
+        runner.move(Instant.now());
+
+        // then
+        assertThat(runner.getSpeed()).isEqualTo((int) (RacingGame.MAX_SPEED * RacingGame.SPEED_DECAY_RATE));
+    }
+
+    @Test
+    void 탭이_없어도_속도는_최저_속도_아래로_떨어지지_않는다() {
+        // given — 0이 되면 isStopped()로 영영 못 움직여 완주하지 못한 채 경주가 끝난다
+        final Runner runner = 최고_속도로_달리는_러너();
+        final Instant now = Instant.now();
+
+        // when
+        for (int i = 0; i < 200; i++) {
+            runner.move(now);
+        }
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(runner.getSpeed()).isEqualTo(RacingGame.MIN_SPEED);
+            softly.assertThat(runner.isStopped()).isFalse();
+        });
+    }
+
+    @Test
+    void 감속된_뒤_다시_탭하면_속도가_회복된다() {
+        // given
+        final Runner runner = 최고_속도로_달리는_러너();
+        final Instant now = Instant.now();
+        for (int i = 0; i < 5; i++) {
+            runner.move(now);
+        }
+
+        // when
+        runner.updateSpeed(10, (lastTapedTime, at, tapCount) -> RacingGame.MAX_SPEED, now);
+
+        // then
+        assertThat(runner.getSpeed()).isEqualTo(RacingGame.MAX_SPEED);
+    }
+
+    @Test
+    void 결승선을_넘는_틱에는_아직_주행_중_감속이_적용된다() {
+        // given — isSlowingDown()은 position 대입 전에 평가되므로 그 틱은 아직 완주로 보이지 않는다
+        final Runner runner = 최고_속도로_달리는_러너();
+        ReflectionTestUtils.setField(runner, "position", RacingGame.FINISH_LINE - RacingGame.MAX_SPEED);
+
+        // when
+        runner.move(Instant.now());
+
+        // then — SLOW_DOWN_STEP(57)이 아니라 비율 감속(54)이다
+        assertSoftly(softly -> {
+            softly.assertThat(runner.isFinished()).isTrue();
+            softly.assertThat(runner.getSpeed()).isEqualTo((int) (RacingGame.MAX_SPEED * RacingGame.SPEED_DECAY_RATE));
+        });
+    }
+
+    @Test
+    void 완주한_뒤에는_주행_중_감속이_아니라_완주_후_감속이_적용된다() {
+        // given — 완주 틱까지 진행시킨다
+        final Runner runner = 최고_속도로_달리는_러너();
+        final Instant now = Instant.now();
+        ReflectionTestUtils.setField(runner, "position", RacingGame.FINISH_LINE - RacingGame.MAX_SPEED);
+        runner.move(now);
+        final int 완주_틱_속도 = runner.getSpeed();
+
+        // when
+        runner.move(now);
+
+        // then — 비율 감속이면 48, 완주 후 감속이면 51이다
+        assertThat(runner.getSpeed()).isEqualTo(완주_틱_속도 - Runner.SLOW_DOWN_STEP);
     }
 
     @Test
@@ -252,6 +333,12 @@ class RunnerTest {
         // then
         assertThat(runner.isFinished()).isTrue();
         assertThat(runner.getFinishTime()).isEqualTo(expectFinishTime);
+    }
+
+    private Runner 최고_속도로_달리는_러너() {
+        final Runner runner = new Runner(PlayerFixture.게스트한스().toGamer());
+        runner.updateSpeed(10, (lastTapedTime, at, tapCount) -> RacingGame.MAX_SPEED, Instant.now());
+        return runner;
     }
 
     /**

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnersTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnersTest.java
@@ -33,7 +33,7 @@ class RunnersTest {
 
         // then
         final Map<Runner, Integer> positions = runners.getPositions();
-        assertThat(positions.values()).allMatch(position -> position == RacingGame.INITIAL_SPEED);
+        assertThat(positions.values()).allMatch(position -> position == RacingGame.START_LINE);
     }
 
     @Test
@@ -75,7 +75,7 @@ class RunnersTest {
 
         // then
         assertThat(positions).hasSize(2);
-        assertThat(positions.values()).allMatch(position -> position == RacingGame.INITIAL_SPEED);
+        assertThat(positions.values()).allMatch(position -> position == RacingGame.START_LINE);
     }
 
     @Test

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnersTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnersTest.java
@@ -13,7 +13,8 @@ class RunnersTest {
 
     private final SpeedCalculator speedCalculator = (lastTapedTime, now, tapCount) -> 30;
 
-    final List<Gamer> players = List.of(PlayerFixture.호스트한스().toGamer(), PlayerFixture.게스트꾹이().toGamer());
+    final List<Gamer> players =
+            List.of(PlayerFixture.호스트한스().toGamer(), PlayerFixture.게스트꾹이().toGamer());
     final Runners runners = new Runners(players);
 
     @Test
@@ -39,10 +40,7 @@ class RunnersTest {
     void 우승자를_찾을_수_있다() {
         // given
         final Instant now = Instant.now();
-        runners.updateSpeed(players.getFirst().getName(), 10, speedCalculator, now);
-        for (int i = 0; i < 100; i++) {
-            runners.moveAll(now);
-        }
+        달린다(100, now, players.getFirst().getName());
 
         // when
         final Runner winner = runners.findWinner().get();
@@ -61,10 +59,7 @@ class RunnersTest {
     void 우승자가_있는지_확인할_수_있다() {
         // given
         final Instant now = Instant.now();
-        runners.updateSpeed(players.getFirst().getName(), 10, speedCalculator, now);
-        for (int i = 0; i < 100; i++) {
-            runners.moveAll(now);
-        }
+        달린다(100, now, players.getFirst().getName());
 
         // when && then
         assertThat(runners.hasWinner()).isTrue();
@@ -97,11 +92,7 @@ class RunnersTest {
     void 모든_러너가_완주했는지_확인할_수_있다() {
         // given
         final Instant now = Instant.now();
-        runners.updateSpeed(players.getFirst().getName(), 10, speedCalculator, now);
-        runners.updateSpeed(players.get(1).getName(), 10, speedCalculator, now);
-        for (int i = 0; i < 100; i++) {
-            runners.moveAll(now);
-        }
+        달린다(100, now, players.getFirst().getName(), players.get(1).getName());
 
         // when && then
         assertThat(runners.isAllFinished()).isTrue();
@@ -132,5 +123,18 @@ class RunnersTest {
 
         // then
         assertThat(runners.getRunners().getFirst().getLastSpeedUpdateTime()).isEqualTo(time);
+    }
+
+    /**
+     * 지정한 러너들이 매 틱 탭하며 달린다. 주행 중 감속이 있으므로 속도를 한 번만 주고
+     * 반복 이동하면 속도가 계속 줄어 완주하지 못한다.
+     */
+    private void 달린다(int ticks, Instant now, String... tappingNames) {
+        for (int i = 0; i < ticks; i++) {
+            for (final String name : tappingNames) {
+                runners.updateSpeed(name, 10, speedCalculator, now);
+            }
+            runners.moveAll(now);
+        }
     }
 }

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/TapPerSecondSpeedCalculatorTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/TapPerSecondSpeedCalculatorTest.java
@@ -2,7 +2,6 @@ package coffeeshout.racinggame.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import coffeeshout.racinggame.domain.TapPerSecondSpeedCalculator;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
@@ -67,7 +66,7 @@ class TapPerSecondSpeedCalculatorTest {
     }
 
     @Test
-    void 탭을_하지_않으면_속도는_0이다() {
+    void 탭_횟수가_0이면_최저_속도가_된다() {
         // given
         final Instant lastTapedTime = Instant.now();
         final Instant now = lastTapedTime.plusMillis(1000);

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -21,6 +21,7 @@ import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.repository.RoomRepository;
 import coffeeshout.room.infra.persistence.RoomEntity;
 import coffeeshout.support.TestStompSession;
+import coffeeshout.support.TestStompSession.MessageCollector;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -156,9 +157,7 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
         eventPublisher.publishEvent(
                 new GameStartReadyEvent("evt-" + joinCodeValue, joinCodeValue, host.getName(), gamers));
 
-        stateResponses.get(1, TimeUnit.SECONDS); // DESCRIPTION
-        stateResponses.get(5, TimeUnit.SECONDS); // PREPARE (4초 후)
-        stateResponses.get(3, TimeUnit.SECONDS); // PLAYING (2초 후)
+        awaitState(stateResponses, RacingGameState.PLAYING, 5);
 
         /*
          탭은 주기적으로 보내야 한다. 주행 중에는 매 틱 속도가 감쇠하므로(RacingGame.SPEED_DECAY_RATE)
@@ -181,19 +180,35 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
                 TimeUnit.MILLISECONDS);
 
         // then - DONE 상태 확인. 주행 약 9주기(3.6초) + 완주 후 감속 + race-finished-delay 만큼 걸린다.
-        final RacingGameStateResponse finishedState;
         try {
-            finishedState = payloadAs(stateResponses.get(10, TimeUnit.SECONDS), RacingGameStateResponse.class);
+            awaitState(stateResponses, RacingGameState.DONE, 10);
         } finally {
-            // DONE 이후의 탭은 PLAYING이 아니라 BusinessException이 된다 — 받자마자 멈춘다.
+            // DONE 이후의 탭은 컨슈머 스레드에서 BusinessException이 되어 WARN 로그만 남긴다.
+            // 태퍼가 스스로 멈추지는 않으므로 여기서 끈다.
             tapper.shutdownNow();
         }
-        assertThat(finishedState.state()).isEqualTo(RacingGameState.DONE);
 
         // then - 종료 결과가 실제로 저장된다. DONE 브로드캐스트는 결과 저장보다 앞서 예약되므로(#1662)
         // 종료 신호만 검증하면 저장이 통째로 실패해도 이 테스트는 초록으로 남는다.
         await().atMost(Duration.ofSeconds(5))
                 .untilAsserted(() -> assertThat(저장된_레이싱_결과_수()).isEqualTo(gamers.size()));
+    }
+
+    /**
+     * 목표 상태가 나올 때까지 훑는다. 상태 토픽은 DESCRIPTION→PREPARE→PLAYING→DONE 순으로
+     * 브로드캐스트되므로 위치 기반 get()으로 읽으면 프레임이 하나만 끼어도 엉뚱한 것을 단언한다
+     * (testing-integration.md). 참조 구현은 NunchiIntegrationTest#awaitState.
+     */
+    private RacingGameStateResponse awaitState(
+            MessageCollector stateResponses, RacingGameState target, int timeoutSeconds) {
+        for (int i = 0; i < 8; i++) {
+            final RacingGameStateResponse response =
+                    payloadAs(stateResponses.get(timeoutSeconds, TimeUnit.SECONDS), RacingGameStateResponse.class);
+            if (response.state() == target) {
+                return response;
+            }
+        }
+        throw new AssertionError(target + " 상태를 받지 못했습니다");
     }
 
     private Integer 저장된_레이싱_결과_수() {

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -163,7 +163,9 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
         /*
          탭은 주기적으로 보내야 한다. 주행 중에는 매 틱 속도가 감쇠하므로(RacingGame.SPEED_DECAY_RATE)
          한 발만 쏘면 속도가 MIN_SPEED까지 떨어져 아무도 결승(3000)에 닿지 못한다 — 실제 플레이와 같이
-         계속 눌러야 한다. 프론트도 200ms마다 누적 탭을 보낸다(RacingGameOverlay).
+         계속 눌러야 한다. 프론트도 200ms마다 누적 탭을 보낸다(RacingGameOverlay). 다만 프론트는
+         안 눌렀을 때 tapCount 0을 보내고 그건 MIN_SPEED로 환산되므로, 여기서 재현하는 것은
+         '탭 메시지가 계속 도착하는' 정상 경로다.
 
          주기를 400ms로 두는 이유는 WS Rate Limiter다. 세션당 초당 20건을 넘기면 초과분이 조용히
          드롭되는데(#1664 CI 실패) 이 테스트는 한 세션으로 4명분을 보낸다. 400ms 주기면 초당 10건이라

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -23,6 +23,8 @@ import coffeeshout.room.infra.persistence.RoomEntity;
 import coffeeshout.support.TestStompSession;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -159,20 +161,31 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
         stateResponses.get(3, TimeUnit.SECONDS); // PLAYING (2초 후)
 
         /*
-         탭은 플레이어당 한 번만 보낸다. 속도는 감쇠하지 않고(Runner.speed는 탭 또는 완주 후 감속으로만 변한다)
-         `tapCount / 경과시간`을 MAX_SPEED(60)로 clamp한 값이므로, 큰 tapCount 한 발이면 전원이 최고속도에
-         고정된 채 결승(3000)까지 간다 — 50틱 주행 + 감속 20틱(SLOW_DOWN_STEP 3) 뒤 전원 정지하면 DONE.
-         연타로 유지하면 안 된다: WS Rate Limiter가 세션당 초당 20건 초과분을 조용히 드롭하므로(#1664 CI 실패)
-         어느 라운드가 살아남는지가 부하에 따라 갈리고, 마지막 생존 탭의 경과시간이 길면 그 러너만 MIN_SPEED로
-         남아 완주하지 못한다. DONE은 전원 정지가 조건이라 한 명만 뒤처져도 영영 오지 않는다.
-        */
-        for (Gamer gamer : gamers) {
-            singleSession.send(tapRequestUrl, new TapCommand(gamer.getName(), 200));
-        }
+         탭은 주기적으로 보내야 한다. 주행 중에는 매 틱 속도가 감쇠하므로(RacingGame.SPEED_DECAY_RATE)
+         한 발만 쏘면 속도가 MIN_SPEED까지 떨어져 아무도 결승(3000)에 닿지 못한다 — 실제 플레이와 같이
+         계속 눌러야 한다. 프론트도 200ms마다 누적 탭을 보낸다(RacingGameOverlay).
 
-        // then - DONE 상태 확인. 70틱 × move-interval(50ms) + race-finished-delay 만큼 걸리므로 상한을 넉넉히 둔다.
-        RacingGameStateResponse finishedState =
-                payloadAs(stateResponses.get(10, TimeUnit.SECONDS), RacingGameStateResponse.class);
+         주기를 400ms로 두는 이유는 WS Rate Limiter다. 세션당 초당 20건을 넘기면 초과분이 조용히
+         드롭되는데(#1664 CI 실패) 이 테스트는 한 세션으로 4명분을 보낸다. 400ms 주기면 초당 10건이라
+         상한의 절반이다. 200ms로 줄이면 정확히 상한에 걸려 드롭 여부가 부하에 좌우된다.
+
+         tapCount 40은 경과 400ms 기준 초당 100탭이라 MAX_SPEED(60)로 clamp된다.
+        */
+        final ScheduledExecutorService tapper = Executors.newSingleThreadScheduledExecutor();
+        tapper.scheduleAtFixedRate(
+                () -> gamers.forEach(gamer -> singleSession.send(tapRequestUrl, new TapCommand(gamer.getName(), 40))),
+                0,
+                400,
+                TimeUnit.MILLISECONDS);
+
+        // then - DONE 상태 확인. 주행 약 9주기(3.6초) + 완주 후 감속 + race-finished-delay 만큼 걸린다.
+        final RacingGameStateResponse finishedState;
+        try {
+            finishedState = payloadAs(stateResponses.get(10, TimeUnit.SECONDS), RacingGameStateResponse.class);
+        } finally {
+            // DONE 이후의 탭은 PLAYING이 아니라 BusinessException이 된다 — 받자마자 멈춘다.
+            tapper.shutdownNow();
+        }
         assertThat(finishedState.state()).isEqualTo(RacingGameState.DONE);
 
         // then - 종료 결과가 실제로 저장된다. DONE 브로드캐스트는 결과 저장보다 앞서 예약되므로(#1662)


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1669
- close #1632

# 🚀 작업 내용

## 무엇이 달라지는가

레이싱게임에서 **탭 신호가 끊긴 플레이어가 최고 속도로 계속 달리지 않는다.** 지금은 앱을 백그라운드로 보내거나 연결이 끊기면 마지막 속도가 그대로 굳어 조작 없이 완주한다. 폰을 주머니에 넣은 사람이 우승할 수 있다.

부수적으로 레이싱게임 테스트가 시계에 기대지 않게 되고, `Thread.sleep`이 사라진다.

## 왜 바꿨는가

서버에 속도를 낮추는 경로가 없었다. 속도 갱신은 탭 메시지가 올 때만 일어나고, 100ms마다 도는 이동 루프는 속도를 건드리지 않는다. `Runner.speed`를 줄이는 코드는 **완주 후 감속** 하나뿐이라 주행 중에는 마지막 값이 그대로 굳는다.

**단, 손을 떼는 것만으로는 이 상태가 되지 않는다.** 프론트는 안 눌러도 200ms마다 `tapCount: 0`을 보내고(`RacingGameOverlay`), `TapPerSecondSpeedCalculator`가 그걸 `MIN_SPEED`로 환산한다. 기존 테스트 `탭_횟수가_0이면_최저_속도가_된다`가 이미 그 동작을 단언하고 있다. 포그라운드에서 손만 떼는 경우는 `dev`에서도 이미 느려진다.

문제는 **탭 메시지 자체가 도착하지 않을 때**다. 앱이 백그라운드로 가 `setInterval`이 얼어붙거나, 화면이 꺼지거나, WS가 끊기거나, 변조된 클라이언트가 전송을 멈추면 `lastSpeedUpdateTime`이 멈춰 이전 속도가 유지된다. 최고 속도 60이면 결승선 3000까지 50틱, 즉 5초다.

이건 서버가 클라이언트를 믿고 있었다는 뜻이다. 감속은 서버가 시간으로 판단해야 한다. 미니게임 결과는 룰렛 확률 조정에 쓰이므로(ADR-0025) 최종 당첨자 선정까지 왜곡된다.

두 번째 변경(#1632)은 이 수정의 전제다. 완주 순위를 결정적으로 검증하려면 테스트가 tick 시각을 정할 수 있어야 하는데, `moveAll()`이 내부에서 `Instant.now()`를 읽고 있었다.

## 흐름 그림

```mermaid
stateDiagram-v2
    [*] --> 주행중
    주행중 --> 주행중: 탭 도착 → 속도 = CPS 환산값
    주행중 --> 주행중: 틱 → 전진 후 속도 ×0.9 (신규)
    주행중 --> 완주: 위치 ≥ 3000
    완주 --> 완주: 틱 → 속도 -3 (기존)
    완주 --> 정지: 속도 0
    정지 --> [*]
```

기존에는 `주행중` 상태에 속도를 낮추는 전이가 없었다. 완주 후 감속(`-3`)과 주행 중 감속(`×0.9`)은 서로 다른 전이이며 겹치지 않는다.

## 변경 목록

1. 주행 중 매 틱 속도를 `×0.9`로 줄인다. 탭은 올리고 시간은 내리는 균형이라 계속 눌러야 속도가 유지된다. `Runner#decay`
2. 감속 하한을 `MIN_SPEED`(3)로 두었다. 0이 되면 그 러너는 영영 못 움직이는데 경주는 끝나버려 완주 시각이 비어 있는 채로 결과를 계산하게 된다. `Runner#decay`
3. 완주 후 감속과 주행 중 감속을 배타적으로 분기했다. 완주한 러너는 기존대로 `SLOW_DOWN_STEP`만큼 줄어 멈춘다. `Runner#move`
4. 탭과 자동 이동이 같은 `speed`를 쓰게 되어 러너 단위 락을 걸었다. 감속이 들어오기 전에는 두 스레드의 쓰기 구간이 겹치지 않았다 — 리뷰에서 잡힌 이 PR의 회귀다. `Runner#updateSpeed`, `Runner#move`
5. 감속률을 상수로 두었다. 레이싱 물리값이 이미 전부 상수라 이것만 설정으로 빼면 값이 두 곳으로 갈린다. `RacingGame.SPEED_DECAY_RATE`
6. 한 틱을 전진시키는 메서드가 시각을 파라미터로 받는다. 유일한 호출자가 호출 시점의 `Instant.now()`를 넘긴다. `RacingGame#moveAll`, `RacingGameService#executeAutoMove`

<details>
<summary>감속 곡선과 조작감</summary>

최고 속도 60에서 시작해 탭이 없을 때의 속도 변화다.

| 틱 | 0 | 1 | 2 | 3 | 5 | 8 | 10 | 15 | 21 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 속도 | 60 | 54 | 48 | 43 | 34 | 24 | 19 | 9 | 3 |

0.6초 만에 절반으로 떨어지고 2.1초에 최저 속도에 닿는다. 고정 감소(`-3/틱`)와 총 소요 시간은 비슷하지만(1.9초) 곡선이 다르다. 비율 쪽이 고속에서 크게 깎여 '몰아치고 손 떼기'를 초반에 강하게 응징한다.

계속 누르는 경우의 손해는 작다. 프론트는 200ms마다 탭을 보내고 이동 틱은 100ms이므로 탭 사이에 2틱이 지난다. 실효 속도는 최고 속도의 약 95%(`(1 + 0.9) / 2`)다.

</details>

## 검증

먼저 회귀 테스트를 써서 버그를 실패로 재현한 뒤 고쳤다.

감속 자체의 경계·불변식은 `RunnerTest`에서 본다. 탭 없이 `move()`만 반복해야 감속이 실제로 실행된다 — 매 틱 탭하면 `updateSpeed()`가 속도를 통째로 덮어써 감속 결과가 지워진다.

- `탭이_없으면_이동할_때마다_속도가_줄어든다`
- `탭이_없어도_속도는_최저_속도_아래로_떨어지지_않는다` — 0이 되면 완주 못 한 채 경주가 끝나는 것을 막는 가드다
- `감속된_뒤_다시_탭하면_속도가_회복된다` — 감속만 검증하면 되돌릴 수 없게 만드는 회귀를 놓친다
- `결승선을_넘는_틱에는_아직_주행_중_감속이_적용된다`
- `완주한_뒤에는_주행_중_감속이_아니라_완주_후_감속이_적용된다`

러너 둘이 얽히는 결과는 `RacingGameTest`에서 본다.

- `탭_메시지가_끊겨도_결승선까지_자동_주행하지_않는다` — 리포트된 증상 그대로다. 최고 속도 한 틱 뒤 50틱 동안 탭이 한 건도 오지 않을 때 결승선에 닿지 않는지 본다
- `계속_탭한_러너가_탭이_끊긴_러너보다_앞선다`

`./gradlew :game:test` 전체와 `:game:pmdMain :game:pmdTest spotlessCheck`가 통과한다.

테스트가 헛돌지 않는지는 변이 실험 두 번으로 확인했다. 감속을 no-op으로 바꾸면 `RunnerTest` 3건이 실패하고, 두 러너의 속도를 같게 만들면 순위 테스트가 실패한다. 둘 다 원복하면 통과한다.

동시성 회귀 테스트는 넣지 않았다. 결정적으로 재현할 방법이 없어 플레이키한 테스트가 된다.

## 이번에 함께 정리한 테스트

`RacingGameTest`를 프로젝트 테스트 컨벤션에 맞췄다. `@Nested`로 시나리오를 묶고, 복수 검증을 `SoftAssertions`로 바꾸고, 예외 검증을 `assertCoffeeShoutException`으로 교체해 에러코드까지 확인한다.

300틱을 손으로 도는 루프는 `달린다(시작틱, 끝틱, 속도맵)` 헬퍼로 뺐다. **속도맵에 든 러너는 매 틱 탭한 것으로, 빠진 러너는 손을 뗀 것으로 본다.** 감속 회귀 테스트가 이 헬퍼 위에 그대로 얹힌다.

# 💬 리뷰 중점사항

**감속률 0.9가 적당한지 봐주세요.** 밸런스 값이라 정답이 없습니다. 상수로 두어 조정에는 재배포가 필요합니다. 설정으로 빼는 편이 낫다고 보시면 그렇게 바꾸겠습니다. 레이싱 물리값이 전부 상수라 일관성을 택했습니다.

**감속이 완주 직전 틱에도 적용됩니다.** 결승선을 넘는 그 틱에서는 아직 `isFinished()`가 거짓이라 주행 중 감속 분기를 탑니다. 완주 시각은 그 틱의 속도로 이미 계산된 뒤이므로 순위에는 영향이 없고, 다음 틱부터 완주 후 감속으로 넘어갑니다. 의도한 동작이며 테스트로 못 박았습니다.

**러너 단위 락으로 충분한지 봐주세요.** 게터(`getPositions`·`getSpeeds`)는 동기화하지 않았습니다. 브로드캐스트용 읽기라 한 틱 낡은 값을 보내도 무해하다고 봤습니다. 데드락은 락 순서가 한 방향이라 없습니다 — 스케줄러는 리스트 락 → 러너 락 순이고, 탭 경로는 `stream()`으로 찾아 리스트 락을 잡지 않습니다.

**통합 테스트의 탭 주기 400ms는 Rate Limiter 때문에 정했습니다.** 한 세션이 4명분을 보내므로 200ms로 줄이면 초당 20건, 정확히 상한에 걸립니다. #1664가 그 상황에서 났습니다.

# 🙅 이번에 하지 않은 것

- **경기 시간 상한(#1713).** 탭이 끊긴 러너는 이제 최저 속도로 기어가는데, 종료 조건이 전원 정지라 나머지가 최대 80초 넘게 기다립니다. 상한 부재 자체는 선행 구멍이지만(처음부터 안 누른 러너는 지금도 100초) 이번 변경이 노출도를 넓혔습니다. 강제 종료 시 `finishTime`·순위 처리 설계가 필요해 분리했습니다.
- **서비스 계층 시각 주입(#1714).** #1632의 이음매가 도메인까지만 왔습니다. `CapturingScheduler`로 타이밍을 검증하려면 서비스도 시각을 주입받아야 합니다.
- **매 틱 CPS 재계산(이슈의 방법 B).** 원래 의도에 가장 충실하지만 탭 이력 보관이 필요해 변경이 큽니다. 감쇠만으로 리포트된 증상이 해소됩니다.
- **`Clock` 빈 주입.** `ClockConfig`는 있지만 `RacingGameService`는 다른 네 곳에서도 `Instant.now()`를 씁니다. 여기만 바꾸면 반쪽입니다.
- **완주 기록의 밀리초 절삭.** 프로덕션은 틱이 100ms 간격이라 두 러너가 같은 밀리초에 완주할 일이 없습니다.
- **`RacingGameService.java`의 포맷 변경.** Spotless가 `ratchetFrom("origin/dev")`으로 걸려 있어 건드린 파일은 전체가 재정렬됩니다. 로직 변경은 `executeAutoMove` 한 줄입니다.
