### PR TITLE
[docs] 카드게임 도메인모델 문서를 현행 코드와 일치하도록 갱신

### DIFF
--- a/backend/docs/카드게임도메인모델.md
+++ b/backend/docs/카드게임도메인모델.md
@@ -2,57 +2,69 @@
 
 ## 카드 게임 (CardGame)
 
+_implements Playable_
+
+### 상수
+
+- `ADDITION_CARD_COUNT = 7`: 덱의 덧셈 카드 수
+- `MULTIPLIER_CARD_COUNT = 2`: 덱의 곱셈 카드 수
+- `TOTAL_ROUNDS = 2`: 총 라운드 수
+
 ### 상태
 
-- `deck`: `Deck` 게임에 사용되는 카드 덱
+- `deck`: `Deck` 게임에 사용되는 카드 덱 (9장, 생성 시 확정)
+- `seed`: `long` 결정적 랜덤의 근원 — 덱 생성·셔플·랜덤 배정이 모두 이 시드에서 유도된다
 - `playerHands`: `PlayerHands` 플레이어들의 카드 핸드 관리
 - `round`: `CardGameRound` 현재 라운드
 - `state`: `CardGameState` 현재 게임 상태
 
 ### 행위
 
-- `getResult()`: 게임 결과를 반환한다.
-- `getMiniGameType()`: 미니게임 타입을 반환한다.
-- `startGame(List<Player>)`: 게임을 시작한다.
-- `getScores()`: 플레이어별 점수를 반환한다.
-- `startRound()`: 새 라운드를 시작한다.
-- `updateDescription()`: 설명 상태로 변경한다.
-- `startPlay()`: 게임 플레이를 시작한다.
-- `selectCard(Player, Integer)`: 플레이어가 카드를 선택한다.
+- `getResult()`: 게임 결과를 반환한다. (`MiniGameResult.fromDescending` — 점수 내림차순 순위)
+- `getMiniGameType()`: 미니게임 타입(`CARD_GAME`)을 반환한다.
+- `setUp(List<Gamer>)`: 참가자 목록으로 핸드를 초기화한다.
+- `getScores()`: 플레이어별 점수(`Map<Gamer, MiniGameScore>`)를 반환한다.
+- `startRound()`: 다음 라운드로 진행한다. 상태는 1라운드면 `FIRST_LOADING`, 이후 라운드면 `LOADING`.
+- `updateDescription()`: `PREPARE` 상태로 변경한다.
+- `startPlay()`: 덱을 시드 기반으로 섞고 `PLAYING` 상태로 변경한다. (`seed + 1000` — 덱 생성과 구별하기 위한 오프셋)
+- `selectCard(Gamer, Integer)`: 플레이어가 카드를 선택하고, **현재 라운드가 완료됐는지를 반환**한다.
 - `isFinishedThisRound()`: 현재 라운드가 끝났는지 확인한다.
-- `findPlayerByName(PlayerName)`: 이름으로 플레이어를 찾는다.
-- `assignRandomCardsToUnselectedPlayers()`: 선택하지 않은 플레이어들에게 랜덤 카드 배정
+- `isFirstRound()` / `isLastRound()`: 현재 라운드가 첫/마지막 라운드인지 확인한다.
+- `getTotalRounds()`: 총 라운드 수를 반환한다.
+- `findByName(String)`: 이름으로 참가자를 찾는다.
+- `assignRandomCardsToUnselectedPlayers()`: 미선택 플레이어들에게 남은 카드 중 랜덤 배정한다. (`seed + round.toIndex()` — 라운드별 일관 랜덤)
 - `findCardOwnerInCurrentRound(Card)`: 현재 라운드에서 특정 카드의 소유자를 찾는다.
 - `changeScoreBoardState()`: 점수판 상태로 변경
 - `changeDoneState()`: 완료 상태로 변경
 
 ### 규칙
 
-- 카드 선택은 게임이 PLAYING 상태일 때만 가능하다.
+- 카드 선택은 게임이 `PLAYING` 상태일 때만 가능하다. 그 외 상태에서는 `NOT_PLAYING_STATE` 비즈니스 예외가 발생한다.
 - 각 플레이어는 라운드마다 하나의 카드를 선택한다.
+- 같은 시드는 같은 덱 구성·셔플 순서·랜덤 배정을 만든다. (시드는 `CardGameFactory`가 `joinCode.hashCode()`에서 유도)
 
 ## 플레이어 핸드들 (PlayerHands)
 
 ### 상태
 
-- `playerHands`: `Map<Player, CardHand>` 플레이어별 카드 핸드
+- `playerHands`: `Map<Gamer, CardHand>` 플레이어별 카드 핸드
 
 ### 행위
 
-- `put(Player, Card)`: 플레이어에게 카드를 배정한다.
+- `put(Gamer, Card)`: 플레이어에게 카드를 배정한다.
 - `totalHandSize()`: 모든 플레이어의 총 카드 수를 반환한다.
 - `playerCount()`: 플레이어 수를 반환한다.
-- `isRoundFinished()`: 라운드가 끝났는지 확인한다.
-- `findPlayerByName(PlayerName)`: 이름으로 플레이어를 찾는다.
-- `scoreByPlayer()`: 플레이어별 점수를 계산한다.
+- `isRoundFinished(CardGameRound)`: 해당 라운드가 끝났는지(전원 선택) 확인한다.
+- `findByName(String)`: 이름으로 참가자를 찾는다. 없으면 비즈니스 예외.
+- `scoreByPlayer()`: 플레이어별 점수를 계산한다. 카드가 없는 참가자도 0점으로 포함된다.
 - `getUnselectedPlayers(CardGameRound)`: 특정 라운드에서 카드를 선택하지 않은 플레이어들을 반환한다.
-- `findCardOwner(Card, CardGameRound)`: 특정 라운드에서 카드의 소유자를 찾는다.
+- `findCardOwner(Card, CardGameRound)`: 특정 라운드에서 카드의 소유자를 찾는다. 라운드 스코프 — 다른 라운드에 배정된 카드는 소유자 없음이다.
 
 ## 카드 핸드 (CardHand)
 
 ### 상태
 
-- `hand`: `List<Card>` 플레이어가 보유한 카드들
+- `hand`: `List<Card>` 플레이어가 보유한 카드들. **N번째 카드 = N라운드에 얻은 카드**
 
 ### 행위
 
@@ -72,34 +84,37 @@
 
 ### 행위
 
-- `shuffle()`: 카드를 섞고 선택된 카드 목록을 초기화한다.
+- `shuffle(Random)` / `shuffle()`: 카드를 섞고 선택된 카드 목록을 초기화한다. 시드 결정성이 필요하면 `Random`을 주입한다.
 - `pick(int)`: 특정 인덱스의 카드를 선택한다.
-- `pickRandom()`: 랜덤하게 카드를 선택한다.
+- `pickRandom(Random)` / `pickRandom()`: 미선택 카드 중 랜덤하게 선택한다.
 - `size()`: 덱의 크기를 반환한다.
 
 ### 규칙
 
 - 이미 선택된 카드는 다시 선택할 수 없다.
+- 랜덤 선택은 아직 선택되지 않은 카드 중에서만 뽑는다.
 
 ## 카드 게임 라운드 (CardGameRound)
 
-_Enum_
+_값 객체 (Class)_
 
-### 상수
+### 상태
 
-- `READY`: 준비 상태
-- `FIRST`: 첫 번째 라운드
-- `SECOND`: 두 번째 라운드
-- `END`: 게임 종료
+- `number`: `int` 현재 라운드 번호 (0 = 준비)
+- `totalRounds`: `int` 총 라운드 수
 
 ### 행위
 
+- `ready(int)`: 준비 상태(번호 0)의 라운드를 생성한다.
+- `roundOf(int, int)`: 특정 번호의 라운드를 생성한다.
+- `isReady()` / `isFirst()` / `isLast()`: 준비/첫/마지막 라운드인지 확인한다.
 - `next()`: 다음 라운드를 반환한다.
-- `toInteger()`: 라운드를 정수로 변환한다.
+- `toIndex()`: 라운드 번호를 반환한다. (준비=0, 1라운드=1, …)
+- `getTotalRounds()`: 총 라운드 수를 반환한다.
 
 ### 규칙
 
-- 마지막 라운드에서는 next()를 호출할 수 없다.
+- 마지막 라운드에서는 `next()`를 호출할 수 없다.
 
 ## 카드 게임 상태 (CardGameState)
 
@@ -108,15 +123,28 @@ _Enum_
 ### 상수
 
 - `READY`: 준비 상태
-- `LOADING`: 로딩 상태
-- `DESCRIPTION`: 설명 상태
+- `FIRST_LOADING`: 1라운드 로딩 상태
+- `LOADING`: 2라운드 이후 로딩 상태
+- `PREPARE`: 준비(설명) 상태 — 1라운드에만 나타난다
 - `PLAYING`: 플레이 상태
 - `SCORE_BOARD`: 점수판 상태
 - `DONE`: 완료 상태
 
-### 상태
+> 각 상태의 지속 시간은 도메인이 아니라 설정(`card-game.timing`, `CardGameTimingProperties`)이 관리한다.
 
-- `duration`: `int` 각 상태의 지속 시간(밀리초)
+## 카드 게임 스텝 (CardGameStep)
+
+_Enum — 각 스텝이 `execute(CardGame)`로 도메인 전이를 수행한다_
+
+### 상수
+
+- `START_ROUND`: 라운드를 시작한다. (`startRound`)
+- `PREPARE`: 준비 상태로 전환한다. (`updateDescription`)
+- `START_PLAY`: 플레이를 시작한다. (`startPlay`)
+- `FINISH_ROUND`: 미선택자에게 랜덤 카드를 배정하고 점수판 상태로 전환한다.
+- `FINISH_GAME`: 게임을 완료 상태로 전환한다.
+
+> 스텝의 스케줄링(체류 시간·조기 종료)은 `CardGameFlowOrchestrator`가 `FlowScheduler`(`:game-api`)로 수행한다 — [아키텍처 레퍼런스](architecture.md)의 Flow 스케줄링 참조.
 
 ## 카드 (Card)
 
@@ -160,7 +188,7 @@ _extends Card_
 
 ### 행위
 
-- `pickCards(int)`: 지정된 수만큼 덧셈 카드를 랜덤하게 선택한다.
+- `pickCards(int, Random)`: 지정된 수만큼 덧셈 카드를 랜덤하게 선택한다. 풀 상한을 초과하면 예외.
 
 ## 곱셈 카드들 (MultiplierCards)
 
@@ -170,7 +198,7 @@ _extends Card_
 
 ### 행위
 
-- `pickCards(int)`: 지정된 수만큼 곱셈 카드를 랜덤하게 선택한다.
+- `pickCards(int, Random)`: 지정된 수만큼 곱셈 카드를 랜덤하게 선택한다. 풀 상한을 초과하면 예외.
 
 ## 카드 게임 점수 (CardGameScore)
 
@@ -178,12 +206,12 @@ _extends MiniGameScore_
 
 ### 상태
 
-- `addition`: `int` 덧셈 점수
-- `multiplier`: `int` 곱셈 점수
+- `addition`: `int` 덧셈 점수 (초기값 0)
+- `multiplier`: `int` 곱셈 점수 (초기값 1)
 
 ### 행위
 
-- `getValue()`: 최종 점수를 계산한다. (addition * multiplier)
+- `getValue()`: 최종 점수를 계산한다. (`(long) addition * multiplier` — 핸드의 덧셈 카드를 모두 더한 뒤 곱셈 카드를 모두 곱한다)
 
 ## 카드 덱 생성기 (CardGameDeckGenerator)
 
@@ -191,7 +219,7 @@ _Interface_
 
 ### 행위
 
-- `generate(int, int)`: `Deck`를 생성하여 반환한다.
+- `generate(int, int, long)`: 덧셈·곱셈 카드 수와 시드로 `Deck`을 생성하여 반환한다.
 
 ## 랜덤 카드 덱 생성기 (CardGameRandomDeckGenerator)
 
@@ -199,16 +227,4 @@ _implements CardGameDeckGenerator_
 
 ### 행위
 
-- `generate(int, int)`: 덧셈 카드와 곱셈 카드를 조합해서 랜덤 덱을 생성한다.
-
-## 카드 게임 태스크 실행기 (CardGameTaskExecutorsV2)
-
-### 상태
-
-- `roomTaskExecutorMap`: `Map<JoinCode, MiniGameTaskManager<CardGameTaskType>>` 방별 태스크 실행기 매핑
-
-### 행위
-
-- `put(JoinCode, MiniGameTaskManager<CardGameTaskType>)`: 태스크 실행기를 등록한다.
-- `get(JoinCode)`: 특정 방의 태스크 실행기를 반환한다.
-- `cancelPlaying(JoinCode, CardGameTaskType)`: 진행중인 태스크를 취소한다.
+- `generate(int, int, long)`: 시드 기반 랜덤으로 덧셈 카드와 곱셈 카드를 조합해 덱을 생성한다. 같은 시드는 같은 덱을 만든다.


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- 없음 (경량 경로 — 문서 전용, `scope.sh` `SRC_EMPTY=1`)

# 🚀 작업 내용

1. `backend/docs/카드게임도메인모델.md`가 과거 구현 기준으로 남아 코드와 어긋난 항목들을 현행 코드 기준으로 갱신했습니다.
   - **CardGameState**: `DESCRIPTION`·`duration` 필드 제거, 실제 상태 집합(`READY / FIRST_LOADING / LOADING / PREPARE / PLAYING / SCORE_BOARD / DONE`) 반영. 지속 시간은 도메인이 아니라 `CardGameTimingProperties`(`card-game.timing`) 소관임을 명시
   - **CardGameRound**: enum(`READY/FIRST/SECOND/END`)이 아니라 `number`/`totalRounds` 값 객체 — `ready()`, `roundOf()`, `isFirst/isLast`, `toIndex()` 반영
   - **CardGame**: `startGame(List<Player>)` → `setUp(List<Gamer>)`, `selectCard`가 라운드 완료 여부를 반환한다는 점, 상수 3종(`ADDITION_CARD_COUNT=7`, `MULTIPLIER_CARD_COUNT=2`, `TOTAL_ROUNDS=2`), **시드 결정성**(덱 생성·셔플 `seed+1000`·랜덤 배정 `seed+round.toIndex()`, 시드는 `joinCode.hashCode()` 유도) 추가
   - 존재하지 않는 **CardGameTaskExecutorsV2 절 삭제** → 실제 구조인 `CardGameStep` + `CardGameFlowOrchestrator`/`FlowScheduler` 참조로 대체
   - `Deck`/`AdditionCards`/`MultiplierCards`/`CardGameDeckGenerator` 시그니처(`Random`·`seed` 파라미터) 반영, 라운드 스코프 소유자 판정·미선택 카드 한정 랜덤 규칙 명시

# 💬 리뷰 중점사항

- 문서 전용 변경이라 동작 변화 없음. `markdownlint-cli2` 통과 확인함
- `CardGameStep` 절을 새로 넣으면서 도메인 모델 문서 범위를 살짝 넘는지(스케줄링 언급) — 과하다고 보시면 해당 절의 인용 문단만 덜어내면 됩니다

---
_Generated by [Claude Code](https://claude.ai/code/session_018viyhDzcnaNRGWepK6jud1)_