### PR TITLE
[fix] FE destination 을 ws-catalog 와 대조하고 죽은 racing-game/start 제거

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -6,6 +6,9 @@ on:
     branches: [dev, prod]
     paths:
       - "frontend/**"
+      # wsContract 테스트가 이 fixture 를 SSOT 로 읽는다. BE 만 바꾼 PR 에서도 돌아야
+      # 토픽 이름 변경으로 FE 구독이 끊기는 걸 머지 전에 잡는다.
+      - "backend/app/src/test/resources/__fixtures__/ws-catalog.json"
 
   # 다른 워크플로우에서 호출할 수 있도록 설정
   workflow_call:

--- a/frontend/src/apis/websocket/__tests__/wsContract.test.ts
+++ b/frontend/src/apis/websocket/__tests__/wsContract.test.ts
@@ -1,0 +1,164 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, resolve } from 'path';
+import ts from 'typescript';
+import { isBrokerDestination, WEBSOCKET_CONFIG } from '../constants/constants';
+
+/**
+ * FE 가 쓰는 destination 이 BE 카탈로그에 실재하는지 검사한다.
+ *
+ * STOMP 는 존재하지 않는 토픽도 구독에 성공하고, publish 는 ack 이 없어 브로커가 조용히 버린다.
+ * 그래서 오타나 삭제된 destination 이 빌드·린트·런타임 어디에도 안 걸리고 사용자만 화면이
+ * 안 넘어가는 걸 본다. 이 테스트가 그 구멍을 막는다.
+ *
+ * SSOT 는 BE 가 생성해 커밋하는 ws-catalog.json 이다. 신선도는 backend-ci 가 강제한다.
+ */
+
+const REPO_ROOT = resolve(__dirname, '../../../../..');
+const CATALOG_PATH = join(REPO_ROOT, 'backend/app/src/test/resources/__fixtures__/ws-catalog.json');
+const SRC_ROOT = resolve(__dirname, '../../..');
+
+/** 이 이름으로 호출되면 첫 인자를 destination 으로 본다. */
+const SUBSCRIBE_HOOKS = ['useWebSocketSubscription', 'useUserSocketSubscription'];
+const SEND_FN = 'send';
+
+/** 판정할 수 없는 호출부를 의도적으로 넘길 때 붙이는 표식. */
+const IGNORE_MARK = 'ws-contract-ignore';
+
+type Catalog = {
+  topics: { path: string }[];
+  queues: { path: string }[];
+  sends: { destination: string }[];
+  errors: { topic: string };
+};
+
+type Usage = {
+  kind: 'subscribe' | 'send';
+  raw: string | null;
+  where: string;
+  ignored: boolean;
+};
+
+/**
+ * 경로 변수 표기를 한 자리표시자로 접는다. FE 의 `${joinCode}` 와 BE 의 `{joinCode}` 가 같은
+ * `{}` 가 되어 이름이 달라도 비교할 수 있다. 파라미터 이름은 로컬 바인딩일 뿐이라 대조하지 않는다.
+ * BE 의 WsCatalogContractTest.normalize 와 같은 규칙이다.
+ */
+const normalize = (path: string): string =>
+  path
+    .split('/')
+    .map((segment) => (segment.includes('{') ? '{}' : segment))
+    .join('/');
+
+const collectSourceFiles = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return collectSourceFiles(full);
+    return /\.tsx?$/.test(entry) ? [full] : [];
+  });
+
+/**
+ * 첫 인자를 정적 문자열로 접는다. 보간은 값을 알 수 없으므로 `{}` 자리표시자로 남긴다.
+ * 식별자나 함수 호출처럼 접을 수 없으면 null 을 돌려 "판정 불가"로 보고한다.
+ */
+const literalize = (node: ts.Expression): string | null => {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  if (ts.isTemplateExpression(node)) {
+    return node.head.text + node.templateSpans.map((span) => `{}${span.literal.text}`).join('');
+  }
+  return null;
+};
+
+const collectUsages = (): Usage[] => {
+  const usages: Usage[] = [];
+
+  for (const file of collectSourceFiles(SRC_ROOT)) {
+    const text = readFileSync(file, 'utf-8');
+    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+    const lines = text.split('\n');
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+        const name = node.expression.text;
+        const kind = SUBSCRIBE_HOOKS.includes(name)
+          ? ('subscribe' as const)
+          : name === SEND_FN
+            ? ('send' as const)
+            : null;
+
+        if (kind && node.arguments.length > 0) {
+          const line = source.getLineAndCharacterOfPosition(node.getStart()).line;
+          usages.push({
+            kind,
+            raw: literalize(node.arguments[0]),
+            where: `${relative(REPO_ROOT, file)}:${line + 1}`,
+            ignored: [lines[line], lines[line - 1] ?? ''].some((l) => l.includes(IGNORE_MARK)),
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(source);
+  }
+
+  return usages;
+};
+
+/** 런타임 wrapper 가 붙이는 prefix 를 그대로 재현한다. 규칙이 바뀌면 검사도 따라가도록 import 해서 쓴다. */
+const toFullPath = (usage: Usage & { raw: string }): string => {
+  if (usage.kind === 'send') return WEBSOCKET_CONFIG.APP_PREFIX + usage.raw;
+  return isBrokerDestination(usage.raw) ? usage.raw : WEBSOCKET_CONFIG.TOPIC_PREFIX + usage.raw;
+};
+
+describe('WebSocket destination 컨트랙트', () => {
+  const catalog: Catalog = JSON.parse(readFileSync(CATALOG_PATH, 'utf-8'));
+  const usages = collectUsages();
+
+  const subscribable = new Set(
+    [
+      ...catalog.topics.map((topic) => topic.path),
+      ...catalog.queues.map((queue) => queue.path),
+      // 카탈로그는 프로퍼티에서 온 /queue/errors 를 적고 FE 는 /user/queue/errors 로 구독한다.
+      // Spring user-destination 규약상 둘 다 같은 큐를 가리킨다.
+      catalog.errors.topic,
+      `/user${catalog.errors.topic}`,
+    ].map(normalize)
+  );
+  const sendable = new Set(catalog.sends.map((entry) => normalize(entry.destination)));
+
+  const resolved = usages.filter((usage) => usage.raw !== null && usage.raw.startsWith('/'));
+
+  it('카탈로그를 읽고 호출부를 찾는다', () => {
+    expect(subscribable.size).toBeGreaterThan(0);
+    expect(sendable.size).toBeGreaterThan(0);
+    // 파서가 조용히 아무것도 못 찾으면 검사 전체가 무의미해진다.
+    expect(resolved.length).toBeGreaterThan(20);
+  });
+
+  it('구독 destination 이 카탈로그에 있다', () => {
+    const missing = resolved
+      .filter((usage) => usage.kind === 'subscribe')
+      .filter((usage) => !subscribable.has(normalize(toFullPath(usage as Usage & { raw: string }))))
+      .map((usage) => `${usage.where} → ${toFullPath(usage as Usage & { raw: string })}`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('발행 destination 이 카탈로그에 있다', () => {
+    const missing = resolved
+      .filter((usage) => usage.kind === 'send')
+      .filter((usage) => !sendable.has(normalize(toFullPath(usage as Usage & { raw: string }))))
+      .map((usage) => `${usage.where} → ${toFullPath(usage as Usage & { raw: string })}`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('구독 훅의 destination 은 정적으로 판정할 수 있다', () => {
+    // 변수로 조립하면 검사가 눈을 감는다. 조용히 넘기지 않고 의식적인 예외 표시를 요구한다.
+    const unresolvable = usages
+      .filter((usage) => usage.kind === 'subscribe' && usage.raw === null && !usage.ignored)
+      .map((usage) => usage.where);
+
+    expect(unresolvable).toEqual([]);
+  });
+});

--- a/frontend/src/features/miniGame/racingGame/pages/RacingGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/racingGame/pages/RacingGamePlayPage.tsx
@@ -1,4 +1,3 @@
-import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 import { colorList } from '@/constants/color';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
@@ -24,7 +23,6 @@ const FINISH_LINE_VISUAL_OFFSET = 30;
 
 const RacingGamePage = () => {
   const { joinCode, myName } = useIdentifier();
-  const { send } = useWebSocket();
   const navigate = useReplaceNavigate();
   const { miniGameType } = useParams();
   const { racingGameState, racingGameData } = useRacingGame();
@@ -48,14 +46,6 @@ const RacingGamePage = () => {
     containerRef,
     mySpeed,
   });
-
-  useEffect(() => {
-    setTimeout(() => {
-      send(`/room/${joinCode}/racing-game/start`, {
-        hostName: myName,
-      });
-    }, 2000);
-  }, [joinCode, send, myName]);
 
   useEffect(() => {
     if (racingGameState === 'DONE') {


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

> base가 `feat/1733-ws-contract-ci-gate`(PR #1734)다. 그 PR이 만든 fixture를 SSOT로 읽어야 하기 때문이다. PR #1734가 머지되면 GitHub이 base를 `dev`로 자동 조정한다. **base가 dev가 아닌 동안은 CI가 돌지 않으므로 로컬 검증 결과를 아래에 적었다.**

# 🔥 연관 이슈

- 이슈 #1733의 3단계 (close 는 마지막 PR에서 한다)
- 선행 PR #1734

# 🚀 작업 내용

## 게이트가 잡은 첫 회귀

`RacingGamePlayPage.tsx:52`가 마운트 2초 뒤 `/app/room/{joinCode}/racing-game/start`로 보내고 있었다. BE `RacingGameWebSocketController`에는 `racing-game/tap` 핸들러밖에 없다. 레이싱 시작은 `minigame/command`로 돈다.

`client.publish`는 ack이 없어 브로커가 조용히 버리고, FE는 에러 콜백도 못 받는다. `git log -S "racing-game/start"`로 보면 이 문자열은 FE 히스토리를 통합한 커밋에만 나오고 BE에는 대응 핸들러가 있었던 적이 없다. 죽은 `useEffect`와 그로 인해 쓰이지 않게 된 `useWebSocket` import를 지웠다.

이 한 건이 이번 PR의 절반이다. 빌드·린트·테스트 어디에도 안 걸리고 dev에 들어가 있었다.

## 왜 런타임이 아무 신호도 안 주는가

| drift | 런타임 신호 | 지금까지의 발견자 |
| --- | --- | --- |
| 없는 토픽 구독 | 없다. STOMP는 아무 토픽이나 구독에 성공하고 "구독 성공" 로그까지 찍는다. 메시지만 영원히 안 온다 | 사용자 |
| 없는 destination으로 send | 없다. `client.publish`는 fire-and-forget이다 | 사용자 |
| prefix 중복 | 없다. 위와 같다 | 사용자 |

기계가 잡던 건 FE 내부 자기모순뿐이었다. 타입을 손으로 베껴 적으니 자기모순이 없어서 BE와의 불일치는 아무것도 안 걸렸다.

## 검사 방식

`wsContract.test.ts`가 TypeScript AST로 `useWebSocketSubscription`·`useUserSocketSubscription`·`send`의 첫 인자를 뽑아 카탈로그와 대조한다. 정규식을 쓰지 않은 이유는 `BlockStackingGameProvider.tsx:25`처럼 다중행 호출부가 실제로 있어서다.

- **prefix는 `isBrokerDestination`과 `WEBSOCKET_CONFIG`를 import해서 붙인다.** `useWebSocketMessaging.ts:29`가 쓰는 바로 그 함수다. 복붙하면 `BROKER_PREFIXES`가 바뀌는 순간 검사가 거짓말을 시작한다.
- **경로 변수는 이름을 대조하지 않는다.** FE의 `${joinCode}`와 BE의 `{joinCode}`를 같은 `{}`로 접는다. `${code}`로 리네임해도 오탐이 나지 않아야 한다. BE `WsCatalogContractTest.normalize`와 같은 규칙이다.
- **`/queue/errors`와 `/user/queue/errors`를 둘 다 허용한다.** 카탈로그는 프로퍼티에서 온 값을 적고 FE는 `/user/` 포함으로 구독한다. Spring user-destination 규약상 같은 큐다.
- **단방향 검사다.** "FE의 destination ⊆ 카탈로그"만 본다. 역방향까지 강제하면 BE가 토픽을 먼저 만드는 정상 워크플로에서 BE PR이 FE PR에 묶인다.
- **판정 불가한 구독은 실패시킨다.** `// ws-contract-ignore`로만 넘어간다. 조용히 스킵하면 destination을 변수로 빼는 순간 검사가 눈을 감고 아무도 모른다. 지금은 31개 호출부가 전부 정적 리터럴이라 해당 건이 0이다.

## CI 트리거

`frontend-ci.yml`의 `paths`에 fixture 경로를 더했다. 지금은 `frontend/**`뿐이라 BE만 바꾼 PR에서는 안 돌아서, BE가 토픽 이름을 바꿔 FE 구독이 끊겨도 머지될 수 있었다.

# 💬 리뷰 중점사항

**로컬 검증 결과** (base가 dev가 아니라 CI가 안 도는 동안의 대체 근거)

- `npm run test:jest` 전체 통과 (15 suites / 91 tests)
- `npm run lint` exit 0, `npm run type-check` 통과
- 게이트 돌연변이 검증 3건
  - 구독 destination을 `worm/staaate`로 바꾸면 → `구독 destination 이 카탈로그에 있다` 실패
  - destination을 변수로 바꾸면 → `정적으로 판정할 수 있다` 실패
  - 거기에 `// ws-contract-ignore`를 붙이면 → 통과
- 수정 전 상태에서 돌리면 `racing-game/start` 1건만 실패하고 나머지 30개 호출부는 전부 통과한다

**봐주셨으면 하는 곳**

1. **`racing-game/start` 제거가 맞는지.** BE에 핸들러가 있었던 흔적을 히스토리에서 못 찾았고 시작은 `minigame/command`로 도는 것으로 읽었다. 레이싱 담당이 한 번 봐주면 좋겠다.
2. **`send`라는 이름만 보고 호출부를 잡는 점.** 첫 인자가 `/`로 시작하는 정적 문자열일 때만 검사해서 지금은 오탐이 없다. WS와 무관한 `send`가 생기면 훅 이름처럼 명확한 판별이 필요해진다.
3. **`ws-contract-ignore` 예외가 늘어날 가능성.** destination 상수 모듈을 만드는 리팩터링을 하면 호출부가 전부 식별자가 되어 예외가 쏟아진다. 그때는 게이트를 완화할 게 아니라 상수 정의를 순회하는 형태로 바꿔야 한다고 본다. 예외가 2개 이상 생기면 그 신호로 삼자.

**후속 PR**

- PR3: `tools/api-mcp` 폐기, `ws-contract` 스킬 재작성(prefix 변환표가 지금 코드와 어긋나 있다), ADR-0037

https://claude.ai/code/session_01Xow1uApMZtRyjdaePybJe8
