### PR TITLE
[test] 미니게임 종료→결과 저장 이음매를 게임별 통합 테스트로 보장 (레이싱 외 6종)

### DIFF
--- a/backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveIntegrationTest.java
@@ -3,6 +3,7 @@ package coffeeshout.minigame.event;
 import static org.awaitility.Awaitility.await;
 
 import coffeeshout.GameModuleIntegrationTest;
+import coffeeshout.blindtimer.application.BlindTimerGameProgressHandler;
 import coffeeshout.blindtimer.domain.BlindTimerGame;
 import coffeeshout.blockstacking.domain.BlockStackingGame;
 import coffeeshout.fixture.CardGameDeckStub;
@@ -83,6 +84,9 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
     @Autowired
     UserJpaRepository userJpaRepository;
 
+    @Autowired
+    BlindTimerGameProgressHandler blindTimerProgressHandler;
+
     JoinCode joinCode;
     Gamer host;
     List<Gamer> gamers;
@@ -127,17 +131,16 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
 
     @Test
     void 블라인드타이머_종료시_결과와_정산_이벤트가_저장된다() {
-        // 종료는 targetTime + timeoutBuffer(3s)에 예약된다. 목표 시간을 줄여 입력 없이 타임아웃으로 끝낸다
-        // (미입력 플레이어는 BlindTimerScore.ofTimeout으로 채점되므로 결과는 그대로 만들어진다).
-        게임을_시작한다(new BlindTimerGame(Duration.ofMillis(500)));
+        final BlindTimerGame game = 게임을_시작한다(new BlindTimerGame(Duration.ofSeconds(10)));
+
+        전원_STOP시킨다(game);
 
         결과_저장과_정산_아웃박스를_확인한다(MiniGameType.BLIND_TIMER);
     }
 
     @Test
     void 스피드터치_종료시_결과와_정산_이벤트가_저장된다() {
-        final SpeedTouchGame game = new SpeedTouchGame();
-        게임을_시작한다(game);
+        final SpeedTouchGame game = 게임을_시작한다(new SpeedTouchGame());
 
         전원_완주시킨다(game);
 
@@ -145,7 +148,20 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
     }
 
     /**
-     * 스피드터치만 종료에 입력이 필요하다 — playing 타임아웃이 30초라 기다릴 수 없다.
+     * 타임아웃(목표시간 + 버퍼 3초)을 기다리지 않고 전원 STOP으로 끝낸다. 기다리는 쪽이 코드는 짧지만 3.5초를
+     * 순수 대기로 쓰고, 프로덕션에서 훨씬 흔한 경로는 전원이 멈춰 끝나는 쪽이다. 스피드터치와 같은 이유로 WS가
+     * 아니라 컨슈머가 호출하는 진입점을 직접 부른다.
+     */
+    private void 전원_STOP시킨다(BlindTimerGame game) {
+        await().atMost(Duration.ofSeconds(5)).until(game::isPlaying);
+
+        for (Gamer gamer : gamers) {
+            blindTimerProgressHandler.handleStop(joinCode.getValue(), gamer.getName());
+        }
+    }
+
+    /**
+     * 스피드터치는 종료에 입력이 필요하다 — playing 타임아웃이 30초라 기다릴 수 없다.
      *
      * <p>터치를 WS로 보내지 않고 컨슈머가 호출하는 애플리케이션 진입점을 직접 부른다. 전원 25회 = 100번의 WS
      * 왕복은 느린 데다, Rate Limiter가 세션당 초당 20건 초과분을 조용히 드롭해 완주가 부하에 따라 갈린다(#1664).
@@ -169,17 +185,21 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
      * <p>방은 도메인 {@code Room}(인메모리)과 {@code RoomEntity}(DB)를 둘 다 채워야 한다 — 저장 리스너가
      * {@code RoomSnapshotQuery}로 room_session id와 player id를 해석하기 때문이다.
      */
-    private void 게임을_시작한다(Playable game) {
+    private <T extends Playable> T 게임을_시작한다(T game) {
         final Room room = RoomFixture.호스트_꾹이(joinCode);
         room.getPlayers().forEach(player -> player.updateReadyState(true));
         roomRepository.save(room);
         roomEntityRepository.save(new RoomEntity(joinCode.getValue()));
 
+        // 세션 맵은 컨텍스트 수명인데 joinCode 유일성을 보장하는 Redis 레지스트리는 매 테스트 flush된다.
+        // 두 수명이 어긋나 같은 코드가 재발급되면 initSession이 조용히 no-op이 되어 직전 세션을 물려받는다.
+        gameSessionService.deleteSession(joinCode);
         gameSessionService.initSession(joinCode, host);
         gameSessionService.getSession(joinCode).replaceGames(host, List.of(game));
 
         eventPublisher.publishEvent(
                 new GameStartReadyEvent("evt-" + joinCode.getValue(), joinCode.getValue(), host.getName(), gamers));
+        return game;
     }
 
     /**
@@ -208,14 +228,18 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
      */
     private Integer 정산_아웃박스_수(MiniGameType miniGameType) {
         return jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM outbox_event WHERE stream_key = ? AND payload LIKE ?",
+                "SELECT COUNT(*) FROM outbox_event WHERE stream_key = ? AND payload LIKE ? ESCAPE '!'",
                 Integer.class,
                 SettlementStreamKey.RESULT.getRedisKey(),
-                "%" + miniGameType.name() + "%");
+                "%" + miniGameType.name().replace("_", "!_") + "%");
     }
 
     private Long 회원_한_명을_만든다() {
-        return userJpaRepository.save(new UserEntity("T1663", "루키")).getId();
+        // user_code는 UNIQUE고 DB 정리 실패는 로그만 남기고 삼켜진다(TestContainerSupport). 테스트마다 다른
+        // 코드를 써서 정리 성공 여부에 기대지 않는다. joinCode가 4자라 접두어 T를 붙이면 정확히 5자다.
+        return userJpaRepository
+                .save(new UserEntity("T" + joinCode.getValue(), "루키"))
+                .getId();
     }
 
     private List<Gamer> 루키를_회원으로_바꾼_명단(Long userId) {

--- a/backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveIntegrationTest.java
@@ -1,6 +1,5 @@
 package coffeeshout.minigame.event;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import coffeeshout.GameModuleIntegrationTest;
@@ -23,11 +22,15 @@ import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.repository.RoomRepository;
 import coffeeshout.room.domain.service.JoinCodeGenerator;
 import coffeeshout.room.infra.persistence.RoomEntity;
+import coffeeshout.settlement.infra.SettlementStreamKey;
 import coffeeshout.speedtouch.application.SpeedTouchGameProgressHandler;
 import coffeeshout.speedtouch.domain.SpeedTouchGame;
 import coffeeshout.speedtouch.domain.SpeedTouchPlayer;
+import coffeeshout.user.infra.persistence.UserEntity;
+import coffeeshout.user.infra.persistence.UserJpaRepository;
 import java.time.Duration;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,6 +80,9 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
     @Autowired
     SpeedTouchGameProgressHandler speedTouchProgressHandler;
 
+    @Autowired
+    UserJpaRepository userJpaRepository;
+
     JoinCode joinCode;
     Gamer host;
     List<Gamer> gamers;
@@ -91,28 +97,28 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
     }
 
     @Test
-    void 카드게임_종료시_결과가_저장된다() {
+    void 카드게임_종료시_결과와_정산_이벤트가_저장된다() {
         게임을_시작한다(new CardGameFake(new CardGameDeckStub()));
 
         결과_저장과_정산_아웃박스를_확인한다(MiniGameType.CARD_GAME);
     }
 
     @Test
-    void 사다리게임_종료시_결과가_저장된다() {
+    void 사다리게임_종료시_결과와_정산_이벤트가_저장된다() {
         게임을_시작한다(new LadderGame());
 
         결과_저장과_정산_아웃박스를_확인한다(MiniGameType.LADDER_GAME);
     }
 
     @Test
-    void 블록쌓기_종료시_결과가_저장된다() {
+    void 블록쌓기_종료시_결과와_정산_이벤트가_저장된다() {
         게임을_시작한다(new BlockStackingGame());
 
         결과_저장과_정산_아웃박스를_확인한다(MiniGameType.BLOCK_STACKING);
     }
 
     @Test
-    void 눈치게임_종료시_결과가_저장된다() {
+    void 눈치게임_종료시_결과와_정산_이벤트가_저장된다() {
         // 아무도 누르지 않으면 idle 타임아웃(500ms)으로 종료된다.
         게임을_시작한다(new NunchiGame(nunchiTiming.numberWindow().toMillis()));
 
@@ -120,7 +126,7 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
     }
 
     @Test
-    void 블라인드타이머_종료시_결과가_저장된다() {
+    void 블라인드타이머_종료시_결과와_정산_이벤트가_저장된다() {
         // 종료는 targetTime + timeoutBuffer(3s)에 예약된다. 목표 시간을 줄여 입력 없이 타임아웃으로 끝낸다
         // (미입력 플레이어는 BlindTimerScore.ofTimeout으로 채점되므로 결과는 그대로 만들어진다).
         게임을_시작한다(new BlindTimerGame(Duration.ofMillis(500)));
@@ -129,7 +135,7 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
     }
 
     @Test
-    void 스피드터치_종료시_결과가_저장된다() {
+    void 스피드터치_종료시_결과와_정산_이벤트가_저장된다() {
         final SpeedTouchGame game = new SpeedTouchGame();
         게임을_시작한다(game);
 
@@ -169,7 +175,6 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
         roomRepository.save(room);
         roomEntityRepository.save(new RoomEntity(joinCode.getValue()));
 
-        gameSessionService.deleteSession(joinCode);
         gameSessionService.initSession(joinCode, host);
         gameSessionService.getSession(joinCode).replaceGames(host, List.of(game));
 
@@ -182,10 +187,11 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
      * (2라운드 × playing 2s)을 기준으로 넉넉히 잡는다.
      */
     private void 결과_저장과_정산_아웃박스를_확인한다(MiniGameType miniGameType) {
-        await().atMost(Duration.ofSeconds(20)).untilAsserted(() -> {
-            assertThat(저장된_결과_수(miniGameType)).isEqualTo(gamers.size());
-            assertThat(정산_아웃박스_수(miniGameType)).isEqualTo(1);
-        });
+        await().atMost(Duration.ofSeconds(20))
+                .untilAsserted(() -> SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(저장된_결과_수(miniGameType)).isEqualTo(gamers.size());
+                    softly.assertThat(정산_아웃박스_수(miniGameType)).isEqualTo(1);
+                }));
     }
 
     private Integer 저장된_결과_수(MiniGameType miniGameType) {
@@ -193,20 +199,23 @@ class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
                 "SELECT COUNT(*) FROM mini_game_result WHERE mini_game_type = ?", Integer.class, miniGameType.name());
     }
 
-    /** 정산 이벤트는 결과 저장과 같은 트랜잭션에서 Outbox에 기록된다(#1610). 릴레이는 행을 지우지 않고 상태만 바꾼다. */
+    /**
+     * 정산 이벤트는 결과 저장과 같은 트랜잭션에서 Outbox에 기록된다(#1610). 릴레이는 행을 지우지 않고 상태만 바꾼다.
+     *
+     * <p>스트림 키만으로도 테스트당 게임이 하나라 충분하지만 payload의 게임 타입까지 건다. 게임 스케줄러는 컨텍스트
+     * 수명이라 앞선 테스트가 남긴 종료 태스크가 이 테스트 도중 발화할 수 있고, 그때 격리를 보장하는 것이 타입
+     * 필터다(레이싱 IT가 같은 이유로 스케줄러 큐를 비운다).
+     */
     private Integer 정산_아웃박스_수(MiniGameType miniGameType) {
         return jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM outbox_event WHERE stream_key = 'settlement:result' AND payload LIKE ?",
+                "SELECT COUNT(*) FROM outbox_event WHERE stream_key = ? AND payload LIKE ?",
                 Integer.class,
+                SettlementStreamKey.RESULT.getRedisKey(),
                 "%" + miniGameType.name() + "%");
     }
 
     private Long 회원_한_명을_만든다() {
-        jdbcTemplate.update(
-                "INSERT INTO app_user (user_code, nickname, created_at, updated_at) VALUES (?, ?, NOW(6), NOW(6))",
-                "T1663",
-                "루키");
-        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+        return userJpaRepository.save(new UserEntity("T1663", "루키")).getId();
     }
 
     private List<Gamer> 루키를_회원으로_바꾼_명단(Long userId) {

--- a/backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveIntegrationTest.java
@@ -1,0 +1,218 @@
+package coffeeshout.minigame.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import coffeeshout.GameModuleIntegrationTest;
+import coffeeshout.blindtimer.domain.BlindTimerGame;
+import coffeeshout.blockstacking.domain.BlockStackingGame;
+import coffeeshout.fixture.CardGameDeckStub;
+import coffeeshout.fixture.CardGameFake;
+import coffeeshout.fixture.GamerFixture;
+import coffeeshout.fixture.RoomFixture;
+import coffeeshout.gamecommon.Gamer;
+import coffeeshout.gamecommon.JoinCode;
+import coffeeshout.gamecommon.Playable;
+import coffeeshout.laddergame.domain.LadderGame;
+import coffeeshout.minigame.application.GameSessionService;
+import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.nunchi.config.NunchiTimingProperties;
+import coffeeshout.nunchi.domain.NunchiGame;
+import coffeeshout.room.application.port.RoomEntityRepository;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.repository.RoomRepository;
+import coffeeshout.room.domain.service.JoinCodeGenerator;
+import coffeeshout.room.infra.persistence.RoomEntity;
+import coffeeshout.speedtouch.application.SpeedTouchGameProgressHandler;
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+import coffeeshout.speedtouch.domain.SpeedTouchPlayer;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * 미니게임 종료 → 결과 저장 이음매를 게임별로 보장한다(#1663).
+ *
+ * <p>검증 대상은 개별 게임의 진행 규칙이 아니라 <b>종료 시 {@code MiniGameFinishedEvent}의 부수효과</b>(결과
+ * 영속·시즌 정산 Outbox 기록)다. 이 이음매는 어느 계층에서도 검증되지 않아, 레이싱 결과가 프로덕션에서 통째로
+ * 유실되는 동안에도 전체 스위트가 초록이었다(#1662). 서비스 테스트는 이벤트 퍼블리셔가 mock이라 리스너가 아예
+ * 돌지 않고, 리스너 단위 테스트는 저장소를 mock한 채 {@code handle}을 직접 부르며, 게임별 IT는 종료 <b>신호</b>
+ * (DONE 브로드캐스트)까지만 본다. DONE 브로드캐스트는 저장 이벤트보다 앞줄에 예약되므로 저장이 통째로 깨져도
+ * 종료만 보는 테스트는 통과한다.
+ *
+ * <p>레이싱은 {@code RacingGameIntegrationTest}가 덮으므로 여기서는 나머지 6종을 다룬다. 게임별 IT에 나눠 넣지
+ * 않은 이유는 기존 IT들이 방을 DB에 만들지 않고({@code :game}만으로 시작) 저장 경로가 애초에 돌지 않기 때문이다 —
+ * 6곳에 같은 방 영속 셋업을 복붙하는 대신 여기 한 벌만 둔다.
+ *
+ * <p>WebSocket을 쓰지 않는다. 이 이음매는 STOMP 전송과 무관하고, 게임 IT들이 겪은 트레일링 브로드캐스트 누수를
+ * 피할 수 있다.
+ */
+class MiniGameResultSaveIntegrationTest extends GameModuleIntegrationTest {
+
+    @Autowired
+    GameSessionService gameSessionService;
+
+    @Autowired
+    RoomRepository roomRepository;
+
+    @Autowired
+    RoomEntityRepository roomEntityRepository;
+
+    @Autowired
+    ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    JoinCodeGenerator joinCodeGenerator;
+
+    @Autowired
+    NunchiTimingProperties nunchiTiming;
+
+    @Autowired
+    SpeedTouchGameProgressHandler speedTouchProgressHandler;
+
+    JoinCode joinCode;
+    Gamer host;
+    List<Gamer> gamers;
+
+    @BeforeEach
+    void setUp() {
+        joinCode = joinCodeGenerator.generate();
+        host = GamerFixture.호스트_꾹이();
+        // Outbox 기록은 회원(userId != null)만 담기므로 전원 게스트면 정산 이벤트 자체가 안 만들어진다.
+        // 호스트를 회원으로 만들면 세션 호스트(게스트로 생성) 동일성 비교가 얽히므로 루키를 회원으로 둔다.
+        gamers = 루키를_회원으로_바꾼_명단(회원_한_명을_만든다());
+    }
+
+    @Test
+    void 카드게임_종료시_결과가_저장된다() {
+        게임을_시작한다(new CardGameFake(new CardGameDeckStub()));
+
+        결과_저장과_정산_아웃박스를_확인한다(MiniGameType.CARD_GAME);
+    }
+
+    @Test
+    void 사다리게임_종료시_결과가_저장된다() {
+        게임을_시작한다(new LadderGame());
+
+        결과_저장과_정산_아웃박스를_확인한다(MiniGameType.LADDER_GAME);
+    }
+
+    @Test
+    void 블록쌓기_종료시_결과가_저장된다() {
+        게임을_시작한다(new BlockStackingGame());
+
+        결과_저장과_정산_아웃박스를_확인한다(MiniGameType.BLOCK_STACKING);
+    }
+
+    @Test
+    void 눈치게임_종료시_결과가_저장된다() {
+        // 아무도 누르지 않으면 idle 타임아웃(500ms)으로 종료된다.
+        게임을_시작한다(new NunchiGame(nunchiTiming.numberWindow().toMillis()));
+
+        결과_저장과_정산_아웃박스를_확인한다(MiniGameType.NUNCHI_GAME);
+    }
+
+    @Test
+    void 블라인드타이머_종료시_결과가_저장된다() {
+        // 종료는 targetTime + timeoutBuffer(3s)에 예약된다. 목표 시간을 줄여 입력 없이 타임아웃으로 끝낸다
+        // (미입력 플레이어는 BlindTimerScore.ofTimeout으로 채점되므로 결과는 그대로 만들어진다).
+        게임을_시작한다(new BlindTimerGame(Duration.ofMillis(500)));
+
+        결과_저장과_정산_아웃박스를_확인한다(MiniGameType.BLIND_TIMER);
+    }
+
+    @Test
+    void 스피드터치_종료시_결과가_저장된다() {
+        final SpeedTouchGame game = new SpeedTouchGame();
+        게임을_시작한다(game);
+
+        전원_완주시킨다(game);
+
+        결과_저장과_정산_아웃박스를_확인한다(MiniGameType.SPEED_TOUCH);
+    }
+
+    /**
+     * 스피드터치만 종료에 입력이 필요하다 — playing 타임아웃이 30초라 기다릴 수 없다.
+     *
+     * <p>터치를 WS로 보내지 않고 컨슈머가 호출하는 애플리케이션 진입점을 직접 부른다. 전원 25회 = 100번의 WS
+     * 왕복은 느린 데다, Rate Limiter가 세션당 초당 20건 초과분을 조용히 드롭해 완주가 부하에 따라 갈린다(#1664).
+     * 종료 판정({@code isAllFinished} → {@code finishGame})은 이 진입점 안에서 일어나므로 저장 경로는 동일하다.
+     */
+    private void 전원_완주시킨다(SpeedTouchGame game) {
+        await().atMost(Duration.ofSeconds(5)).until(game::isPlaying);
+
+        for (Gamer gamer : gamers) {
+            for (int number = 1; number <= SpeedTouchPlayer.LAST_NUMBER; number++) {
+                speedTouchProgressHandler.handleTouch(joinCode.getValue(), gamer.getName(), number);
+            }
+        }
+    }
+
+    /**
+     * 프로덕션 시작 경로({@code :room}의 {@code MiniGameStartConsumer}가 발행하는 {@code GameStartReadyEvent})부터
+     * 태운다. 기존 게임 IT들처럼 {@code service.start()}를 직접 부르면 {@code MiniGamePersistenceService}가
+     * 건너뛰어져 {@code MiniGameEntity}가 없고, 저장 리스너가 "미니게임 엔티티가 존재하지 않습니다"로 죽는다.
+     *
+     * <p>방은 도메인 {@code Room}(인메모리)과 {@code RoomEntity}(DB)를 둘 다 채워야 한다 — 저장 리스너가
+     * {@code RoomSnapshotQuery}로 room_session id와 player id를 해석하기 때문이다.
+     */
+    private void 게임을_시작한다(Playable game) {
+        final Room room = RoomFixture.호스트_꾹이(joinCode);
+        room.getPlayers().forEach(player -> player.updateReadyState(true));
+        roomRepository.save(room);
+        roomEntityRepository.save(new RoomEntity(joinCode.getValue()));
+
+        gameSessionService.deleteSession(joinCode);
+        gameSessionService.initSession(joinCode, host);
+        gameSessionService.getSession(joinCode).replaceGames(host, List.of(game));
+
+        eventPublisher.publishEvent(
+                new GameStartReadyEvent("evt-" + joinCode.getValue(), joinCode.getValue(), host.getName(), gamers));
+    }
+
+    /**
+     * 저장은 게임마다 다른 스케줄러 스레드에서 일어나므로 폴링으로 기다린다. 상한은 가장 느린 카드게임
+     * (2라운드 × playing 2s)을 기준으로 넉넉히 잡는다.
+     */
+    private void 결과_저장과_정산_아웃박스를_확인한다(MiniGameType miniGameType) {
+        await().atMost(Duration.ofSeconds(20)).untilAsserted(() -> {
+            assertThat(저장된_결과_수(miniGameType)).isEqualTo(gamers.size());
+            assertThat(정산_아웃박스_수(miniGameType)).isEqualTo(1);
+        });
+    }
+
+    private Integer 저장된_결과_수(MiniGameType miniGameType) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mini_game_result WHERE mini_game_type = ?", Integer.class, miniGameType.name());
+    }
+
+    /** 정산 이벤트는 결과 저장과 같은 트랜잭션에서 Outbox에 기록된다(#1610). 릴레이는 행을 지우지 않고 상태만 바꾼다. */
+    private Integer 정산_아웃박스_수(MiniGameType miniGameType) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM outbox_event WHERE stream_key = 'settlement:result' AND payload LIKE ?",
+                Integer.class,
+                "%" + miniGameType.name() + "%");
+    }
+
+    private Long 회원_한_명을_만든다() {
+        jdbcTemplate.update(
+                "INSERT INTO app_user (user_code, nickname, created_at, updated_at) VALUES (?, ?, NOW(6), NOW(6))",
+                "T1663",
+                "루키");
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+    }
+
+    private List<Gamer> 루키를_회원으로_바꾼_명단(Long userId) {
+        return GamerFixture.꾹이_루키_엠제이_한스().stream()
+                .map(gamer ->
+                        "루키".equals(gamer.getName()) ? Gamer.of(gamer.getName(), userId, gamer.getColorIndex()) : gamer)
+                .toList();
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1663

# 🚀 작업 내용

## 무엇이 달라지는가

미니게임이 끝났을 때 결과가 실제로 DB에 남는지를, 게임 6종 각각에 대해 테스트가 확인한다. 지금까지는 레이싱만 확인하고 있었다. 저장이 통째로 깨져도 나머지 6종에서는 아무 테스트도 빨개지지 않았다.

## 왜 바꿨는가

**게임 종료 뒤에 일어나는 저장을 어느 계층도 보고 있지 않다.** 종료 시 `MiniGameFinishedEvent`가 발행되고, 그 리스너가 결과를 저장하고 시즌 정산 이벤트를 기록한다. 이 이음매가 검증되지 않은 채로 남아 있다.

계층마다 못 보는 이유가 다르다. 서비스 테스트는 이벤트 발행기를 mock으로 바꿔 놓아서 리스너가 아예 실행되지 않는다. 리스너 단위 테스트는 저장소를 전부 mock한 채 `handle`을 직접 부르므로 매핑 로직만 본다. 게임별 통합 테스트는 실제 경로가 도는 유일한 계층이지만 종료 **신호**까지만 검증한다.

이 마지막 항목이 특히 위험하다. 종료를 알리는 DONE 브로드캐스트는 저장 이벤트보다 **앞줄에** 예약된다. 그래서 저장이 완전히 실패해도 DONE은 정상적으로 나가고, 종료만 보는 테스트는 초록으로 통과한다. #1662에서 레이싱 결과가 프로덕션에서 유실되는 동안 스위트 전체가 초록이었던 게 이 때문이다.

지금 6종은 실제로 저장되고 있어 장애 상태는 아니다. 다만 종료 트리거가 게임마다 제각각이라 같은 계열의 회귀가 어느 게임에서든 재발할 수 있다. 재발하면 소급 복구가 불가능한 데이터 유실이고, 조용히 유실되므로 알림도 없다.

## 흐름 그림

```mermaid
sequenceDiagram
    participant G as 미니게임
    participant S as 게임 서비스
    participant L as 결과 저장 리스너
    participant DB as MySQL
    G->>S: 종료 조건 충족
    S-->>G: DONE 브로드캐스트 (먼저 나간다)
    S->>L: MiniGameFinishedEvent
    L->>DB: mini_game_result 저장
    L->>DB: outbox_event (정산) 기록
```

기존 테스트는 `DONE 브로드캐스트`까지만 확인했다. 이번 PR은 그 아래 두 줄을 확인한다.

## 변경 목록

1. 6종의 종료 → 저장을 검증하는 통합 테스트를 한 파일에 추가했다. 게임별 테스트에 나눠 넣지 않은 이유는 검증 대상이 개별 게임의 진행 규칙이 아니라 종료 이후의 공통 이음매 하나이기 때문이다. `backend/game/src/test/java/coffeeshout/minigame/event/MiniGameResultSaveIntegrationTest.java`

2. 게임 시작을 `GameStartReadyEvent` 발행으로 태운다. 기존 게임 테스트처럼 서비스의 `start()`를 직접 부르면 미니게임 엔티티를 만드는 단계가 통째로 건너뛰어져, 저장 리스너가 "미니게임 엔티티가 존재하지 않습니다"로 죽는다. 레이싱 테스트가 쓰는 방식과 같다.

3. 방을 인메모리와 DB 양쪽에 만든다. 저장 리스너가 방 세션 id와 플레이어 id를 조회로 해석하기 때문이다. 기존 게임 테스트들은 방을 DB에 만들지 않아 저장 경로가 애초에 돌지 않는다.

4. 참가자 4명 중 1명을 회원으로 둔다. 시즌 정산 이벤트는 로그인 사용자만 담으므로 전원 게스트면 Outbox 기록 자체가 일어나지 않아 검증할 대상이 없다.

5. WebSocket을 쓰지 않고 `MOCK` 환경 통합 테스트로 작성했다. 이 이음매는 STOMP 전송과 무관하고, 게임 테스트들이 겪어 온 토픽 공유로 인한 브로드캐스트 누수를 피할 수 있다.

<details>
<summary>게임별 종료 트리거와 테스트에서 하는 일</summary>

| 게임 | 종료 트리거 | 테스트가 하는 일 |
| --- | --- | --- |
| 카드게임 | 2라운드 소진 | 없음 (자동 종료) |
| 사다리게임 | 페이즈 소진 | 없음 (자동 종료) |
| 블록쌓기 | playing 타임아웃 2초 | 없음 (자동 종료) |
| 눈치게임 | idle 타임아웃 500ms | 없음 (자동 종료) |
| 블라인드타이머 | 목표시간 + 버퍼 3초 | 목표시간을 500ms로 줄여 타임아웃으로 끝냄 |
| 스피드터치 | 전원 25회 완주 | 터치 진입점을 직접 호출해 전원 완주 |

스피드터치만 입력이 필요하다. playing 타임아웃이 30초라 기다릴 수 없기 때문이다. 터치를 WebSocket으로 보내면 전원 25회 = 100번 왕복이라 느리고, Rate Limiter가 세션당 초당 20건 초과분을 조용히 드롭해 완주 여부가 부하에 따라 갈린다(#1664 CI 실패 이력). 그래서 컨슈머가 호출하는 애플리케이션 진입점을 그대로 부른다. 종료 판정과 저장 경로는 동일하다.

</details>

## 검증

`./gradlew :game:test` 전체 통과. 새 테스트 6종은 모두 초록이고 합계 약 45초다.

**저장을 깨면 실제로 빨개지는지 확인했다** (이슈 성공 기준 3). 리스너의 결과 저장 한 줄을 주석 처리하고 돌리자 6종 전부 실패했다.

```text
6 tests completed, 6 failed
```

확인 후 원상복구했으며, 이 PR의 diff에는 프로덕션 코드 변경이 없다.

# 💬 리뷰 중점사항

**한 파일에 6종을 모은 선택.** 게임별 테스트 파일에 하나씩 넣는 대안도 있었다. 그렇게 하면 6곳에 같은 방 영속 셋업이 복붙되고, 앞으로 시작 경로가 바뀔 때 6곳을 같이 고쳐야 한다. 반대로 한 파일에 모으면 게임을 찾아갈 때 두 곳을 봐야 한다. 후자를 택했는데, 다르게 보는 시각이 있으면 알려주세요.

**스피드터치만 애플리케이션 진입점을 직접 호출한다.** 다른 5종은 입력 없이 끝나므로 이 비대칭이 생겼다. WebSocket 왕복을 피한 이유는 위 접은 글에 적었다. 종료 판정이 그 진입점 안에 있어 저장 경로는 동일하지만, 이 정도 우회가 통합 테스트로서 괜찮은지 봐주세요.

**대기 상한 20초.** 가장 느린 카드게임(2라운드 × playing 2초)에 맞춘 값이다. CI 부하에서 부족할지 판단이 필요합니다.

# 🙅 이번에 하지 않은 것

- **레이싱**은 #1662에서 이미 덮여 있어 건드리지 않았다.
- **정산 소비 이후**(Outbox → Redis Stream → 정산 원장)는 범위 밖이다. 이번 검증은 Outbox 기록까지다. 그 뒤는 `SettlementConsumerGroupIntegrationTest`가 본다.
- **기존 6개 게임 통합 테스트**는 손대지 않았다. 그쪽은 여전히 진행·브로드캐스트를 담당한다.
