### PR TITLE
[chore] frontend CI 의 SEO grep 이 속성 따옴표 유무와 무관하게 통과하게 수정

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -75,8 +75,10 @@ jobs:
           npm run build
           # 라우트별 정적 HTML·sitemap 이 실제로 생성됐는지 확인한다 (#1710).
           # 빠지면 CloudFront 가 SPA fallback 으로 홈 HTML 을 주고 색인이 다시 홈으로 합쳐진다.
-          grep -q 'canonical" href="https://www.zzol.site/games/card-game"' dist/games/card-game/index.html
-          grep -q 'name="robots" content="noindex' dist/404/index.html
+          # 속성 따옴표는 있어도 없어도 통과시킨다 — webpack 5.110 부터 production 빌드가 HTML 을 자체 압축하며
+          # 불필요한 따옴표를 지운다(webpack/webpack#21841). 따옴표를 전제하면 minor 업데이트마다 CI 가 빨개진다.
+          grep -qE 'canonical"? href="?https://www.zzol.site/games/card-game["> ]' dist/games/card-game/index.html
+          grep -qE 'name="?robots"? content="?noindex' dist/404/index.html
           # 기대 개수도 pages.json 에서 뽑는다 — 숫자를 여기 적으면 페이지를 늘릴 때마다 CI 만 빨개진다.
           # node -p 대신 stdout.write 를 쓴다 — node -p 는 TTY 에서 숫자에 ANSI 색을 입혀 test 가 깨진다.
           test "$(grep -c '<loc>' dist/sitemap.xml)" -eq "$(node -e \


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- 없음 (경량 경로. dependabot PR #1728 의 CI 실패를 푼다)

# 🚀 작업 내용

**무엇이 달라지는가**

frontend CI 의 정적 HTML 검증이 속성 따옴표가 있어도 없어도 통과한다. 이 PR 이 merge 되면 dependabot 의 minor·patch 묶음 PR(#1728)이 rebase 뒤 통과한다.

**왜 바꿨는가**

#1728 은 lint·테스트·빌드가 다 성공한 뒤 SEO 검증 grep 에서 죽는다. 묶음 안의 webpack 5.109.2 → 5.110.1 이 원인이다. webpack 5.110.0 부터 production 빌드가 HTML 을 자체 압축하며 불필요한 속성 따옴표를 지운다(webpack/webpack#21841). 생성된 HTML 은 `<link rel=canonical href=https://www.zzol.site/games/card-game>` 형태인데, 기존 grep 은 `canonical" href="https://...` 처럼 따옴표를 전제해서 못 찾는다. 페이지 자체는 정상이고 검증 패턴이 너무 좁았던 것이다.

**변경 목록**

1. canonical 검사를 `canonical"? href="?https://www.zzol.site/games/card-game["> ]` 로 바꿨다. 따옴표를 선택으로 두고, 경로 끝에 `"`·`>`·공백 경계를 잡아 `/games/card-game-x` 같은 다른 경로가 오탐되지 않게 했다. `.github/workflows/frontend-ci.yml`
2. robots 검사를 `name="?robots"? content="?noindex` 로 바꿨다. 같은 이유다.
3. 왜 느슨하게 뒀는지 주석으로 남겼다. 다음에 webpack 이 압축 방식을 또 바꿔도 grep 부터 의심하게 하려는 것이다.

**검증**

로컬에서 새 패턴을 네 경우로 돌렸다. 전부 의도대로 나왔다.

| 입력 | 기대 | 결과 |
| --- | --- | --- |
| #1728 브랜치를 그대로 빌드한 `dist/` (webpack 5.110.1, 따옴표 없음) | 통과 | 통과 |
| 현재 운영 페이지 `www.zzol.site/games/card-game`, `/404` (webpack 5.109, 따옴표 있음) | 통과 | 통과 |
| `href=https://www.zzol.site/games/card-game-x` | 거부 | 거부 |
| `content="index, follow"` | 거부 | 거부 |

YAML 문법은 `yaml.safe_load` 로 확인했다.

# 💬 리뷰 중점사항

grep 을 느슨하게 하는 대신 webpack 설정에서 `optimization.minimize.html` 을 꺼서 따옴표를 유지하는 길도 있다. 압축은 결과물이 작아지는 쪽이고 검증 스크립트가 형식에 묶일 이유가 없어서 grep 을 고쳤다. 반대 판단이면 알려주면 바꾼다.

# 🙅 이번에 하지 않은 것

- #1730(eslint 10)·#1729(eslint-plugin-cypress 7)는 이 PR 과 무관하다. `eslint-plugin-react` 가 eslint 10 을 아직 지원하지 않아 `npm ci` 에서 ERESOLVE 로 죽는다(jsx-eslint/eslint-plugin-react#3977). 닫고 dependabot `ignore` 를 두는 건 별도 PR 로 한다.

https://claude.ai/code/session_01DK8g4eX6GnrFmkKT3Rtrv2
