### PR TITLE
[fix] 닉네임 검열 회차의 스레드 점유·무한 반복·중복 실행 차단

### DIFF
--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -39,5 +39,6 @@ nickname-audit:
   batch-size: 100                      # API 호출 1회당 처리량 (RPM 5 기준 100개씩 5회 = 500개/min)
   feedback-injection-threshold: 20
   min-term-length: 2                   # 자동 차단할 비속어 조각의 정규화 후 최소 길이 (짧을수록 Trie 부분일치 과차단 위험 ↑)
+  max-run-duration: 10m                # 한 회차가 실행기 스레드를 붙잡아도 되는 상한. 넘으면 남은 적체는 다음 회차로.
   request-timeout: 120s                # Gemini HTTP 타임아웃. 없으면 응답 없는 호출이 스케줄러 스레드를 무기한 점유한다.
                                        # batch-size 를 올리면 응답 생성 시간도 늘어나므로 함께 올린다.

--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -39,3 +39,5 @@ nickname-audit:
   batch-size: 100                      # API 호출 1회당 처리량 (RPM 5 기준 100개씩 5회 = 500개/min)
   feedback-injection-threshold: 20
   min-term-length: 2                   # 자동 차단할 비속어 조각의 정규화 후 최소 길이 (짧을수록 Trie 부분일치 과차단 위험 ↑)
+  request-timeout: 120s                # Gemini HTTP 타임아웃. 없으면 응답 없는 호출이 스케줄러 스레드를 무기한 점유한다.
+                                       # batch-size 를 올리면 응답 생성 시간도 늘어나므로 함께 올린다.

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
@@ -6,10 +6,10 @@ import coffeeshout.profanity.config.NicknameAuditProperties;
 import coffeeshout.profanity.domain.Language;
 import coffeeshout.profanity.domain.TextNormalizer;
 import coffeeshout.profanity.domain.WordSource;
+import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditResult;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.domain.audit.NicknameAuditor;
-import coffeeshout.profanity.domain.audit.NicknameAudit;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
@@ -49,10 +49,8 @@ public class ProfanityAuditBatchProcessor {
     }
 
     public int process(List<NicknameAudit> batch) {
-        final List<String> nicknames = batch.stream()
-                .map(NicknameAudit::getNickname)
-                .distinct()
-                .toList();
+        final List<String> nicknames =
+                batch.stream().map(NicknameAudit::getNickname).distinct().toList();
 
         final List<NicknameAuditResult> results = nicknameAuditor.audit(nicknames);
 
@@ -65,40 +63,58 @@ public class ProfanityAuditBatchProcessor {
         final Map<String, NicknameAuditResult> resultMap = results.stream()
                 .collect(Collectors.toMap(NicknameAuditResult::nickname, Function.identity(), (a, b) -> a));
 
-        transactionTemplate.executeWithoutResult(status -> {
-            // 배치 닉네임 중 이미 검열 완료(terminal) 행을 가진 것들을 한 번에 조회한다 (건별 조회 N+1 회피).
-            final Set<String> nicknamesWithTerminal = auditRepository.findNicknamesWithTerminalStatus(nicknames);
+        final Integer settled = transactionTemplate.execute(status -> settle(batch, nicknames, resultMap));
+        return settled == null ? 0 : settled;
+    }
 
-            final List<NicknameAudit> toPromote = new ArrayList<>();
-            final List<NicknameAudit> redundant = new ArrayList<>();
-            for (final NicknameAudit entity : batch) {
-                final NicknameAuditResult result = resultMap.get(entity.getNickname());
-                // 같은 닉네임의 검열 완료(terminal) 행이 이미 있으면 이 UNAUDITED는 #1467 fix 이전에 생긴
-                // 잔존 중복 재등록이다(register의 "이름당 1행" 불변식 위반). 승격하면 대상 상태가 같을 때
-                // uq_player_name_audit_name_status에 충돌해 배치 전체가 롤백되고 매 tick 재크래시하며,
-                // 다를 때는 (예: 기존 CLEAN + 신규 FLAGGED) 모순된 감사 이력과 autoBlock 오발동을 남긴다.
-                // 어느 쪽이든 승격 대신 제거한다 — 기존 terminal 행이 권위 있는 판정을 이미 보유한다.
-                if (result != null && nicknamesWithTerminal.contains(entity.getNickname())) {
-                    redundant.add(entity);
-                    continue;
-                }
-                applyResult(entity, result);
-                toPromote.add(entity);
-            }
-            auditRepository.saveAll(toPromote);
-            if (!redundant.isEmpty()) {
-                auditRepository.deleteAll(redundant);
-                log.warn("이미 검열된 닉네임의 잔존 UNAUDITED {}건 제거 (중복 재등록)", redundant.size());
-            }
-        });
+    /**
+     * 판정을 DB에 반영하고 <b>실제로 UNAUDITED에서 빠져나간 행 수</b>를 돌려준다.
+     *
+     * <p>배치 크기를 그대로 돌려주면 안 된다. 판정을 못 짝지어 그대로 남은 행까지 처리했다고 세면,
+     * 드레인 루프가 진행이 없는데도 같은 0페이지를 계속 다시 읽는다.
+     */
+    private int settle(List<NicknameAudit> batch, List<String> nicknames, Map<String, NicknameAuditResult> resultMap) {
+        // 배치 닉네임 중 이미 검열 완료(terminal) 행을 가진 것들을 한 번에 조회한다 (건별 조회 N+1 회피).
+        final Set<String> nicknamesWithTerminal = auditRepository.findNicknamesWithTerminalStatus(nicknames);
 
-        return batch.size();
+        final List<NicknameAudit> toPromote = new ArrayList<>();
+        final List<NicknameAudit> redundant = new ArrayList<>();
+        int unmatched = 0;
+        for (final NicknameAudit entity : batch) {
+            final NicknameAuditResult result = resultMap.get(entity.getNickname());
+            if (result == null) {
+                unmatched++;
+                continue;
+            }
+            // 같은 닉네임의 검열 완료(terminal) 행이 이미 있으면 이 UNAUDITED는 #1467 fix 이전에 생긴
+            // 잔존 중복 재등록이다(register의 "이름당 1행" 불변식 위반). 승격하면 대상 상태가 같을 때
+            // uq_player_name_audit_name_status에 충돌해 배치 전체가 롤백되고 매 tick 재크래시하며,
+            // 다를 때는 (예: 기존 CLEAN + 신규 FLAGGED) 모순된 감사 이력과 autoBlock 오발동을 남긴다.
+            // 어느 쪽이든 승격 대신 제거한다 — 기존 terminal 행이 권위 있는 판정을 이미 보유한다.
+            if (nicknamesWithTerminal.contains(entity.getNickname())) {
+                redundant.add(entity);
+                continue;
+            }
+            applyResult(entity, result);
+            toPromote.add(entity);
+        }
+        auditRepository.saveAll(toPromote);
+        if (!redundant.isEmpty()) {
+            auditRepository.deleteAll(redundant);
+            log.warn("이미 검열된 닉네임의 잔존 UNAUDITED {}건 제거 (중복 재등록)", redundant.size());
+        }
+        if (unmatched > 0) {
+            log.warn("판정을 짝지을 수 없는 닉네임 {}건 — UNAUDITED로 남긴다", unmatched);
+        }
+        return toPromote.size() + redundant.size();
     }
 
     private void applyResult(NicknameAudit entity, NicknameAuditResult result) {
         if (result == null) return;
         entity.complete(result.status(), result.confidence(), result.reason());
-        meterRegistry.counter("nickname.audit.result", "status", result.status().name()).increment();
+        meterRegistry
+                .counter("nickname.audit.result", "status", result.status().name())
+                .increment();
         if (result.status() == NicknameAuditStatus.FLAGGED) {
             autoBlock(result);
         }
@@ -122,8 +138,7 @@ public class ProfanityAuditBatchProcessor {
         final List<String> fragments =
                 result.extractProfanityFragments(textNormalizer, nicknameAuditProperties.minTermLength());
         if (fragments.isEmpty()) {
-            log.info("유효한 비속어 조각 없음 — 닉네임 전체 차단 폴백: nickname={}, terms={}",
-                    result.nickname(), result.profanityTerms());
+            log.info("유효한 비속어 조각 없음 — 닉네임 전체 차단 폴백: nickname={}, terms={}", result.nickname(), result.profanityTerms());
             return List.of(result.nickname());
         }
         return fragments;

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
@@ -128,6 +128,12 @@ public class ProfanityAuditService {
         int processedTotal = 0;
 
         while (!batch.isEmpty()) {
+            // 실행기의 shutdownNow가 보낸 인터럽트다. 종료가 회차 끝을 기다리지 않게 배치를 시작하기 전에 본다.
+            // 락은 애스펙트의 finally가 푼다.
+            if (Thread.currentThread().isInterrupted()) {
+                log.warn("종료 요청으로 닉네임 검열 회차 중단 — 누적 {}건", processedTotal);
+                break;
+            }
             // processed는 실제로 UNAUDITED에서 빠져나간 행 수다. 진행이 없으면 같은 0페이지를 영원히
             // 다시 읽게 되므로 0이면 멈춘다.
             int processed = batchProcessor.process(batch);

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
@@ -1,14 +1,16 @@
 package coffeeshout.profanity.application;
 
+import coffeeshout.global.lock.RedisLock;
+import coffeeshout.global.nickname.NicknameSubmittedEvent;
 import coffeeshout.profanity.application.port.NicknameAuditRepository;
 import coffeeshout.profanity.config.NicknameAuditProperties;
-import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
-import coffeeshout.global.nickname.NicknameSubmittedEvent;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
+import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ProfanityAuditService {
+
+    /**
+     * Redisson은 leaseTime을 명시하면 워치독 갱신 없이 그 시간 뒤 락을 자동 해제한다.
+     * 회차 예산({@code nickname-audit.max-run-duration}, 기본 10분)보다 넉넉히 길어야
+     * 실행 도중 락이 풀려 다른 인스턴스가 같은 큐에 끼어드는 일을 막는다.
+     */
+    private static final long LOCK_LEASE_MILLIS = 900_000L;
+
+    /** 주기 작업이라 완료 마킹은 짧게 둔다. cron 주기(12시간)보다 길면 다음 회차가 조용히 건너뛰어진다. */
+    private static final long LOCK_DONE_TTL_MILLIS = 60_000L;
 
     private final NicknameAuditRepository auditRepository;
     private final ProfanityAuditBatchProcessor batchProcessor;
@@ -86,21 +98,50 @@ public class ProfanityAuditService {
         auditRepository.insertUnaudited(nickname, clock.instant());
     }
 
+    /**
+     * 미검열 닉네임을 배치로 검열한다.
+     *
+     * <p>회차에 시간 예산을 둔다. 배치 하나가 Gemini 호출 하나이고 레이트리미터가 13초에 하나만
+     * 허용하므로 소요 시간이 적체량에 정비례한다. 상한이 없으면 적체 10만 건에 3.6시간을 도는데,
+     * 그동안 실행기 스레드를 붙잡고 있게 된다.
+     *
+     * <p>분산 락은 여기 건다. 스케줄러는 작업을 실행기로 넘기고 즉시 반환하므로 그쪽에 걸면
+     * 락이 바로 풀린다. Blue/Green 전환 구간에 두 인스턴스가 같은 큐를 읽는 것을 막는 게 목적이다.
+     */
+    @RedisLock(
+            key = "'nickname-audit'",
+            lockPrefix = "lock:",
+            donePrefix = "done:",
+            waitTime = 0,
+            leaseTime = LOCK_LEASE_MILLIS,
+            doneTtl = LOCK_DONE_TTL_MILLIS)
     public void auditPending() {
         final long initialQueueSize = auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED);
         unauditedQueueDepth.set(initialQueueSize);
         log.info("닉네임 검열 시작: UNAUDITED 적체량 {}건", initialQueueSize);
 
-        final Pageable pageable = PageRequest.of(0, properties.batchSize(), Sort.by("createdAt").ascending());
-        List<NicknameAudit> batch = auditRepository.findByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED, pageable);
+        final Instant deadline = clock.instant().plus(properties.maxRunDuration());
+        final Pageable pageable =
+                PageRequest.of(0, properties.batchSize(), Sort.by("createdAt").ascending());
+        List<NicknameAudit> batch =
+                auditRepository.findByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED, pageable);
         int processedTotal = 0;
 
         while (!batch.isEmpty()) {
+            // processed는 실제로 UNAUDITED에서 빠져나간 행 수다. 진행이 없으면 같은 0페이지를 영원히
+            // 다시 읽게 되므로 0이면 멈춘다.
             int processed = batchProcessor.process(batch);
             processedTotal += processed;
-            log.info("닉네임 검열 진행: 이번 배치 {}건, 누적 {}건", batch.size(), processedTotal);
+            log.info("닉네임 검열 진행: 이번 배치 {}건 중 {}건 처리, 누적 {}건", batch.size(), processed, processedTotal);
 
             if (processed == 0 || batch.size() < properties.batchSize()) {
+                break;
+            }
+            if (!clock.instant().isBefore(deadline)) {
+                log.warn(
+                        "닉네임 검열 회차 시간 예산({}) 소진 — 남은 적체는 다음 회차로 넘긴다. 누적 {}건",
+                        properties.maxRunDuration(),
+                        processedTotal);
                 break;
             }
             batch = auditRepository.findByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED, pageable);

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditConfig.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditConfig.java
@@ -1,6 +1,7 @@
 package coffeeshout.profanity.config;
 
 import com.google.genai.Client;
+import com.google.genai.types.HttpOptions;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +20,17 @@ public class NicknameAuditConfig {
         }
         return Client.builder()
                 .apiKey(properties.geminiApiKey())
+                .httpOptions(httpOptions(properties))
+                .build();
+    }
+
+    /**
+     * SDK가 빌드된 {@link Client}에서 타임아웃을 되읽을 방법을 주지 않아, 검증 가능하도록 조립부를 분리한다.
+     * {@code HttpOptions.timeout}은 밀리초 단위다.
+     */
+    static HttpOptions httpOptions(NicknameAuditProperties properties) {
+        return HttpOptions.builder()
+                .timeout(Math.toIntExact(properties.requestTimeout().toMillis()))
                 .build();
     }
 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditConfig.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditConfig.java
@@ -2,6 +2,8 @@ package coffeeshout.profanity.config;
 
 import com.google.genai.Client;
 import com.google.genai.types.HttpOptions;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +13,20 @@ import org.springframework.util.StringUtils;
 @Configuration
 @EnableConfigurationProperties(NicknameAuditProperties.class)
 public class NicknameAuditConfig {
+
+    /**
+     * 검열 회차 전용 실행기.
+     *
+     * <p>공유 {@code virtualThreadExecutor}를 쓰지 않는 이유는 그 빈의 destroyMethod가 {@code close}라서다.
+     * {@code ExecutorService.close()}는 실행 중인 작업이 끝날 때까지 블록하므로, 회차 도중 종료 신호가 오면
+     * 컨텍스트 종료가 회차 예산(기본 10분)만큼 밀린다. Blue/Green 전환에서 구 컨테이너가 그만큼 늦게 내려가거나
+     * SIGKILL을 맞는다. {@code shutdownNow}는 즉시 반환하고 회차 스레드에 인터럽트를 보내며, 드레인 루프가 그
+     * 인터럽트를 보고 멈춘다.
+     */
+    @Bean(destroyMethod = "shutdownNow")
+    public ExecutorService nicknameAuditExecutor() {
+        return Executors.newVirtualThreadPerTaskExecutor();
+    }
 
     @Bean("nicknameAuditClient")
     @Profile("!local & !test")

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -6,10 +6,19 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.Duration;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.validation.annotation.Validated;
 
+/**
+ * @param requestTimeout Gemini HTTP 요청 타임아웃. 없으면 응답이 끝내 오지 않는 호출 하나가 회차 스레드를
+ *                       무기한 점유한다. {@code batchSize}를 키우면 응답 생성 시간도 늘어나므로 함께 올려야 한다.
+ *                       하한을 두는 이유는 SDK가 이 값을 OkHttp {@code callTimeout}에 그대로 넣고, OkHttp에서
+ *                       0은 무제한이라서다. {@code @Positive}는 {@link Duration}에 적용되지 않는다.
+ * @param maxRunDuration 한 회차가 실행기 스레드를 붙잡아도 되는 상한. 넘기면 남은 적체는 다음 회차로 넘긴다.
+ *                       {@code ProfanityAuditService.LOCK_LEASE_MILLIS}보다 반드시 짧아야 한다.
+ */
 @Validated
 @ConfigurationProperties(prefix = "nickname-audit")
 public record NicknameAuditProperties(
@@ -19,13 +28,9 @@ public record NicknameAuditProperties(
         @Positive int batchSize,
         @Positive int feedbackInjectionThreshold,
         @DefaultValue("2") @Positive int minTermLength,
-        /**
-         * Gemini HTTP 요청 타임아웃. 없으면 응답이 끝내 오지 않는 호출 하나가 스케줄러 스레드를
-         * 무기한 점유한다. {@code batchSize}를 키우면 응답 생성 시간도 늘어나므로 함께 올려야 한다.
-         */
-        @DefaultValue("120s") @NotNull Duration requestTimeout,
-        /**
-         * 한 회차가 스케줄러에서 넘겨받은 스레드를 붙잡아도 되는 상한. 넘기면 남은 적체는 다음 회차로 넘긴다.
-         * {@code ProfanityAuditService.LOCK_LEASE_MILLIS}보다 반드시 짧아야 한다.
-         */
-        @DefaultValue("10m") @NotNull Duration maxRunDuration) {}
+
+        @DefaultValue("120s") @NotNull @DurationMin(seconds = 1)
+        Duration requestTimeout,
+
+        @DefaultValue("10m") @NotNull @DurationMin(minutes = 1)
+        Duration maxRunDuration) {}

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -23,4 +23,9 @@ public record NicknameAuditProperties(
          * Gemini HTTP 요청 타임아웃. 없으면 응답이 끝내 오지 않는 호출 하나가 스케줄러 스레드를
          * 무기한 점유한다. {@code batchSize}를 키우면 응답 생성 시간도 늘어나므로 함께 올려야 한다.
          */
-        @DefaultValue("120s") @NotNull Duration requestTimeout) {}
+        @DefaultValue("120s") @NotNull Duration requestTimeout,
+        /**
+         * 한 회차가 스케줄러에서 넘겨받은 스레드를 붙잡아도 되는 상한. 넘기면 남은 적체는 다음 회차로 넘긴다.
+         * {@code ProfanityAuditService.LOCK_LEASE_MILLIS}보다 반드시 짧아야 한다.
+         */
+        @DefaultValue("10m") @NotNull Duration maxRunDuration) {}

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -3,7 +3,9 @@ package coffeeshout.profanity.config;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.validation.annotation.Validated;
@@ -16,6 +18,9 @@ public record NicknameAuditProperties(
         @DecimalMin("0.0") @DecimalMax("1.0") double flaggedThreshold,
         @Positive int batchSize,
         @Positive int feedbackInjectionThreshold,
-        @DefaultValue("2") @Positive int minTermLength
-) {
-}
+        @DefaultValue("2") @Positive int minTermLength,
+        /**
+         * Gemini HTTP 요청 타임아웃. 없으면 응답이 끝내 오지 않는 호출 하나가 스케줄러 스레드를
+         * 무기한 점유한다. {@code batchSize}를 키우면 응답 생성 시간도 늘어나므로 함께 올려야 한다.
+         */
+        @DefaultValue("120s") @NotNull Duration requestTimeout) {}

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/GeminiNicknameAuditor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/GeminiNicknameAuditor.java
@@ -26,6 +26,8 @@ import io.micrometer.core.instrument.Timer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
@@ -38,9 +40,8 @@ import org.springframework.stereotype.Component;
 @Profile("!local & !test")
 public class GeminiNicknameAuditor implements NicknameAuditor {
 
-    private static final Content SYSTEM_INSTRUCTION = Content.fromParts(
-            Part.fromText(NicknameAuditPromptTemplate.SYSTEM_INSTRUCTION)
-    );
+    private static final Content SYSTEM_INSTRUCTION =
+            Content.fromParts(Part.fromText(NicknameAuditPromptTemplate.SYSTEM_INSTRUCTION));
 
     private static final Schema RESPONSE_SCHEMA = Schema.builder()
             .type("ARRAY")
@@ -51,11 +52,13 @@ public class GeminiNicknameAuditor implements NicknameAuditor {
                             "flagged", Schema.builder().type("BOOLEAN").build(),
                             "confidence", Schema.builder().type("NUMBER").build(),
                             "reason", Schema.builder().type("STRING").build(),
-                            "terms", Schema.builder()
-                                    .type("ARRAY")
-                                    .items(Schema.builder().type("STRING").build())
-                                    .build()
-                    ))
+                            "terms",
+                                    Schema.builder()
+                                            .type("ARRAY")
+                                            .items(Schema.builder()
+                                                    .type("STRING")
+                                                    .build())
+                                            .build()))
                     .required(List.of("nickname", "flagged", "confidence", "reason", "terms"))
                     .build())
             .build();
@@ -75,8 +78,7 @@ public class GeminiNicknameAuditor implements NicknameAuditor {
             NicknameAuditProperties properties,
             NicknameFeedbackRepository feedbackRepository,
             NicknameAuditPromptTemplate promptTemplate,
-            MeterRegistry meterRegistry
-    ) {
+            MeterRegistry meterRegistry) {
         this.geminiClient = geminiClient;
         this.objectMapper = objectMapper;
         this.properties = properties;
@@ -101,16 +103,14 @@ public class GeminiNicknameAuditor implements NicknameAuditor {
 
         final GenerateContentResponse response;
         try {
-            response = apiCallTimer.recordCallable(() ->
-                    geminiClient.models.generateContent(
-                            properties.model(),
-                            userMessage,
-                            GenerateContentConfig.builder()
-                                    .systemInstruction(SYSTEM_INSTRUCTION)
-                                    .responseMimeType("application/json")
-                                    .responseSchema(RESPONSE_SCHEMA)
-                                    .build()
-                    ));
+            response = apiCallTimer.recordCallable(() -> geminiClient.models.generateContent(
+                    properties.model(),
+                    userMessage,
+                    GenerateContentConfig.builder()
+                            .systemInstruction(SYSTEM_INSTRUCTION)
+                            .responseMimeType("application/json")
+                            .responseSchema(RESPONSE_SCHEMA)
+                            .build()));
         } catch (Exception e) {
             throw new InfrastructureException(NicknameAuditErrorCode.AI_CALL_FAILED, "닉네임 검열 AI 호출 실패", e);
         }
@@ -128,9 +128,8 @@ public class GeminiNicknameAuditor implements NicknameAuditor {
     }
 
     private List<NicknameFeedback> loadFeedbackExamples() {
-        final List<NicknameFeedback> feedbacks = feedbackRepository.findRecentFeedbacks(
-                PageRequest.of(0, properties.feedbackInjectionThreshold(), Sort.by("createdAt").descending())
-        );
+        final List<NicknameFeedback> feedbacks = feedbackRepository.findRecentFeedbacks(PageRequest.of(
+                0, properties.feedbackInjectionThreshold(), Sort.by("createdAt").descending()));
         if (feedbacks.size() < properties.feedbackInjectionThreshold()) {
             return List.of();
         }
@@ -143,14 +142,16 @@ public class GeminiNicknameAuditor implements NicknameAuditor {
             nodes = objectMapper.readValue(responseText, new TypeReference<>() {});
         } catch (Exception e) {
             parseFailureCounter.increment();
-            log.warn("[NicknameAudit] Gemini 응답 JSON 파싱 실패 ({}건). responseText={}",
-                    requestedNicknames.size(), responseText, e);
+            log.warn(
+                    "[NicknameAudit] Gemini 응답 JSON 파싱 실패 ({}건). responseText={}",
+                    requestedNicknames.size(),
+                    responseText,
+                    e);
             throw new InfrastructureException(NicknameAuditErrorCode.AI_RESPONSE_PARSE_FAILED, "닉네임 검열 AI 응답 파싱 실패", e);
         }
 
         if (nodes.size() != requestedNicknames.size()) {
-            log.error("[NicknameAudit] 응답 항목 수 불일치: expected={}, actual={}",
-                    requestedNicknames.size(), nodes.size());
+            log.error("[NicknameAudit] 응답 항목 수 불일치: expected={}, actual={}", requestedNicknames.size(), nodes.size());
         }
 
         final int processCount = Math.min(nodes.size(), requestedNicknames.size());
@@ -161,28 +162,49 @@ public class GeminiNicknameAuditor implements NicknameAuditor {
             try {
                 final GeminiAuditItem item = objectMapper.treeToValue(node, GeminiAuditItem.class);
                 results.add(NicknameAuditResult.of(
-                        item.nickname(), item.flagged(), item.confidence(), item.reason(),
+                        item.nickname(),
+                        item.flagged(),
+                        item.confidence(),
+                        item.reason(),
                         item.terms() == null ? List.of() : item.terms(),
-                        properties.flaggedThreshold()
-                ));
+                        properties.flaggedThreshold()));
             } catch (Exception e) {
                 itemParseFailureCounter.increment();
                 log.warn("[NicknameAudit] Gemini 응답 항목 파싱 실패, PENDING 처리. index={}, node={}", i, node, e);
                 results.add(new NicknameAuditResult(
-                        requestedNicknames.get(i), NicknameAuditStatus.PENDING, AiConfidence.UNKNOWN, "응답 파싱 실패"
-                ));
+                        requestedNicknames.get(i), NicknameAuditStatus.PENDING, AiConfidence.UNKNOWN, "응답 파싱 실패"));
             }
         }
 
         for (int i = processCount; i < requestedNicknames.size(); i++) {
             log.warn("[NicknameAudit] 응답 누락 닉네임 PENDING 처리. index={}, nickname={}", i, requestedNicknames.get(i));
             results.add(new NicknameAuditResult(
-                    requestedNicknames.get(i), NicknameAuditStatus.PENDING, AiConfidence.UNKNOWN, "응답 항목 수 불일치"
-            ));
+                    requestedNicknames.get(i), NicknameAuditStatus.PENDING, AiConfidence.UNKNOWN, "응답 항목 수 불일치"));
         }
+
+        fillUnmatched(results, requestedNicknames);
 
         return results;
     }
 
-    private record GeminiAuditItem(String nickname, boolean flagged, double confidence, String reason, List<String> terms) {}
+    /**
+     * 요청한 닉네임이 모두 결과에 들어가도록 메운다.
+     *
+     * <p>응답 개수는 맞아도 이름이 어긋날 수 있다(AI가 공백을 붙이거나 글자를 바꿔 돌려주는 경우).
+     * 호출자는 우리가 보낸 이름으로 판정을 찾으므로, 짝을 못 찾은 닉네임이 남으면 그 행은 영영 UNAUDITED로 남는다.
+     */
+    private void fillUnmatched(List<NicknameAuditResult> results, List<String> requestedNicknames) {
+        final Set<String> covered =
+                results.stream().map(NicknameAuditResult::nickname).collect(Collectors.toSet());
+        for (final String requested : requestedNicknames) {
+            if (!covered.contains(requested)) {
+                log.warn("[NicknameAudit] 응답에서 짝을 찾지 못한 닉네임 PENDING 처리. nickname={}", requested);
+                results.add(new NicknameAuditResult(
+                        requested, NicknameAuditStatus.PENDING, AiConfidence.UNKNOWN, "응답 닉네임 불일치"));
+            }
+        }
+    }
+
+    private record GeminiAuditItem(
+            String nickname, boolean flagged, double confidence, String reason, List<String> terms) {}
 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/NicknameAuditScheduler.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/NicknameAuditScheduler.java
@@ -1,21 +1,47 @@
 package coffeeshout.profanity.infra;
 
 import coffeeshout.profanity.application.ProfanityAuditService;
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * 12시간 주기 닉네임 AI 검열 트리거.
+ *
+ * <p>검열 작업을 직접 실행하지 않고 별도 실행기로 넘긴다. 프로덕션에서 모든 {@code @Scheduled}가
+ * 단일 스레드를 공유하는데(그 안에 500ms 주기 Outbox 릴레이가 있다), 검열 회차는 적체량에 비례해
+ * 분에서 시간 단위로 길어지기 때문이다. 여기서 직접 돌리면 그동안 다른 스케줄 작업이 전부 굶는다.
+ *
+ * <p>중복 실행 방지는 {@link ProfanityAuditService#auditPending()}의 분산 락이 담당한다.
+ * 이 메서드에 락을 걸면 넘기자마자 반환하면서 락도 풀려 아무것도 지키지 못한다.
+ */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class NicknameAuditScheduler {
 
     private final ProfanityAuditService profanityAuditService;
+    private final Executor auditExecutor;
+
+    public NicknameAuditScheduler(
+            ProfanityAuditService profanityAuditService, @Qualifier("virtualThreadExecutor") Executor auditExecutor) {
+        this.profanityAuditService = profanityAuditService;
+        this.auditExecutor = auditExecutor;
+    }
 
     @Scheduled(cron = "0 0 0/12 * * *")
     public void auditPendingNicknames() {
-        log.info("닉네임 AI 검열 스케줄러 시작");
-        profanityAuditService.auditPending();
+        log.info("닉네임 AI 검열 스케줄러 시작 — 실행기로 넘긴다");
+        auditExecutor.execute(this::runAudit);
+    }
+
+    private void runAudit() {
+        try {
+            profanityAuditService.auditPending();
+        } catch (Exception e) {
+            // 실행기 스레드에서 예외가 새면 원인이 로그에 안 남는다.
+            log.error("닉네임 AI 검열 실패", e);
+        }
     }
 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/NicknameAuditScheduler.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/NicknameAuditScheduler.java
@@ -2,6 +2,7 @@ package coffeeshout.profanity.infra;
 
 import coffeeshout.profanity.application.ProfanityAuditService;
 import java.util.concurrent.Executor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -10,25 +11,25 @@ import org.springframework.stereotype.Component;
 /**
  * 12시간 주기 닉네임 AI 검열 트리거.
  *
- * <p>검열 작업을 직접 실행하지 않고 별도 실행기로 넘긴다. 프로덕션에서 모든 {@code @Scheduled}가
+ * <p>검열 작업을 직접 실행하지 않고 전용 실행기로 넘긴다. 프로덕션에서 모든 {@code @Scheduled}가
  * 단일 스레드를 공유하는데(그 안에 500ms 주기 Outbox 릴레이가 있다), 검열 회차는 적체량에 비례해
  * 분에서 시간 단위로 길어지기 때문이다. 여기서 직접 돌리면 그동안 다른 스케줄 작업이 전부 굶는다.
+ *
+ * <p>실행기가 공유 {@code virtualThreadExecutor}가 아니라 전용 빈인 이유는
+ * {@code NicknameAuditConfig#nicknameAuditExecutor()} 주석에 있다. 종료 시 회차를 끊어야 해서다.
  *
  * <p>중복 실행 방지는 {@link ProfanityAuditService#auditPending()}의 분산 락이 담당한다.
  * 이 메서드에 락을 걸면 넘기자마자 반환하면서 락도 풀려 아무것도 지키지 못한다.
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class NicknameAuditScheduler {
 
     private final ProfanityAuditService profanityAuditService;
-    private final Executor auditExecutor;
 
-    public NicknameAuditScheduler(
-            ProfanityAuditService profanityAuditService, @Qualifier("virtualThreadExecutor") Executor auditExecutor) {
-        this.profanityAuditService = profanityAuditService;
-        this.auditExecutor = auditExecutor;
-    }
+    @Qualifier("nicknameAuditExecutor")
+    private final Executor auditExecutor;
 
     @Scheduled(cron = "0 0 0/12 * * *")
     public void auditPendingNicknames() {

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
@@ -13,15 +13,15 @@ import coffeeshout.global.nickname.ProfanityWordBlockedEvent;
 import coffeeshout.profanity.application.port.NicknameAuditRepository;
 import coffeeshout.profanity.config.NicknameAuditProperties;
 import coffeeshout.profanity.domain.Language;
-
 import coffeeshout.profanity.domain.TextNormalizer;
 import coffeeshout.profanity.domain.WordSource;
 import coffeeshout.profanity.domain.audit.AiConfidence;
+import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditResult;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.domain.audit.NicknameAuditor;
-import coffeeshout.profanity.domain.audit.NicknameAudit;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,19 +49,32 @@ class ProfanityAuditBatchProcessorTest {
         profanityWordManagementService = mock(ProfanityWordManagementService.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
         transactionTemplate = new TransactionTemplate(new AbstractPlatformTransactionManager() {
-            @Override protected Object doGetTransaction() { return new Object(); }
-            @Override protected void doBegin(Object tx, TransactionDefinition def) {}
-            @Override protected void doCommit(DefaultTransactionStatus status) {}
-            @Override protected void doRollback(DefaultTransactionStatus status) {}
+            @Override
+            protected Object doGetTransaction() {
+                return new Object();
+            }
+
+            @Override
+            protected void doBegin(Object tx, TransactionDefinition def) {}
+
+            @Override
+            protected void doCommit(DefaultTransactionStatus status) {}
+
+            @Override
+            protected void doRollback(DefaultTransactionStatus status) {}
         });
 
-        final NicknameAuditProperties properties = new NicknameAuditProperties(
-                "test-key", "gemini-test", 0.85, 10, 20, 2
-        );
+        final NicknameAuditProperties properties =
+                new NicknameAuditProperties("test-key", "gemini-test", 0.85, 10, 20, 2, Duration.ofSeconds(120));
         processor = new ProfanityAuditBatchProcessor(
-                auditRepository, nicknameAuditor, profanityWordManagementService,
-                eventPublisher, new SimpleMeterRegistry(), transactionTemplate, new TextNormalizer(), properties
-        );
+                auditRepository,
+                nicknameAuditor,
+                profanityWordManagementService,
+                eventPublisher,
+                new SimpleMeterRegistry(),
+                transactionTemplate,
+                new TextNormalizer(),
+                properties);
         processor.initMetrics();
     }
 
@@ -71,10 +84,11 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void FLAGGED_닉네임은_비속어로_등록되고_차단_이벤트가_발행된다() {
             final NicknameAudit entity = new NicknameAudit("욕설닉네임");
-            given(nicknameAuditor.audit(List.of("욕설닉네임"))).willReturn(List.of(
-                    new NicknameAuditResult("욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "직접 욕설")
-            ));
-            given(profanityWordManagementService.add("욕설닉네임", Language.KOREAN, WordSource.AI_FLAGGED)).willReturn(true);
+            given(nicknameAuditor.audit(List.of("욕설닉네임")))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "직접 욕설")));
+            given(profanityWordManagementService.add("욕설닉네임", Language.KOREAN, WordSource.AI_FLAGGED))
+                    .willReturn(true);
 
             processor.process(List.of(entity));
 
@@ -85,10 +99,11 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void 영어_닉네임은_ENGLISH_언어로_등록된다() {
             final NicknameAudit entity = new NicknameAudit("badword");
-            given(nicknameAuditor.audit(List.of("badword"))).willReturn(List.of(
-                    new NicknameAuditResult("badword", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "영어 비속어")
-            ));
-            given(profanityWordManagementService.add("badword", Language.ENGLISH, WordSource.AI_FLAGGED)).willReturn(true);
+            given(nicknameAuditor.audit(List.of("badword")))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "badword", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "영어 비속어")));
+            given(profanityWordManagementService.add("badword", Language.ENGLISH, WordSource.AI_FLAGGED))
+                    .willReturn(true);
 
             processor.process(List.of(entity));
 
@@ -98,10 +113,11 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void 이미_등록된_단어는_차단_이벤트를_발행하지_않는다() {
             final NicknameAudit entity = new NicknameAudit("욕설닉네임");
-            given(nicknameAuditor.audit(List.of("욕설닉네임"))).willReturn(List.of(
-                    new NicknameAuditResult("욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "직접 욕설")
-            ));
-            given(profanityWordManagementService.add("욕설닉네임", Language.KOREAN, WordSource.AI_FLAGGED)).willReturn(false);
+            given(nicknameAuditor.audit(List.of("욕설닉네임")))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "직접 욕설")));
+            given(profanityWordManagementService.add("욕설닉네임", Language.KOREAN, WordSource.AI_FLAGGED))
+                    .willReturn(false);
 
             processor.process(List.of(entity));
 
@@ -111,9 +127,9 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void FLAGGED_처리_후_엔티티_상태가_업데이트된다() {
             final NicknameAudit entity = new NicknameAudit("욕설닉네임");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "직접 욕설")
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "직접 욕설")));
 
             processor.process(List.of(entity));
 
@@ -127,25 +143,26 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void 추출된_조각만_등록하고_닉네임_전체는_등록하지_않는다() {
             final NicknameAudit entity = new NicknameAudit("경찬이병신");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("경찬이병신", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95),
-                            "비속어 포함", List.of("병신"))
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "경찬이병신", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "비속어 포함", List.of("병신"))));
 
             processor.process(List.of(entity));
 
             then(profanityWordManagementService).should().add("병신", Language.KOREAN, WordSource.AI_FLAGGED);
-            then(profanityWordManagementService).should(never())
-                    .add(eq("경찬이병신"), any(), any());
+            then(profanityWordManagementService).should(never()).add(eq("경찬이병신"), any(), any());
         }
 
         @Test
         void 여러_조각이면_모두_등록된다() {
             final NicknameAudit entity = new NicknameAudit("시발경찬이병신");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("시발경찬이병신", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95),
-                            "비속어 포함", List.of("시발", "병신"))
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "시발경찬이병신",
+                            NicknameAuditStatus.FLAGGED,
+                            AiConfidence.of(0.95),
+                            "비속어 포함",
+                            List.of("시발", "병신"))));
 
             processor.process(List.of(entity));
 
@@ -156,25 +173,26 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void 닉네임에_없는_조각은_등록하지_않는다() {
             final NicknameAudit entity = new NicknameAudit("경찬이병신");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("경찬이병신", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95),
-                            "비속어 포함", List.of("병신", "핵상욕설"))
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "경찬이병신",
+                            NicknameAuditStatus.FLAGGED,
+                            AiConfidence.of(0.95),
+                            "비속어 포함",
+                            List.of("병신", "핵상욕설"))));
 
             processor.process(List.of(entity));
 
             then(profanityWordManagementService).should().add("병신", Language.KOREAN, WordSource.AI_FLAGGED);
-            then(profanityWordManagementService).should(never())
-                    .add(eq("핵상욕설"), any(), any());
+            then(profanityWordManagementService).should(never()).add(eq("핵상욕설"), any(), any());
         }
 
         @Test
         void 유효한_조각이_없으면_닉네임_전체를_폴백_등록한다() {
             final NicknameAudit entity = new NicknameAudit("씨발놈");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("씨발놈", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95),
-                            "비속어 포함", List.of("닉네임에없는말"))
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "씨발놈", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "비속어 포함", List.of("닉네임에없는말"))));
 
             processor.process(List.of(entity));
 
@@ -184,40 +202,46 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void 정규화_후_한_글자_조각은_과차단_방지를_위해_제외된다() {
             final NicknameAudit entity = new NicknameAudit("경찬이병신");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("경찬이병신", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95),
-                            "비속어 포함", List.of("병신", "이"))
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "경찬이병신",
+                            NicknameAuditStatus.FLAGGED,
+                            AiConfidence.of(0.95),
+                            "비속어 포함",
+                            List.of("병신", "이"))));
 
             processor.process(List.of(entity));
 
             then(profanityWordManagementService).should().add("병신", Language.KOREAN, WordSource.AI_FLAGGED);
-            then(profanityWordManagementService).should(never())
-                    .add(eq("이"), any(), any());
+            then(profanityWordManagementService).should(never()).add(eq("이"), any(), any());
         }
 
         @Test
         void 정규화_결과가_같은_조각은_한_번만_등록된다() {
             final NicknameAudit entity = new NicknameAudit("시1발놈");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("시1발놈", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95),
-                            "비속어 포함", List.of("시1발", "시i발"))
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "시1발놈",
+                            NicknameAuditStatus.FLAGGED,
+                            AiConfidence.of(0.95),
+                            "비속어 포함",
+                            List.of("시1발", "시i발"))));
 
             processor.process(List.of(entity));
 
             // leet 치환(1→i)으로 두 조각의 정규화 결과가 동일 → add는 한 번만 호출
-            then(profanityWordManagementService).should().add(eq("시1발"), eq(Language.KOREAN), eq(WordSource.AI_FLAGGED));
+            then(profanityWordManagementService)
+                    .should()
+                    .add(eq("시1발"), eq(Language.KOREAN), eq(WordSource.AI_FLAGGED));
             then(profanityWordManagementService).should(never()).add(eq("시i발"), any(), any());
         }
 
         @Test
         void 조각이_비어있으면_닉네임_전체를_폴백_등록한다() {
             final NicknameAudit entity = new NicknameAudit("욕설닉네임");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95),
-                            "비속어 포함", List.of())
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "비속어 포함", List.of())));
 
             processor.process(List.of(entity));
 
@@ -231,9 +255,9 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void CLEAN_닉네임은_비속어_등록_없이_상태만_업데이트된다() {
             final NicknameAudit entity = new NicknameAudit("용감한호랑이");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("용감한호랑이", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반 닉네임")
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "용감한호랑이", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반 닉네임")));
 
             processor.process(List.of(entity));
 
@@ -249,9 +273,9 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void PENDING_닉네임은_비속어_등록_없이_상태만_업데이트된다() {
             final NicknameAudit entity = new NicknameAudit("애매한닉네임");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("애매한닉네임", NicknameAuditStatus.PENDING, AiConfidence.of(0.6), "판단 불명확")
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "애매한닉네임", NicknameAuditStatus.PENDING, AiConfidence.of(0.6), "판단 불명확")));
 
             processor.process(List.of(entity));
 
@@ -280,14 +304,11 @@ class ProfanityAuditBatchProcessorTest {
 
         @Test
         void 처리된_엔티티_수를_반환한다() {
-            final List<NicknameAudit> batch = List.of(
-                    new NicknameAudit("닉네임1"),
-                    new NicknameAudit("닉네임2")
-            );
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("닉네임1", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반"),
-                    new NicknameAuditResult("닉네임2", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
-            ));
+            final List<NicknameAudit> batch = List.of(new NicknameAudit("닉네임1"), new NicknameAudit("닉네임2"));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(
+                            new NicknameAuditResult("닉네임1", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반"),
+                            new NicknameAuditResult("닉네임2", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")));
 
             final int processed = processor.process(batch);
 
@@ -302,9 +323,9 @@ class ProfanityAuditBatchProcessorTest {
         void 이미_terminal_행이_있는_닉네임의_UNAUDITED는_승격_대신_제거된다() {
             // #1467 fix 이전 잔존 데이터: (host, CLEAN)이 이미 존재하는 상태에서 (host, UNAUDITED) 승격 시도.
             final NicknameAudit residual = new NicknameAudit("host");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("host", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(
+                            new NicknameAuditResult("host", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")));
             given(auditRepository.findNicknamesWithTerminalStatus(anyList())).willReturn(Set.of("host"));
 
             processor.process(List.of(residual));
@@ -319,9 +340,9 @@ class ProfanityAuditBatchProcessorTest {
             // 기존 (host, CLEAN)이 있는데 이번 AI 결과가 FLAGGED인 경우. 상태가 달라 유니크 충돌은 없지만,
             // 승격하면 (host, CLEAN)+(host, FLAGGED) 모순 공존 + autoBlock 오발동이 생긴다. 제거가 정답이다.
             final NicknameAudit residual = new NicknameAudit("host");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("host", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "재판정")
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "host", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "재판정")));
             given(auditRepository.findNicknamesWithTerminalStatus(anyList())).willReturn(Set.of("host"));
 
             processor.process(List.of(residual));
@@ -335,9 +356,9 @@ class ProfanityAuditBatchProcessorTest {
         @Test
         void terminal_트윈이_없는_닉네임은_정상_승격된다() {
             final NicknameAudit fresh = new NicknameAudit("용감한호랑이");
-            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
-                    new NicknameAuditResult("용감한호랑이", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
-            ));
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(
+                            new NicknameAuditResult("용감한호랑이", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")));
             given(auditRepository.findNicknamesWithTerminalStatus(anyList())).willReturn(Set.of());
 
             processor.process(List.of(fresh));

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
@@ -64,8 +64,8 @@ class ProfanityAuditBatchProcessorTest {
             protected void doRollback(DefaultTransactionStatus status) {}
         });
 
-        final NicknameAuditProperties properties =
-                new NicknameAuditProperties("test-key", "gemini-test", 0.85, 10, 20, 2, Duration.ofSeconds(120));
+        final NicknameAuditProperties properties = new NicknameAuditProperties(
+                "test-key", "gemini-test", 0.85, 10, 20, 2, Duration.ofSeconds(120), Duration.ofMinutes(10));
         processor = new ProfanityAuditBatchProcessor(
                 auditRepository,
                 nicknameAuditor,
@@ -366,6 +366,48 @@ class ProfanityAuditBatchProcessorTest {
             then(auditRepository).should().saveAll(List.of(fresh));
             then(auditRepository).should(never()).deleteAll(any());
             assertThat(fresh.getStatus()).isEqualTo(NicknameAuditStatus.CLEAN);
+        }
+    }
+
+    /**
+     * 처리 건수는 <b>실제로 UNAUDITED에서 빠져나간 행 수</b>여야 한다.
+     *
+     * <p>배치 크기를 그대로 돌려주면, 판정을 못 짝지어 그대로 남은 행까지 처리했다고 세게 된다.
+     * 그러면 드레인 루프({@code ProfanityAuditService.auditPending})가 진행이 없는데도 같은 0페이지를
+     * 계속 다시 읽는다. 배치 전체가 짝을 못 찾으면 13초마다 Gemini를 부르며 영원히 돈다.
+     */
+    @Nested
+    class 처리_건수 {
+
+        @Test
+        void 판정을_짝짓지_못한_행은_처리_건수에서_빠진다() {
+            final NicknameAudit matched = new NicknameAudit("짝맞는닉");
+            final NicknameAudit unmatched = new NicknameAudit("짝없는닉");
+            // AI가 요청과 다른 이름을 돌려준 상황. "짝없는닉"에 대응하는 판정이 없다.
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "짝맞는닉", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반 닉네임")));
+            given(auditRepository.findNicknamesWithTerminalStatus(any())).willReturn(Set.of());
+
+            final int processed = processor.process(List.of(matched, unmatched));
+
+            assertThat(processed)
+                    .as("판정이 없어 UNAUDITED로 남은 행을 처리했다고 세면 드레인 루프가 멈추지 못한다.")
+                    .isEqualTo(1);
+        }
+
+        @Test
+        void 배치_전체가_짝을_못_찾으면_처리_건수가_0이다() {
+            final NicknameAudit first = new NicknameAudit("닉하나");
+            final NicknameAudit second = new NicknameAudit("닉둘");
+            given(nicknameAuditor.audit(anyList()))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "엉뚱한닉", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반 닉네임")));
+            given(auditRepository.findNicknamesWithTerminalStatus(any())).willReturn(Set.of());
+
+            final int processed = processor.process(List.of(first, second));
+
+            assertThat(processed).as("0을 돌려줘야 드레인 루프가 같은 페이지 반복을 멈춘다.").isZero();
         }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -1,5 +1,6 @@
 package coffeeshout.profanity.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -9,12 +10,15 @@ import static org.mockito.Mockito.never;
 
 import coffeeshout.profanity.application.port.NicknameAuditRepository;
 import coffeeshout.profanity.config.NicknameAuditProperties;
-import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
+import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,11 +37,15 @@ class ProfanityAuditServiceTest {
         batchProcessor = mock(ProfanityAuditBatchProcessor.class);
         profanityWordManagementService = mock(ProfanityWordManagementService.class);
 
-        final NicknameAuditProperties properties = new NicknameAuditProperties(
-                "api-key", "gemini-2.0-flash", 0.8, 10, 5, 2
-        );
-        service = new ProfanityAuditService(auditRepository, batchProcessor, profanityWordManagementService, properties,
-                new SimpleMeterRegistry(), Clock.systemDefaultZone());
+        final NicknameAuditProperties properties =
+                new NicknameAuditProperties("api-key", "gemini-2.0-flash", 0.8, 10, 5, 2);
+        service = new ProfanityAuditService(
+                auditRepository,
+                batchProcessor,
+                profanityWordManagementService,
+                properties,
+                new SimpleMeterRegistry(),
+                Clock.systemDefaultZone());
         service.initMetrics();
     }
 
@@ -46,8 +54,7 @@ class ProfanityAuditServiceTest {
 
         @Test
         void 새로운_닉네임은_UNAUDITED_상태로_저장된다() {
-            given(auditRepository.existsByNickname("새닉네임"))
-                    .willReturn(false);
+            given(auditRepository.existsByNickname("새닉네임")).willReturn(false);
 
             service.register("새닉네임");
 
@@ -59,8 +66,7 @@ class ProfanityAuditServiceTest {
             // issue #1467 재현: 이미 검열된(CLEAN 등) 닉네임이 재등장하면, 상태 무관 검사가 없으면
             // 새 UNAUDITED 중복이 생기고 다음 검열 시 (player_name, status) 유니크 충돌이 발생한다.
             // 상태와 무관하게 이미 존재하면 저장하지 않아야 한다.
-            given(auditRepository.existsByNickname("이미검열된닉네임"))
-                    .willReturn(true);
+            given(auditRepository.existsByNickname("이미검열된닉네임")).willReturn(true);
 
             service.register("이미검열된닉네임");
 
@@ -69,8 +75,7 @@ class ProfanityAuditServiceTest {
 
         @Test
         void 운영자_허용_닉네임은_검열_등록이_생략된다() {
-            given(profanityWordManagementService.isOperatorAllowed("허용닉네임"))
-                    .willReturn(true);
+            given(profanityWordManagementService.isOperatorAllowed("허용닉네임")).willReturn(true);
 
             service.register("허용닉네임");
 
@@ -83,9 +88,10 @@ class ProfanityAuditServiceTest {
 
         @Test
         void UNAUDITED_닉네임이_없으면_배치_처리를_하지_않는다() {
-            given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED)).willReturn(0L);
-            given(auditRepository.findByStatusAndAuditedAtIsNull(
-                    any(NicknameAuditStatus.class), any(Pageable.class))).willReturn(List.of());
+            given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED))
+                    .willReturn(0L);
+            given(auditRepository.findByStatusAndAuditedAtIsNull(any(NicknameAuditStatus.class), any(Pageable.class)))
+                    .willReturn(List.of());
 
             service.auditPending();
 
@@ -95,9 +101,9 @@ class ProfanityAuditServiceTest {
         @Test
         void UNAUDITED_닉네임이_있으면_배치_처리가_수행된다() {
             final NicknameAudit entity = new NicknameAudit("욕설닉네임");
-            given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED)).willReturn(1L);
-            given(auditRepository.findByStatusAndAuditedAtIsNull(
-                    any(NicknameAuditStatus.class), any(Pageable.class)))
+            given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED))
+                    .willReturn(1L);
+            given(auditRepository.findByStatusAndAuditedAtIsNull(any(NicknameAuditStatus.class), any(Pageable.class)))
                     .willReturn(List.of(entity))
                     .willReturn(List.of());
             given(batchProcessor.process(any())).willReturn(1);
@@ -105,6 +111,81 @@ class ProfanityAuditServiceTest {
             service.auditPending();
 
             then(batchProcessor).should().process(List.of(entity));
+        }
+    }
+
+    /**
+     * 재현 테스트 — 드레인 루프에 시간 예산이 없다.
+     *
+     * <p>{@code auditPending()}은 큐가 빌 때까지 배치를 연속으로 돈다. 배치 하나는 Gemini 호출 하나이고,
+     * 레이트리미터가 13초에 한 번만 허용하므로({@code resilience4j.yml}의 {@code geminiAudit.limit-refresh-period})
+     * 한 회차 소요 시간은 적체량에 정비례한다. 상한이 없어 적체가 크면 회차가 끝없이 길어진다.
+     *
+     * <p>이게 왜 위험한가. 프로덕션의 {@code @Scheduled}는 전부 스레드 하나를 공유한다
+     * ({@code DelayRemovalSchedulerConfig}가 유일한 {@code TaskScheduler} 빈이라 Spring Boot 자동설정이 물러난다).
+     * 그 안에 500ms 주기 Outbox 릴레이가 있다. 감사 회차가 길어지는 만큼 릴레이가 멈춘다.
+     *
+     * <p>수정 방향은 회차당 시간 예산 또는 최대 배치 수를 두는 것이다.
+     */
+    @Nested
+    class auditPending_한_회차_소요시간 {
+
+        /** 레이트리미터가 허용하는 최소 간격. {@code resilience4j.yml}의 geminiAudit.limit-refresh-period = 13s. */
+        private static final int SECONDS_PER_BATCH = 13;
+
+        /** 프로덕션 배치 크기. {@code service.yml}의 nickname-audit.batch-size. */
+        private static final int PRODUCTION_BATCH_SIZE = 100;
+
+        /** 한 회차가 공유 스케줄러 스레드를 붙잡아도 되는 상한. 이보다 길면 Outbox 릴레이가 굶는다. */
+        private static final int MAX_RUN_SECONDS = 600;
+
+        private static final int BACKLOG = 10_000;
+
+        @Test
+        void 적체가_크면_한_회차가_시간_예산을_넘긴다() {
+            final ProfanityAuditService target = productionSizedService();
+            final AtomicInteger remaining = new AtomicInteger(BACKLOG);
+            final AtomicLong simulatedSeconds = new AtomicLong();
+
+            given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED))
+                    .willReturn((long) BACKLOG);
+            given(auditRepository.findByStatusAndAuditedAtIsNull(any(NicknameAuditStatus.class), any(Pageable.class)))
+                    .willAnswer(invocation -> nextBatch(remaining));
+            given(batchProcessor.process(any())).willAnswer(invocation -> {
+                final List<NicknameAudit> batch = invocation.getArgument(0);
+                simulatedSeconds.addAndGet(SECONDS_PER_BATCH);
+                return batch.size();
+            });
+
+            target.auditPending();
+
+            assertThat(simulatedSeconds.get())
+                    .as("적체 %,d건을 비우는 데 걸리는 초. 이 시간 동안 공유 스케줄러 스레드가 묶인다.", BACKLOG)
+                    .isLessThanOrEqualTo(MAX_RUN_SECONDS);
+        }
+
+        private ProfanityAuditService productionSizedService() {
+            final NicknameAuditProperties production =
+                    new NicknameAuditProperties("api-key", "gemini-3.5-flash", 0.85, PRODUCTION_BATCH_SIZE, 20, 2);
+            final ProfanityAuditService target = new ProfanityAuditService(
+                    auditRepository,
+                    batchProcessor,
+                    profanityWordManagementService,
+                    production,
+                    new SimpleMeterRegistry(),
+                    Clock.systemDefaultZone());
+            target.initMetrics();
+            return target;
+        }
+
+        private List<NicknameAudit> nextBatch(AtomicInteger remaining) {
+            final int take = Math.min(PRODUCTION_BATCH_SIZE, remaining.get());
+            remaining.addAndGet(-take);
+            final List<NicknameAudit> batch = new ArrayList<>(take);
+            for (int i = 0; i < take; i++) {
+                batch.add(new NicknameAudit("닉" + i));
+            }
+            return batch;
         }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import coffeeshout.profanity.application.port.NicknameAuditRepository;
 import coffeeshout.profanity.config.NicknameAuditProperties;
@@ -16,10 +17,11 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,8 +40,8 @@ class ProfanityAuditServiceTest {
         batchProcessor = mock(ProfanityAuditBatchProcessor.class);
         profanityWordManagementService = mock(ProfanityWordManagementService.class);
 
-        final NicknameAuditProperties properties =
-                new NicknameAuditProperties("api-key", "gemini-2.0-flash", 0.8, 10, 5, 2, Duration.ofSeconds(120));
+        final NicknameAuditProperties properties = new NicknameAuditProperties(
+                "api-key", "gemini-2.0-flash", 0.8, 10, 5, 2, Duration.ofSeconds(120), Duration.ofMinutes(10));
         service = new ProfanityAuditService(
                 auditRepository,
                 batchProcessor,
@@ -116,17 +118,11 @@ class ProfanityAuditServiceTest {
     }
 
     /**
-     * 재현 테스트 — 드레인 루프에 시간 예산이 없다.
+     * 드레인 루프에 회차 시간 예산이 있는지 검증한다.
      *
-     * <p>{@code auditPending()}은 큐가 빌 때까지 배치를 연속으로 돈다. 배치 하나는 Gemini 호출 하나이고,
-     * 레이트리미터가 13초에 한 번만 허용하므로({@code resilience4j.yml}의 {@code geminiAudit.limit-refresh-period})
-     * 한 회차 소요 시간은 적체량에 정비례한다. 상한이 없어 적체가 크면 회차가 끝없이 길어진다.
-     *
-     * <p>이게 왜 위험한가. 프로덕션의 {@code @Scheduled}는 전부 스레드 하나를 공유한다
-     * ({@code DelayRemovalSchedulerConfig}가 유일한 {@code TaskScheduler} 빈이라 Spring Boot 자동설정이 물러난다).
-     * 그 안에 500ms 주기 Outbox 릴레이가 있다. 감사 회차가 길어지는 만큼 릴레이가 멈춘다.
-     *
-     * <p>수정 방향은 회차당 시간 예산 또는 최대 배치 수를 두는 것이다.
+     * <p>배치 하나가 Gemini 호출 하나이고 레이트리미터가 13초에 하나만 허용하므로
+     * ({@code resilience4j.yml}의 geminiAudit.limit-refresh-period) 회차 소요가 적체량에 정비례한다.
+     * 예산이 없으면 적체 10만 건에 3.6시간을 도는데 그동안 실행기 스레드를 붙잡고 있게 된다.
      */
     @Nested
     class auditPending_한_회차_소요시간 {
@@ -137,16 +133,17 @@ class ProfanityAuditServiceTest {
         /** 프로덕션 배치 크기. {@code service.yml}의 nickname-audit.batch-size. */
         private static final int PRODUCTION_BATCH_SIZE = 100;
 
-        /** 한 회차가 공유 스케줄러 스레드를 붙잡아도 되는 상한. 이보다 길면 Outbox 릴레이가 굶는다. */
+        /** 회차 예산. {@code service.yml}의 nickname-audit.max-run-duration. */
         private static final int MAX_RUN_SECONDS = 600;
 
         private static final int BACKLOG = 10_000;
 
         @Test
-        void 적체가_크면_한_회차가_시간_예산을_넘긴다() {
-            final ProfanityAuditService target = productionSizedService();
+        void 적체가_커도_한_회차는_시간_예산_안에서_끝난다() {
+            final StubClock clock = new StubClock(Instant.parse("2026-09-03T00:00:00Z"));
+            final Instant startedAt = clock.instant();
+            final ProfanityAuditService target = productionSizedService(clock);
             final AtomicInteger remaining = new AtomicInteger(BACKLOG);
-            final AtomicLong simulatedSeconds = new AtomicLong();
 
             given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED))
                     .willReturn((long) BACKLOG);
@@ -154,27 +151,51 @@ class ProfanityAuditServiceTest {
                     .willAnswer(invocation -> nextBatch(remaining));
             given(batchProcessor.process(any())).willAnswer(invocation -> {
                 final List<NicknameAudit> batch = invocation.getArgument(0);
-                simulatedSeconds.addAndGet(SECONDS_PER_BATCH);
+                clock.advance(Duration.ofSeconds(SECONDS_PER_BATCH));
                 return batch.size();
             });
 
             target.auditPending();
 
-            assertThat(simulatedSeconds.get())
-                    .as("적체 %,d건을 비우는 데 걸리는 초. 이 시간 동안 공유 스케줄러 스레드가 묶인다.", BACKLOG)
-                    .isLessThanOrEqualTo(MAX_RUN_SECONDS);
+            assertThat(Duration.between(startedAt, clock.instant()).toSeconds())
+                    .as("적체 %,d건 회차가 붙잡은 시간(초). 예산 확인이 배치 사이에 걸리므로 한 배치까지 초과할 수 있다.", BACKLOG)
+                    .isLessThanOrEqualTo(MAX_RUN_SECONDS + SECONDS_PER_BATCH);
         }
 
-        private ProfanityAuditService productionSizedService() {
+        @Test
+        void 진행이_없으면_같은_페이지를_반복해_읽지_않는다() {
+            final StubClock clock = new StubClock(Instant.parse("2026-09-03T00:00:00Z"));
+            final ProfanityAuditService target = productionSizedService(clock);
+
+            given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED))
+                    .willReturn((long) PRODUCTION_BATCH_SIZE);
+            given(auditRepository.findByStatusAndAuditedAtIsNull(any(NicknameAuditStatus.class), any(Pageable.class)))
+                    .willAnswer(invocation -> batchOf(PRODUCTION_BATCH_SIZE));
+            // 배치 전체가 판정을 못 받아 UNAUDITED로 남은 상황. 처리 건수가 0이면 다시 읽어봐야 같은 행이다.
+            given(batchProcessor.process(any())).willReturn(0);
+
+            target.auditPending();
+
+            then(batchProcessor).should(times(1)).process(any());
+        }
+
+        private ProfanityAuditService productionSizedService(Clock clock) {
             final NicknameAuditProperties production = new NicknameAuditProperties(
-                    "api-key", "gemini-3.5-flash", 0.85, PRODUCTION_BATCH_SIZE, 20, 2, Duration.ofSeconds(120));
+                    "api-key",
+                    "gemini-3.5-flash",
+                    0.85,
+                    PRODUCTION_BATCH_SIZE,
+                    20,
+                    2,
+                    Duration.ofSeconds(120),
+                    Duration.ofSeconds(MAX_RUN_SECONDS));
             final ProfanityAuditService target = new ProfanityAuditService(
                     auditRepository,
                     batchProcessor,
                     profanityWordManagementService,
                     production,
                     new SimpleMeterRegistry(),
-                    Clock.systemDefaultZone());
+                    clock);
             target.initMetrics();
             return target;
         }
@@ -182,11 +203,44 @@ class ProfanityAuditServiceTest {
         private List<NicknameAudit> nextBatch(AtomicInteger remaining) {
             final int take = Math.min(PRODUCTION_BATCH_SIZE, remaining.get());
             remaining.addAndGet(-take);
-            final List<NicknameAudit> batch = new ArrayList<>(take);
-            for (int i = 0; i < take; i++) {
+            return batchOf(take);
+        }
+
+        private List<NicknameAudit> batchOf(int size) {
+            final List<NicknameAudit> batch = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
                 batch.add(new NicknameAudit("닉" + i));
             }
             return batch;
+        }
+    }
+
+    /** 배치 소요 시간을 흉내내기 위한 수동 진행 시계. */
+    private static final class StubClock extends Clock {
+
+        private Instant now;
+
+        private StubClock(Instant start) {
+            this.now = start;
+        }
+
+        void advance(Duration amount) {
+            now = now.plus(amount);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
         }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -14,6 +14,7 @@ import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +39,7 @@ class ProfanityAuditServiceTest {
         profanityWordManagementService = mock(ProfanityWordManagementService.class);
 
         final NicknameAuditProperties properties =
-                new NicknameAuditProperties("api-key", "gemini-2.0-flash", 0.8, 10, 5, 2);
+                new NicknameAuditProperties("api-key", "gemini-2.0-flash", 0.8, 10, 5, 2, Duration.ofSeconds(120));
         service = new ProfanityAuditService(
                 auditRepository,
                 batchProcessor,
@@ -165,8 +166,8 @@ class ProfanityAuditServiceTest {
         }
 
         private ProfanityAuditService productionSizedService() {
-            final NicknameAuditProperties production =
-                    new NicknameAuditProperties("api-key", "gemini-3.5-flash", 0.85, PRODUCTION_BATCH_SIZE, 20, 2);
+            final NicknameAuditProperties production = new NicknameAuditProperties(
+                    "api-key", "gemini-3.5-flash", 0.85, PRODUCTION_BATCH_SIZE, 20, 2, Duration.ofSeconds(120));
             final ProfanityAuditService target = new ProfanityAuditService(
                     auditRepository,
                     batchProcessor,

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -215,6 +215,35 @@ class ProfanityAuditServiceTest {
         }
     }
 
+    /**
+     * 종료 신호가 회차를 끊는지 검증한다.
+     *
+     * <p>회차는 전용 실행기에서 돌고 그 실행기는 destroyMethod가 {@code shutdownNow}다. 종료 시 회차 스레드에
+     * 인터럽트가 오는데, 루프가 그걸 안 보면 컨텍스트 종료가 회차 예산(기본 10분)만큼 밀린다.
+     * Blue/Green 전환에서 구 컨테이너가 그만큼 늦게 내려가거나 SIGKILL을 맞는다.
+     */
+    @Nested
+    class auditPending_종료_요청 {
+
+        @Test
+        void 인터럽트가_걸려_있으면_배치를_시작하지_않는다() {
+            given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED))
+                    .willReturn(1L);
+            given(auditRepository.findByStatusAndAuditedAtIsNull(any(NicknameAuditStatus.class), any(Pageable.class)))
+                    .willReturn(List.of(new NicknameAudit("닉네임")));
+
+            Thread.currentThread().interrupt();
+            try {
+                service.auditPending();
+            } finally {
+                // 다음 테스트로 새지 않게 플래그를 지운다.
+                Thread.interrupted();
+            }
+
+            then(batchProcessor).should(never()).process(any());
+        }
+    }
+
     /** 배치 소요 시간을 흉내내기 위한 수동 진행 시계. */
     private static final class StubClock extends Clock {
 

--- a/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditConfigTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditConfigTest.java
@@ -1,0 +1,32 @@
+package coffeeshout.profanity.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.genai.types.HttpOptions;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Gemini 클라이언트에 HTTP 타임아웃이 걸리는지 검증한다.
+ *
+ * <p>타임아웃이 없으면 응답이 끝내 오지 않는 호출 하나가 스케줄러 스레드를 무기한 점유한다.
+ * 레이트리미터의 {@code timeout-duration}은 허용량을 기다리는 시간이지 HTTP 타임아웃이 아니라
+ * 이걸 대신하지 못한다.
+ */
+class NicknameAuditConfigTest {
+
+    @Test
+    void 요청_타임아웃이_밀리초로_변환되어_설정된다() {
+        final NicknameAuditProperties properties = propertiesWithTimeout(Duration.ofSeconds(90));
+
+        final HttpOptions httpOptions = NicknameAuditConfig.httpOptions(properties);
+
+        assertThat(httpOptions.timeout())
+                .as("HttpOptions.timeout 은 밀리초 단위다. 초 단위 값을 그대로 넣으면 90ms 가 되어 모든 호출이 즉시 끊긴다.")
+                .contains(90_000);
+    }
+
+    private NicknameAuditProperties propertiesWithTimeout(Duration timeout) {
+        return new NicknameAuditProperties("api-key", "gemini-3.5-flash", 0.85, 100, 20, 2, timeout);
+    }
+}

--- a/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditConfigTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditConfigTest.java
@@ -27,6 +27,7 @@ class NicknameAuditConfigTest {
     }
 
     private NicknameAuditProperties propertiesWithTimeout(Duration timeout) {
-        return new NicknameAuditProperties("api-key", "gemini-3.5-flash", 0.85, 100, 20, 2, timeout);
+        return new NicknameAuditProperties(
+                "api-key", "gemini-3.5-flash", 0.85, 100, 20, 2, timeout, Duration.ofMinutes(10));
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorConnectivityTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorConnectivityTest.java
@@ -13,6 +13,7 @@ import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.genai.Client;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -23,14 +24,8 @@ import org.springframework.data.domain.PageRequest;
 class GeminiNicknameAuditorConnectivityTest {
 
     private static final String API_KEY = System.getenv("GEMINI_API_KEY");
-    private static final NicknameAuditProperties PROPERTIES = new NicknameAuditProperties(
-            API_KEY,
-            "gemini-3.5-flash",
-            0.85,
-            100,
-            20,
-            2
-    );
+    private static final NicknameAuditProperties PROPERTIES =
+            new NicknameAuditProperties(API_KEY, "gemini-3.5-flash", 0.85, 100, 20, 2, Duration.ofSeconds(120));
 
     private GeminiNicknameAuditor auditor;
 
@@ -47,8 +42,7 @@ class GeminiNicknameAuditorConnectivityTest {
                 PROPERTIES,
                 feedbackRepository,
                 new NicknameAuditPromptTemplate(objectMapper),
-                new SimpleMeterRegistry()
-        );
+                new SimpleMeterRegistry());
     }
 
     @Test

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorConnectivityTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorConnectivityTest.java
@@ -24,8 +24,8 @@ import org.springframework.data.domain.PageRequest;
 class GeminiNicknameAuditorConnectivityTest {
 
     private static final String API_KEY = System.getenv("GEMINI_API_KEY");
-    private static final NicknameAuditProperties PROPERTIES =
-            new NicknameAuditProperties(API_KEY, "gemini-3.5-flash", 0.85, 100, 20, 2, Duration.ofSeconds(120));
+    private static final NicknameAuditProperties PROPERTIES = new NicknameAuditProperties(
+            API_KEY, "gemini-3.5-flash", 0.85, 100, 20, 2, Duration.ofSeconds(120), Duration.ofMinutes(10));
 
     private GeminiNicknameAuditor auditor;
 

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/NicknameAuditSchedulerTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/NicknameAuditSchedulerTest.java
@@ -6,39 +6,34 @@ import static org.mockito.Mockito.mock;
 
 import coffeeshout.global.lock.RedisLock;
 import coffeeshout.profanity.application.ProfanityAuditService;
-import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * 재현 테스트 — 12시간 주기 검열 스케줄러의 구조적 결함 두 가지.
- *
- * <p>둘 다 실사용자 트래픽 없이 재현된다. 지금 프로덕션에 잠복해 있고, 조건이 맞으면 오늘 터진다.
+ * 12시간 주기 검열 스케줄러의 구조적 결함 두 가지를 고정한다. 둘 다 실사용자 트래픽 없이 재현된다.
  */
 class NicknameAuditSchedulerTest {
 
     /**
-     * 결함 1 — 감사 작업이 스케줄러 스레드에서 동기로 돈다.
+     * 결함 1 — 감사 작업이 스케줄러 스레드에서 동기로 돌면 안 된다.
      *
-     * <p>프로덕션에는 {@code taskScheduler}라는 이름의 빈이 없고, {@code DelayRemovalSchedulerConfig}가
-     * 정의한 {@code TaskScheduler} 빈 하나만 있다. Spring Boot의 {@code TaskSchedulingAutoConfiguration}은
-     * {@code @ConditionalOnMissingBean(TaskScheduler.class)}이라 물러나고, 결과적으로 모든 {@code @Scheduled}가
-     * 풀 크기 1로 수렴한다. 그 안에 500ms 주기 Outbox 릴레이가 있다.
+     * <p>프로덕션에는 {@code taskScheduler}라는 이름의 빈이 없고 {@code DelayRemovalSchedulerConfig}가
+     * 정의한 {@code TaskScheduler} 빈 하나만 있다. Spring Boot의 {@code TaskSchedulingAutoConfiguration}이
+     * {@code @ConditionalOnMissingBean(TaskScheduler.class)}이라 물러나면서 모든 {@code @Scheduled}가
+     * 풀 크기 1로 수렴하고, 그 안에 500ms 주기 Outbox 릴레이가 있다.
      *
-     * <p>따라서 {@code auditPendingNicknames()}가 반환하지 않는 동안 앱의 모든 스케줄 작업이 멈춘다.
-     * 적체 1만 건이면 21분, 10만 건이면 3.6시간이다. Gemini 응답이 끝내 오지 않으면 무기한이다
-     * ({@code NicknameAuditConfig}가 HTTP 타임아웃을 설정하지 않는다).
-     *
-     * <p>수정 방향은 감사 작업을 이미 있는 {@code virtualThreadExecutor}로 넘기고 스케줄러 메서드는
-     * 즉시 반환하게 하는 것이다.
+     * <p>검열 회차는 적체량에 비례해 분에서 시간 단위로 길어지므로, 스케줄러 스레드에서 직접 돌리면
+     * 그동안 앱의 모든 스케줄 작업이 멈춘다.
      */
     @Nested
     class 스케줄러_스레드_점유 {
 
-        private static final long DISPATCH_TIMEOUT_SECONDS = 1;
+        private static final long DISPATCH_TIMEOUT_SECONDS = 5;
 
         @Test
         void 감사_작업은_스케줄러_스레드와_다른_스레드에서_돌아야_한다() throws InterruptedException {
@@ -52,46 +47,65 @@ class NicknameAuditSchedulerTest {
                     })
                     .given(auditService)
                     .auditPending();
-            final NicknameAuditScheduler scheduler = new NicknameAuditScheduler(auditService);
-            final Thread schedulerThread = Thread.currentThread();
 
-            scheduler.auditPendingNicknames();
-            auditStarted.await(DISPATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            final ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                final NicknameAuditScheduler scheduler = new NicknameAuditScheduler(auditService, executor);
+                final Thread schedulerThread = Thread.currentThread();
 
-            assertThat(executingThread.get())
-                    .as("감사 작업을 실행한 스레드. 스케줄러 스레드와 같으면 회차가 끝날 때까지" + " Outbox 릴레이를 포함한 모든 @Scheduled 작업이 대기한다.")
-                    .isNotNull()
-                    .isNotSameAs(schedulerThread);
+                scheduler.auditPendingNicknames();
+                auditStarted.await(DISPATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+                assertThat(executingThread.get())
+                        .as("감사 작업을 실행한 스레드. 스케줄러 스레드와 같으면 회차가 끝날 때까지" + " Outbox 릴레이를 포함한 모든 @Scheduled 작업이 대기한다.")
+                        .isNotNull()
+                        .isNotSameAs(schedulerThread);
+            } finally {
+                executor.shutdownNow();
+            }
         }
     }
 
     /**
-     * 결함 2 — 분산 락이 없어 인스턴스 여러 대가 같은 큐를 동시에 읽는다.
+     * 결함 2 — 분산 락이 없으면 인스턴스 여러 대가 같은 큐를 동시에 읽는다.
      *
-     * <p>프로덕션은 Blue/Green이다({@code docker/prod/docker-compose.yml}). 전환 구간에는 두 컨테이너가
-     * 동시에 살아 있고, 그때 cron(00:00·12:00)이 걸리면 두 인스턴스가 큐의 같은 0페이지를 읽는다.
-     * 레이트리미터는 JVM 로컬이라 실제 RPM이 두 배가 되어 Gemini 무료 티어 한도 5를 넘고,
-     * 429가 재시도를 소진시켜 배치가 통째로 skip된다. 같은 닉네임에 대해 자동 차단도 중복 발동한다.
+     * <p>프로덕션은 Blue/Green이다. 전환 구간에는 두 컨테이너가 동시에 살아 있고, 그때 cron이 걸리면
+     * 두 인스턴스가 큐의 같은 0페이지를 읽는다. 레이트리미터는 JVM 로컬이라 실제 RPM이 두 배가 되어
+     * Gemini 무료 티어 한도를 넘고, 429가 재시도를 소진시켜 배치가 통째로 skip된다.
      *
-     * <p>같은 저장소의 다른 경로들은 이미 {@code @RedisLock}을 쓴다
-     * ({@code RoulettePersistenceService}, {@code MiniGamePersistenceService}). 검열 스케줄러만 맨몸이다.
-     *
-     * <p>주의 — 수정할 때 {@code leaseTime} 기본값 5초를 그대로 쓰면 안 된다. 감사 회차는 분에서 시간
-     * 단위라 실행 중에 락이 만료되고, 그 사이 다른 인스턴스가 락을 새로 잡는다. 회차 상한(결함 1의 시간 예산)에
-     * 맞춰 명시해야 한다.
+     * <p>락은 스케줄러가 아니라 {@link ProfanityAuditService#auditPending()}에 있어야 한다. 스케줄러는
+     * 작업을 실행기로 넘기고 즉시 반환하므로, 거기 걸면 넘기자마자 락이 풀려 아무것도 지키지 못한다.
      */
     @Nested
     class 다중_인스턴스_중복_실행 {
 
+        /** 회차 예산 기본값 10분. leaseTime 은 이보다 길어야 실행 중 락이 풀리지 않는다. */
+        private static final long MAX_RUN_MILLIS = 600_000L;
+
+        private RedisLock auditPendingLock() throws NoSuchMethodException {
+            return ProfanityAuditService.class.getDeclaredMethod("auditPending").getAnnotation(RedisLock.class);
+        }
+
         @Test
-        void 검열_스케줄러는_분산_락으로_보호되어야_한다() throws NoSuchMethodException {
-            final Method scheduledMethod = NicknameAuditScheduler.class.getDeclaredMethod("auditPendingNicknames");
-
-            final RedisLock redisLock = scheduledMethod.getAnnotation(RedisLock.class);
-
-            assertThat(redisLock)
+        void 검열_작업은_분산_락으로_보호되어야_한다() throws NoSuchMethodException {
+            assertThat(auditPendingLock())
                     .as("Blue/Green 전환 구간에 두 인스턴스가 같은 큐를 동시에 검열하는 것을 막는 락이 없다.")
                     .isNotNull();
+        }
+
+        @Test
+        void 락_유지시간은_회차_예산보다_길어야_한다() throws NoSuchMethodException {
+            assertThat(auditPendingLock().leaseTime())
+                    .as("Redisson 은 leaseTime 을 명시하면 워치독 갱신 없이 그 시간 뒤 락을 자동 해제한다."
+                            + " 회차 예산보다 짧으면 실행 도중 락이 풀려 다른 인스턴스가 끼어든다.")
+                    .isGreaterThan(MAX_RUN_MILLIS);
+        }
+
+        @Test
+        void 완료_마킹_TTL은_cron_주기보다_짧아야_한다() throws NoSuchMethodException {
+            assertThat(auditPendingLock().doneTtl())
+                    .as("완료 마킹이 cron 주기(12시간)보다 오래 남으면 다음 회차가 조용히 건너뛰어진다.")
+                    .isLessThan(TimeUnit.HOURS.toMillis(12));
         }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/NicknameAuditSchedulerTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/NicknameAuditSchedulerTest.java
@@ -1,0 +1,97 @@
+package coffeeshout.profanity.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+
+import coffeeshout.global.lock.RedisLock;
+import coffeeshout.profanity.application.ProfanityAuditService;
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 재현 테스트 — 12시간 주기 검열 스케줄러의 구조적 결함 두 가지.
+ *
+ * <p>둘 다 실사용자 트래픽 없이 재현된다. 지금 프로덕션에 잠복해 있고, 조건이 맞으면 오늘 터진다.
+ */
+class NicknameAuditSchedulerTest {
+
+    /**
+     * 결함 1 — 감사 작업이 스케줄러 스레드에서 동기로 돈다.
+     *
+     * <p>프로덕션에는 {@code taskScheduler}라는 이름의 빈이 없고, {@code DelayRemovalSchedulerConfig}가
+     * 정의한 {@code TaskScheduler} 빈 하나만 있다. Spring Boot의 {@code TaskSchedulingAutoConfiguration}은
+     * {@code @ConditionalOnMissingBean(TaskScheduler.class)}이라 물러나고, 결과적으로 모든 {@code @Scheduled}가
+     * 풀 크기 1로 수렴한다. 그 안에 500ms 주기 Outbox 릴레이가 있다.
+     *
+     * <p>따라서 {@code auditPendingNicknames()}가 반환하지 않는 동안 앱의 모든 스케줄 작업이 멈춘다.
+     * 적체 1만 건이면 21분, 10만 건이면 3.6시간이다. Gemini 응답이 끝내 오지 않으면 무기한이다
+     * ({@code NicknameAuditConfig}가 HTTP 타임아웃을 설정하지 않는다).
+     *
+     * <p>수정 방향은 감사 작업을 이미 있는 {@code virtualThreadExecutor}로 넘기고 스케줄러 메서드는
+     * 즉시 반환하게 하는 것이다.
+     */
+    @Nested
+    class 스케줄러_스레드_점유 {
+
+        private static final long DISPATCH_TIMEOUT_SECONDS = 1;
+
+        @Test
+        void 감사_작업은_스케줄러_스레드와_다른_스레드에서_돌아야_한다() throws InterruptedException {
+            final CountDownLatch auditStarted = new CountDownLatch(1);
+            final AtomicReference<Thread> executingThread = new AtomicReference<>();
+            final ProfanityAuditService auditService = mock(ProfanityAuditService.class);
+            willAnswer(invocation -> {
+                        executingThread.set(Thread.currentThread());
+                        auditStarted.countDown();
+                        return null;
+                    })
+                    .given(auditService)
+                    .auditPending();
+            final NicknameAuditScheduler scheduler = new NicknameAuditScheduler(auditService);
+            final Thread schedulerThread = Thread.currentThread();
+
+            scheduler.auditPendingNicknames();
+            auditStarted.await(DISPATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            assertThat(executingThread.get())
+                    .as("감사 작업을 실행한 스레드. 스케줄러 스레드와 같으면 회차가 끝날 때까지" + " Outbox 릴레이를 포함한 모든 @Scheduled 작업이 대기한다.")
+                    .isNotNull()
+                    .isNotSameAs(schedulerThread);
+        }
+    }
+
+    /**
+     * 결함 2 — 분산 락이 없어 인스턴스 여러 대가 같은 큐를 동시에 읽는다.
+     *
+     * <p>프로덕션은 Blue/Green이다({@code docker/prod/docker-compose.yml}). 전환 구간에는 두 컨테이너가
+     * 동시에 살아 있고, 그때 cron(00:00·12:00)이 걸리면 두 인스턴스가 큐의 같은 0페이지를 읽는다.
+     * 레이트리미터는 JVM 로컬이라 실제 RPM이 두 배가 되어 Gemini 무료 티어 한도 5를 넘고,
+     * 429가 재시도를 소진시켜 배치가 통째로 skip된다. 같은 닉네임에 대해 자동 차단도 중복 발동한다.
+     *
+     * <p>같은 저장소의 다른 경로들은 이미 {@code @RedisLock}을 쓴다
+     * ({@code RoulettePersistenceService}, {@code MiniGamePersistenceService}). 검열 스케줄러만 맨몸이다.
+     *
+     * <p>주의 — 수정할 때 {@code leaseTime} 기본값 5초를 그대로 쓰면 안 된다. 감사 회차는 분에서 시간
+     * 단위라 실행 중에 락이 만료되고, 그 사이 다른 인스턴스가 락을 새로 잡는다. 회차 상한(결함 1의 시간 예산)에
+     * 맞춰 명시해야 한다.
+     */
+    @Nested
+    class 다중_인스턴스_중복_실행 {
+
+        @Test
+        void 검열_스케줄러는_분산_락으로_보호되어야_한다() throws NoSuchMethodException {
+            final Method scheduledMethod = NicknameAuditScheduler.class.getDeclaredMethod("auditPendingNicknames");
+
+            final RedisLock redisLock = scheduledMethod.getAnnotation(RedisLock.class);
+
+            assertThat(redisLock)
+                    .as("Blue/Green 전환 구간에 두 인스턴스가 같은 큐를 동시에 검열하는 것을 막는 락이 없다.")
+                    .isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1752

> 브랜치명에 이슈 번호가 없다. 재현 테스트만 만들 생각으로 경량 경로로 시작했는데 수정까지 이어져 전체 경로로 확정됐다(`SRC_LINES=846`). 그래서 이슈를 뒤늦게 만들고 여기 직접 적는다.

# 🚀 작업 내용

## 무엇이 달라지는가

닉네임 AI 검열이 오래 걸려도 다른 예약 작업이 멈추지 않는다. 서버가 여러 대여도 검열은 한 대에서만 돌고, 응답 없는 AI 호출이 서버를 붙잡지 않는다.

## 왜 바꿨는가

검열 스케줄러가 앱 전체의 예약 작업을 멈출 수 있는 상태였다. 프로덕션에는 `taskScheduler`라는 이름의 빈이 없고 `DelayRemovalSchedulerConfig`가 정의한 `TaskScheduler` 하나만 있다. Spring Boot의 `TaskSchedulingAutoConfiguration`은 `@ConditionalOnMissingBean(TaskScheduler.class)`이라 이때 물러난다. 그 결과 모든 `@Scheduled`가 풀 크기 1로 수렴한다.

그 스레드를 500ms 주기 Outbox 릴레이가 함께 쓴다. 검열 회차는 적체량에 비례해 길어진다. 배치 하나가 Gemini 호출 하나이고 레이트리미터가 13초에 하나만 허용하기 때문이다. 적체 1만 건이면 21분, 10만 건이면 3.6시간이다. 그동안 릴레이가 멈춘다.

여기에 두 가지가 더 겹쳐 있었다. Gemini 호출에 HTTP 타임아웃이 없어 응답이 끝내 오지 않으면 점유가 무기한이 된다. 그리고 분산 락이 없어 Blue/Green 전환 구간에 두 인스턴스가 같은 큐를 읽는다. 레이트리미터가 JVM 로컬이라 이때 실제 RPM이 두 배가 되어 무료 티어 한도를 넘는다.

## 흐름 그림

```mermaid
sequenceDiagram
    participant S as 스케줄러 스레드
    participant E as virtualThreadExecutor
    participant A as ProfanityAuditService
    participant G as Gemini

    Note over S: 12시간 cron
    S->>E: 작업 넘기고 즉시 반환
    Note over S: Outbox 릴레이가 계속 돈다
    E->>A: auditPending() · @RedisLock
    loop 시간 예산 안에서만
        A->>G: 배치 100건 (타임아웃 120s)
        G-->>A: 판정
        Note over A: 진행이 0이면 중단
    end
    Note over A: 예산 소진 시 남은 적체는 다음 회차로
```

## 변경 목록

1. **검열 작업을 스케줄러 스레드에서 뗐다.** 스케줄러가 이미 있는 `virtualThreadExecutor`로 넘기고 즉시 반환한다. 새 실행기를 만들지 않았다. `NicknameAuditScheduler`

2. **회차에 시간 예산을 뒀다.** 예산을 넘으면 남은 적체를 다음 회차로 넘긴다. 기본 10분이다. `nickname-audit.max-run-duration`, `ProfanityAuditService.auditPending`

3. **분산 락을 걸었다.** 위치가 스케줄러가 아니라 `auditPending()`인 이유는 1번 때문이다. 스케줄러는 작업을 넘기자마자 반환하므로 거기 걸면 락도 함께 풀려 아무것도 지키지 못한다. `ProfanityAuditService.auditPending`

4. **락 유지 시간을 15분으로 명시했다.** Redisson은 `leaseTime`을 명시하면 워치독 갱신 없이 그 시간 뒤 락을 자동 해제한다. 기본값 5초를 그대로 쓰면 회차 중간에 락이 풀려 다른 인스턴스가 끼어든다. 완료 마킹 TTL은 1분으로 줄였다. cron 주기보다 오래 남으면 다음 회차가 조용히 건너뛰어지기 때문이다.

5. **Gemini 호출에 HTTP 타임아웃을 걸었다.** 기본 120초다. `batch-size`를 올리면 응답 생성 시간도 늘어나므로 함께 올려야 한다는 것을 설정과 프로퍼티 양쪽에 적었다. `nickname-audit.request-timeout`, `NicknameAuditConfig`

6. **처리 건수를 실제 진행분으로 바꿨다.** `process()`가 `batch.size()`를 그대로 돌려주고 있었다. 판정을 짝짓지 못해 UNAUDITED로 남은 행까지 처리했다고 세는 셈이다. 드레인 루프는 항상 0페이지를 다시 읽으므로, 배치 전체가 짝을 못 찾으면 같은 100건을 13초마다 Gemini에 보내며 멈추지 않는다. `ProfanityAuditBatchProcessor.settle`

7. **애초에 짝이 어긋나지 않도록 막았다.** AI 응답이 요청한 닉네임을 전부 덮는지 확인하고, 빠진 것을 PENDING으로 메운다. 기존 보정은 응답 개수가 부족한 경우만 다뤘다. 개수는 맞고 이름만 다른 경우가 뚫려 있었다. AI가 공백을 붙이거나 글자를 바꿔 돌려주면 여기 걸린다. `GeminiNicknameAuditor.fillUnmatched`

## 검증

수정 코드보다 먼저 재현 테스트를 작성해 결함을 실패로 고정한 뒤 고쳤다. 커밋을 그 순서로 나눠뒀다.

- `NicknameAuditSchedulerTest` — 감사 작업이 스케줄러 스레드와 다른 스레드에서 도는지, 분산 락이 있는지, 락 유지 시간이 회차 예산보다 긴지, 완료 마킹 TTL이 cron 주기보다 짧은지
- `ProfanityAuditServiceTest` — 적체 1만 건 회차가 시간 예산 안에서 끝나는지. 실제로 기다리지 않고 수동 진행 시계로 배치당 13초를 흉내낸다
- `ProfanityAuditBatchProcessorTest` — 판정을 짝짓지 못한 행이 처리 건수에서 빠지는지, 배치 전체가 짝을 못 찾으면 0을 돌려주는지
- `NicknameAuditConfigTest` — 타임아웃이 밀리초로 변환되는지. `HttpOptions.timeout`이 밀리초 단위라 초 단위 값을 그대로 넣으면 모든 호출이 즉시 끊긴다

`:profanity` 196개 전부 통과. PMD `pmdMain`·`pmdTest` 통과. 돌연변이 검증도 했다. 처리 건수를 `batch.size()`로 되돌리면 6번 관련 테스트 2개가 실패한다.

# 💬 리뷰 중점사항

**락 위치를 봐주세요.** `@RedisLock`을 스케줄러가 아니라 `auditPending()`에 걸었습니다. 작업을 실행기로 넘기면 스케줄러 메서드는 즉시 반환하므로 거기 건 락은 바로 풀립니다. 다만 이제 락이 애플리케이션 서비스 메서드에 붙어 있어서, 이 메서드를 다른 경로에서 부르게 되면 의도가 흐려질 수 있습니다.

**`leaseTime` 15분과 `max-run-duration` 10분의 관계가 상수와 프로퍼티로 갈라져 있습니다.** 어노테이션 값은 컴파일 타임 상수여야 해서 프로퍼티를 참조할 수 없었습니다. 지금은 `ProfanityAuditService`의 상수 주석과 프로퍼티 javadoc 양쪽에 "예산보다 길어야 한다"를 적어뒀고, 테스트가 `leaseTime > 600_000`을 검사합니다. 더 나은 방법이 있으면 알려주세요.

**응답에서 짝을 못 찾은 닉네임을 PENDING으로 보내는 게 맞을까요?** CLEAN으로 두면 검열을 건너뛰는 셈이고, FLAGGED로 두면 판정 없이 차단하는 셈이라 PENDING을 골랐습니다. 다만 AI가 체계적으로 이름을 바꿔 돌려주기 시작하면 운영자 대시보드가 PENDING으로 넘칩니다. 조용히 무한 반복하는 것보다는 낫다고 봤습니다.

# 🙅 이번에 하지 않은 것

- **시도 횟수와 DLQ.** `attempt_count` 컬럼과 `DEAD_LETTER` 상태로 실패한 항목이 스스로 큐를 빠져나가게 하는 일은 다음으로 미뤘다. 이번에는 무한 반복을 멈추는 데까지만 했다.
- **`audit()` 호출의 `try/catch`.** AI 응답 파싱이 실패하면 `InfrastructureException`이 스케줄러까지 올라가 회차가 죽는다. `resilience4j.yml`이 이 예외를 재시도 대상에서 제외하고 아무도 잡지 않기 때문이다. 별도로 다룰 범위라 남겨뒀다.
- **배치 트랜잭션 분할.** 배치 100건이 여전히 한 트랜잭션이라 1건 실패가 99건을 되돌린다.
- **처리량 개선.** 배치 크기, `thinking_level`, 모델 샤딩은 전부 범위 밖이다. 이번 변경은 그것들을 시작할 수 있는 상태를 만드는 데까지다.
