### PR TITLE
[fix] 레이싱 게임 서버 정확성 — Runner 동기화, 시작 순서, 속도 상한 검증

### DIFF
--- a/backend/game/src/main/java/coffeeshout/racinggame/application/RacingGameService.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/application/RacingGameService.java
@@ -2,10 +2,10 @@ package coffeeshout.racinggame.application;
 
 import coffeeshout.gamecommon.JoinCode;
 import coffeeshout.minigame.application.GameSessionService;
-import coffeeshout.racinggame.config.RacingGameTimingProperties;
 import coffeeshout.minigame.domain.MiniGameService;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.minigame.event.dto.MiniGameFinishedEvent;
+import coffeeshout.racinggame.config.RacingGameTimingProperties;
 import coffeeshout.racinggame.domain.RacingGame;
 import coffeeshout.racinggame.domain.RacingGameState;
 import coffeeshout.racinggame.domain.SpeedCalculator;
@@ -35,8 +35,7 @@ public class RacingGameService implements MiniGameService {
             @Qualifier("racingGameScheduler") TaskScheduler taskScheduler,
             ApplicationEventPublisher eventPublisher,
             SpeedCalculator speedCalculator,
-            RacingGameTimingProperties timing
-    ) {
+            RacingGameTimingProperties timing) {
         this.gameSessionService = gameSessionService;
         this.taskScheduler = taskScheduler;
         this.eventPublisher = eventPublisher;
@@ -67,31 +66,33 @@ public class RacingGameService implements MiniGameService {
     }
 
     private void startAutoMove(RacingGame racingGame, String joinCode) {
+        // 프론트는 PLAYING 을 받는 즉시 탭을 보낸다. 발행 뒤에 초기화하면 그 첫 탭을 지운다.
+        racingGame.setUpStart();
         racingGame.updateState(RacingGameState.PLAYING);
         eventPublisher.publishEvent(RaceStateChangedEvent.of(racingGame, joinCode));
-        racingGame.setUpStart();
         final ScheduledFuture<?> autoMoveFuture = scheduleAutoMoveTask(racingGame, joinCode);
         racingGame.setAutoMoveFuture(autoMoveFuture);
     }
 
     private void processDescription(String joinCode, RacingGame racingGame) {
         racingGame.updateState(RacingGameState.DESCRIPTION);
-        taskScheduler.schedule(() -> {
-            processPrepare(racingGame, joinCode);
-            eventPublisher.publishEvent(RaceStateChangedEvent.of(racingGame, joinCode));
-        }, Instant.now().plus(timing.description()));
+        taskScheduler.schedule(
+                () -> {
+                    processPrepare(racingGame, joinCode);
+                    eventPublisher.publishEvent(RaceStateChangedEvent.of(racingGame, joinCode));
+                },
+                Instant.now().plus(timing.description()));
     }
 
     private void processPrepare(RacingGame racingGame, String joinCode) {
         racingGame.updateState(RacingGameState.PREPARE);
         eventPublisher.publishEvent(RunnersMovedEvent.of(racingGame, joinCode));
-        taskScheduler.schedule(() -> startAutoMove(racingGame, joinCode),
-                Instant.now().plus(timing.prepare()));
+        taskScheduler.schedule(
+                () -> startAutoMove(racingGame, joinCode), Instant.now().plus(timing.prepare()));
     }
 
     private ScheduledFuture<?> scheduleAutoMoveTask(RacingGame racingGame, String joinCode) {
-        return taskScheduler.scheduleAtFixedRate(() -> executeAutoMove(racingGame, joinCode),
-                timing.moveInterval());
+        return taskScheduler.scheduleAtFixedRate(() -> executeAutoMove(racingGame, joinCode), timing.moveInterval());
     }
 
     private void executeAutoMove(RacingGame racingGame, String joinCode) {
@@ -114,13 +115,17 @@ public class RacingGameService implements MiniGameService {
         racingGame.updateState(RacingGameState.DONE);
         // 순서 불변식(ADR-0025 결정 5): finishGame()으로 roundCount를 먼저 확정·상태 복귀시킨다.
         final int roundCount = gameSessionService.finishGame(new JoinCode(joinCode));
-        taskScheduler.schedule(() -> eventPublisher.publishEvent(RaceFinishedEvent.of(racingGame, joinCode)),
+        taskScheduler.schedule(
+                () -> eventPublisher.publishEvent(RaceFinishedEvent.of(racingGame, joinCode)),
                 Instant.now().plus(timing.raceFinishedDelay()));
         racingGame.stopAutoMove();
         // 확률 조정·결과 저장을 유발하는 이벤트는 종료 알림·정리를 모두 끝낸 뒤 마지막에 발행한다 —
         // 저장 리스너(@Transactional/@RedisLock) 실패가 게임 종료 알림·자동이동 정지를 막지 않도록.
         eventPublisher.publishEvent(new MiniGameFinishedEvent(
-                joinCode, MiniGameType.RACING_GAME.name(), racingGame.getResult().toRankMap(), roundCount));
+                joinCode,
+                MiniGameType.RACING_GAME.name(),
+                racingGame.getResult().toRankMap(),
+                roundCount));
         log.info("레이싱 게임 종료: joinCode={}", joinCode);
     }
 
@@ -134,7 +139,6 @@ public class RacingGameService implements MiniGameService {
     }
 
     private RacingGame getRacingGame(JoinCode joinCode) {
-        return (RacingGame) gameSessionService.getSession(joinCode)
-                .findCompletedGame(MiniGameType.RACING_GAME);
+        return (RacingGame) gameSessionService.getSession(joinCode).findCompletedGame(MiniGameType.RACING_GAME);
     }
 }

--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/RacingGame.java
@@ -29,7 +29,8 @@ public class RacingGame implements Playable {
 
     private Instant startTime;
     private Runners runners;
-    private RacingGameState state;
+    // 스케줄러 스레드가 바꾸고 컨슈머 스레드가 validatePlaying 으로 읽는다.
+    private volatile RacingGameState state;
 
     @Setter
     private ScheduledFuture<?> autoMoveFuture;

--- a/backend/game/src/main/java/coffeeshout/racinggame/domain/Runner.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/domain/Runner.java
@@ -6,10 +6,15 @@ import coffeeshout.gamecommon.Gamer;
 import java.time.Instant;
 import lombok.Getter;
 
-@Getter
+/**
+ * 컨슈머 스레드가 {@link #updateSpeed}를, 스케줄러 스레드가 {@link #move}를 부른다.
+ * 가변 필드 넷을 같은 모니터로 잠가 한쪽이 쓰는 중에 다른 쪽이 읽거나 끼어들지 못하게 한다.
+ */
 public class Runner {
 
     public static final int SLOW_DOWN_STEP = 3;
+
+    @Getter
     private final Gamer gamer;
 
     private int position = 0;
@@ -22,24 +27,26 @@ public class Runner {
         this.lastSpeedUpdateTime = Instant.now();
     }
 
-    public void updateSpeed(int tapCount, SpeedCalculator speedCalculator, Instant now) {
+    public synchronized void updateSpeed(int tapCount, SpeedCalculator speedCalculator, Instant now) {
         if (isFinished()) {
             return;
         }
         final int nextSpeed = speedCalculator.calculateSpeed(lastSpeedUpdateTime, now, tapCount);
-        isTrue(nextSpeed >= RacingGame.MIN_SPEED && nextSpeed <= RacingGame.MAX_SPEED,
+        isTrue(
+                nextSpeed >= RacingGame.MIN_SPEED && nextSpeed <= RacingGame.MAX_SPEED,
                 String.format("스피드는 0 ~ %d이어야 합니다.", RacingGame.MAX_SPEED));
         this.lastSpeedUpdateTime = now;
         this.speed = nextSpeed;
     }
 
-    public void move(Instant now) {
+    public synchronized void move(Instant now) {
         if (isStopped()) {
             return;
         }
         final int nextPosition = position + speed;
         if (crossesFinishLine(nextPosition)) {
-            final long remainingMillis = (long) (calculateDistanceToFinishLine(nextPosition) * calculateMillisPerPosition());
+            final long remainingMillis =
+                    (long) (calculateDistanceToFinishLine(nextPosition) * calculateMillisPerPosition());
             finishTime = now.minusMillis(RacingGame.MOVE_INTERVAL_MILLIS).plusMillis(remainingMillis);
         }
         if (isSlowingDown()) {
@@ -72,19 +79,35 @@ public class Runner {
         speed -= SLOW_DOWN_STEP;
     }
 
-    public boolean isFinished() {
+    public synchronized boolean isFinished() {
         return position >= RacingGame.FINISH_LINE;
     }
 
-    public void initializeSpeed() {
+    public synchronized void initializeSpeed() {
         this.speed = RacingGame.MIN_SPEED;
     }
 
-    public void initializeLastSpeedUpdateTime(Instant time) {
+    public synchronized void initializeLastSpeedUpdateTime(Instant time) {
         this.lastSpeedUpdateTime = time;
     }
 
-    public boolean isStopped() {
+    public synchronized boolean isStopped() {
         return speed == 0;
+    }
+
+    public synchronized int getPosition() {
+        return position;
+    }
+
+    public synchronized int getSpeed() {
+        return speed;
+    }
+
+    public synchronized Instant getLastSpeedUpdateTime() {
+        return lastSpeedUpdateTime;
+    }
+
+    public synchronized Instant getFinishTime() {
+        return finishTime;
     }
 }

--- a/backend/game/src/test/java/coffeeshout/racinggame/application/RacingGameServiceTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/application/RacingGameServiceTest.java
@@ -1,6 +1,7 @@
 package coffeeshout.racinggame.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -18,9 +19,13 @@ import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.repository.RoomRepository;
 import java.time.Duration;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 class RacingGameServiceTest extends GameModuleServiceTest {
 
@@ -37,10 +42,27 @@ class RacingGameServiceTest extends GameModuleServiceTest {
 
     private Room room = RoomFixture.호스트_꾹이();
 
+    @Autowired
+    @Qualifier("racingGameScheduler")
+    private TaskScheduler racingGameScheduler;
+
     @BeforeEach
     void setUp() {
         room.getPlayers().forEach(player -> player.updateReadyState(true));
         roomRepository.save(room);
+    }
+
+    /**
+     * start() 가 건 100ms 자동 이동은 컨텍스트 수명 스케줄러에 남아 테스트가 끝나도 돈다.
+     * 탭이 없으면 약 50초 뒤 혼자 완주해 그때 돌고 있는 다른 테스트의 세션에 결과를 덧쓴다.
+     * 통합 테스트의 자동이동_정리 와 같은 이유로 예약 큐를 비운다.
+     */
+    @AfterEach
+    void 자동이동_정리() {
+        ((ThreadPoolTaskScheduler) racingGameScheduler)
+                .getScheduledThreadPoolExecutor()
+                .getQueue()
+                .clear();
     }
 
     @Test
@@ -92,17 +114,16 @@ class RacingGameServiceTest extends GameModuleServiceTest {
 
         // then
         // 발행 뒤에 속도를 초기화하면 이 탭이 지워져 최저 속도로 남는다.
-        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
-            assertThat(racingGame.getState()).isEqualTo(RacingGameState.PLAYING);
-            assertThat(speedOf(racingGame, HOST_NAME)).isGreaterThan(RacingGame.MIN_SPEED);
-        });
-    }
-
-    private int speedOf(RacingGame racingGame, String playerName) {
-        return racingGame.getRunners().stream()
-                .filter(runner -> runner.getGamer().getName().equals(playerName))
-                .findFirst()
-                .orElseThrow()
-                .getSpeed();
+        await().atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> assertSoftly(softly -> {
+                    softly.assertThat(racingGame.getState()).isEqualTo(RacingGameState.PLAYING);
+                    // 방 픽스처는 호스트 한 명이라 첫 러너가 곧 탭을 친 사람이다.
+                    softly.assertThat(racingGame
+                                    .getRunners()
+                                    .getRunners()
+                                    .getFirst()
+                                    .getSpeed())
+                            .isGreaterThan(RacingGame.MIN_SPEED);
+                }));
     }
 }

--- a/backend/game/src/test/java/coffeeshout/racinggame/application/RacingGameServiceTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/application/RacingGameServiceTest.java
@@ -2,16 +2,19 @@ package coffeeshout.racinggame.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 
-import coffeeshout.fixture.RoomFixture;
 import coffeeshout.GameModuleServiceTest;
+import coffeeshout.fixture.RoomFixture;
 import coffeeshout.gamecommon.Gamer;
 import coffeeshout.minigame.application.GameSessionService;
 import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.minigame.event.dto.MiniGameSelectEvent;
 import coffeeshout.racinggame.domain.RacingGame;
 import coffeeshout.racinggame.domain.RacingGameState;
+import coffeeshout.racinggame.domain.event.RaceStateChangedEvent;
 import coffeeshout.room.domain.Room;
-import coffeeshout.minigame.event.dto.MiniGameSelectEvent;
 import coffeeshout.room.domain.repository.RoomRepository;
 import java.time.Duration;
 import java.util.List;
@@ -47,19 +50,59 @@ class RacingGameServiceTest extends GameModuleServiceTest {
         // 세션은 방 생성 시 권위 있는 호스트로 사전 생성되므로(지연 생성 제거 — Option B), initSession 후 updateGames 한다.
         gameSessionService.deleteSession(room.getJoinCode());
         gameSessionService.initSession(room.getJoinCode(), Gamer.guest(HOST_NAME));
-        gameSessionService.updateGames(new MiniGameSelectEvent(
-                room.getJoinCode().getValue(), HOST_NAME, List.of(MiniGameType.RACING_GAME)));
-        RacingGame racingGame = (RacingGame) gameSessionService.startGame(
-                room.getJoinCode(), Gamer.guest(HOST_NAME), room.getGamers());
+        gameSessionService.updateGames(
+                new MiniGameSelectEvent(room.getJoinCode().getValue(), HOST_NAME, List.of(MiniGameType.RACING_GAME)));
+        RacingGame racingGame =
+                (RacingGame) gameSessionService.startGame(room.getJoinCode(), Gamer.guest(HOST_NAME), room.getGamers());
 
         // when
         racingGameService.start(room.getJoinCode().getValue(), HOST_NAME);
 
         // then
-        await().atMost(Duration.ofSeconds(3))
-                .untilAsserted(() -> {
-                    assertThat(racingGame.getState()).isEqualTo(RacingGameState.PLAYING);
-                    assertThat(racingGame.isStarted()).isTrue();
-                });
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            assertThat(racingGame.getState()).isEqualTo(RacingGameState.PLAYING);
+            assertThat(racingGame.isStarted()).isTrue();
+        });
+    }
+
+    @Test
+    void PLAYING_발행_직후_들어온_첫_탭이_속도에_반영된다() {
+        // given
+        gameSessionService.deleteSession(room.getJoinCode());
+        gameSessionService.initSession(room.getJoinCode(), Gamer.guest(HOST_NAME));
+        gameSessionService.updateGames(
+                new MiniGameSelectEvent(room.getJoinCode().getValue(), HOST_NAME, List.of(MiniGameType.RACING_GAME)));
+        final RacingGame racingGame =
+                (RacingGame) gameSessionService.startGame(room.getJoinCode(), Gamer.guest(HOST_NAME), room.getGamers());
+        final String joinCode = room.getJoinCode().getValue();
+
+        // 프론트는 PLAYING 을 받는 즉시 탭을 보낸다. 발행되는 그 자리에서 탭을 쳐 가장 이른 탭을 흉내 낸다.
+        doAnswer(invocation -> {
+                    if (invocation.getArgument(0) instanceof RaceStateChangedEvent event
+                            && event.state() == RacingGameState.PLAYING) {
+                        racingGameService.tap(joinCode, HOST_NAME, 5);
+                    }
+                    return null;
+                })
+                .when(eventPublisher)
+                .publishEvent(any(Object.class));
+
+        // when
+        racingGameService.start(joinCode, HOST_NAME);
+
+        // then
+        // 발행 뒤에 속도를 초기화하면 이 탭이 지워져 최저 속도로 남는다.
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            assertThat(racingGame.getState()).isEqualTo(RacingGameState.PLAYING);
+            assertThat(speedOf(racingGame, HOST_NAME)).isGreaterThan(RacingGame.MIN_SPEED);
+        });
+    }
+
+    private int speedOf(RacingGame racingGame, String playerName) {
+        return racingGame.getRunners().stream()
+                .filter(runner -> runner.getGamer().getName().equals(playerName))
+                .findFirst()
+                .orElseThrow()
+                .getSpeed();
     }
 }

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnerTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/RunnerTest.java
@@ -2,9 +2,16 @@ package coffeeshout.racinggame.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import coffeeshout.fixture.PlayerFixture;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -238,18 +245,14 @@ class RunnerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "2950, 60, 83",     // 2950 + 60 = 3010, 10 초과
-            "2980, 30, 66",     // 2980 + 30 = 3010, 10 초과
-            "2990, 20, 50",     // 2990 + 20 = 3010, 10 초과
-            "2995, 10, 50",      // 2995 + 10 = 3005, 5 초과
-            "2997, 5, 60",       // 2997 + 5 = 3002, 2 초과
-            "2999, 3, 33",      // 2999 + 3 = 3002, 2 초과
+        "2950, 60, 83", // 2950 + 60 = 3010, 10 초과
+        "2980, 30, 66", // 2980 + 30 = 3010, 10 초과
+        "2990, 20, 50", // 2990 + 20 = 3010, 10 초과
+        "2995, 10, 50", // 2995 + 10 = 3005, 5 초과
+        "2997, 5, 60", // 2997 + 5 = 3002, 2 초과
+        "2999, 3, 33", // 2999 + 3 = 3002, 2 초과
     })
-    void 결승선을_초과하여_도착하면_남은_거리_비율만큼_시간이_보정된다(
-            int startPosition,
-            int speed,
-            int expectedTicksToFinish
-    ) {
+    void 결승선을_초과하여_도착하면_남은_거리_비율만큼_시간이_보정된다(int startPosition, int speed, int expectedTicksToFinish) {
         // given
         final Runner runner = new Runner(PlayerFixture.게스트한스().toGamer());
         final SpeedCalculator speedCalculator = (lastTapedTime, now, tapCount) -> speed;
@@ -261,11 +264,48 @@ class RunnerTest {
 
         // when
         runner.move(tickStartTime);
-        final Instant expectFinishTime = tickStartTime.minusMillis(RacingGame.MOVE_INTERVAL_MILLIS)
-                .plusMillis(expectedTicksToFinish);
+        final Instant expectFinishTime =
+                tickStartTime.minusMillis(RacingGame.MOVE_INTERVAL_MILLIS).plusMillis(expectedTicksToFinish);
 
         // then
         assertThat(runner.isFinished()).isTrue();
         assertThat(runner.getFinishTime()).isEqualTo(expectFinishTime);
+    }
+
+    @Test
+    void 속도를_갱신하는_동안_이동이_끼어들지_못한다() throws Exception {
+        // given
+        final Runner runner = new Runner(PlayerFixture.게스트한스().toGamer());
+        final CountDownLatch calculating = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+        // 컨슈머 스레드가 속도를 계산하는 중간에 멈춰 세운다. 그 사이 스케줄러 스레드가 move 를 부른다.
+        final SpeedCalculator blockingCalculator = (lastTapedTime, now, tapCount) -> {
+            calculating.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return 10;
+        };
+        final ExecutorService threads = Executors.newFixedThreadPool(2);
+
+        try {
+            // when
+            final Future<?> updating = threads.submit(() -> runner.updateSpeed(1, blockingCalculator, Instant.now()));
+            calculating.await(1, TimeUnit.SECONDS);
+            final Future<?> moving = threads.submit(() -> runner.move(Instant.now()));
+
+            // then
+            // 갱신이 끝나기 전에는 이동이 끝나 있으면 안 된다.
+            await().during(Duration.ofMillis(200)).atMost(Duration.ofSeconds(1)).until(() -> !moving.isDone());
+            release.countDown();
+            updating.get(1, TimeUnit.SECONDS);
+            moving.get(1, TimeUnit.SECONDS);
+            // 갱신된 속도 10 으로 이동했어야 한다. 끼어들었다면 속도 0 인 채로 제자리다.
+            assertThat(runner.getPosition()).isEqualTo(10);
+        } finally {
+            threads.shutdownNow();
+        }
     }
 }

--- a/backend/game/src/test/java/coffeeshout/racinggame/domain/TapPerSecondSpeedCalculatorTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/domain/TapPerSecondSpeedCalculatorTest.java
@@ -2,7 +2,6 @@ package coffeeshout.racinggame.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import coffeeshout.racinggame.domain.TapPerSecondSpeedCalculator;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +24,7 @@ class TapPerSecondSpeedCalculatorTest {
     }
 
     @Test
-    void 탭_횟수가_임계값을_초과하면_임계값으로_제한된다() {
+    void 초당_15탭이면_속도도_15다() {
         // given
         final Instant lastTapedTime = Instant.now();
         final Instant now = lastTapedTime.plusMillis(1000);
@@ -138,5 +137,18 @@ class TapPerSecondSpeedCalculatorTest {
         // when & then - 3초에 6번 = 초당 2번
         Instant now3 = lastTapedTime.plusMillis(3000);
         assertThat(speedCalculator.calculateSpeed(lastTapedTime, now3, 6)).isEqualTo(3);
+    }
+
+    @Test
+    void 탭_횟수가_아무리_커도_속도는_상한을_넘지_않는다() {
+        // given
+        final Instant lastTapedTime = Instant.now();
+        final Instant now = lastTapedTime.plusMillis(1);
+
+        // when
+        final int speed = speedCalculator.calculateSpeed(lastTapedTime, now, Integer.MAX_VALUE);
+
+        // then
+        assertThat(speed).isEqualTo(RacingGame.MAX_SPEED);
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1755

# 🚀 작업 내용

## 무엇이 달라지는가

경기 시작 직후 친 첫 탭이 살아남는다. 지금은 시작 신호를 받고 바로 두드려도 그 탭 묶음이 서버에서 지워져 스타트 대시가 반영되지 않았다.

한 러너를 두 스레드가 동시에 만질 때 값이 어긋나지 않는다. 탭을 처리하는 스레드와 100ms마다 이동시키는 스레드가 같은 러너를 아무 잠금 없이 읽고 쓰고 있었다.

## 왜 바꿨는가

다음 묶음이 위치 브로드캐스트에 상태와 완주 시각을 싣는 계약 변경이라, 그 전에 실을 값이 믿을 만해야 한다. 레이싱 감사(#1749)의 서버 발견 중 메시지 계약을 안 건드리는 셋을 먼저 닫는다. 페이로드가 바뀌지 않아 프론트 영향이 없다.

## 시작 순서

```mermaid
sequenceDiagram
    participant S as 스케줄러 스레드
    participant G as RacingGame
    participant F as 프론트
    participant C as 컨슈머 스레드
    S->>G: setUpStart (속도·마지막 탭 시각 초기화)
    S->>G: PLAYING
    S-->>F: 상태 발행
    F->>C: 첫 탭
    C->>G: updateSpeed (초기화된 값 위에 얹힌다)
```

예전에는 발행이 초기화보다 앞이라 첫 탭이 초기화에 덮였다.

## 변경 목록

1. 러너의 읽기·쓰기 메서드와 가변 필드 게터를 한 모니터로 잠갔다. 탭 컨슈머와 이동 스케줄러가 같은 러너를 동기화 없이 만져 올린 속도가 언제 보일지 보장이 없었다. 스피드터치 `SpeedTouchPlayer`와 같은 모양이다. `Runner`
2. 게임 상태 필드에 `volatile`을 붙였다. 스케줄러가 쓰고 컨슈머가 `validatePlaying`으로 읽는다. 블록쌓기 `BlockStackingGame.state`와 같다. `RacingGame`
3. 속도 초기화를 `PLAYING` 발행 앞으로 옮겼다. 발행 뒤에 초기화하면 발행 직후 도착한 탭을 지운다. 두 줄 순서만 바뀐다. `RacingGameService.startAutoMove`
4. 탭 횟수가 아무리 커도 속도가 60을 넘지 않는지 재는 테스트를 넣었다. `Math.clamp`가 이미 지키고 있었지만 재는 테스트가 없었다. 이름과 달리 상한을 안 재던 테스트는 실제 동작에 맞게 이름을 고쳤다. `TapPerSecondSpeedCalculatorTest`

## 검증

세 결함 모두 테스트를 먼저 빨간 상태로 만든 뒤 고쳤다.

- `RunnerTest.속도를_갱신하는_동안_이동이_끼어들지_못한다` — 속도 계산 중간에 멈춰 세우고 `move`를 부른다. 수정 전에는 이동이 먼저 끝나 실패했다
- `RacingGameServiceTest.PLAYING_발행_직후_들어온_첫_탭이_속도에_반영된다` — 목 퍼블리셔에 "PLAYING이 발행되는 순간 탭을 친다"는 답을 심었다. 수정 전에는 속도가 최저값 3으로 남아 실패했다
- `TapPerSecondSpeedCalculatorTest.탭_횟수가_아무리_커도_속도는_상한을_넘지_않는다` — `clamp`를 `max`로 바꾸면 실패하는 것을 확인했다
- `coffeeshout.racinggame.*` 전체 37건 통과, `spotlessCheck`·`pmdMain`·`pmdTest`·`pmdTestFixtures` 통과

# 💬 리뷰 중점사항

**잠금을 서비스가 아니라 `Runner`에 뒀다.** 지렁이처럼 서비스에서 `synchronized (game)`으로 감싸는 방법도 있다. 도메인 단위 테스트로 상호 배제를 재현하려고 러너 쪽을 택했는데, 서비스 쪽이 낫다고 보면 바꿀 수 있다.

**서비스 테스트가 목 퍼블리셔의 답에서 서비스를 다시 부른다.** `publishEvent` 안에서 `tap()`을 호출해 발행 직후의 탭을 흉내 낸다. 발행 순서를 타이밍 없이 결정적으로 재는 방법이지만, 테스트가 퍼블리셔 구현에 기댄다는 점은 봐 주면 좋겠다.

**`RacingGameService`의 diff가 바꾼 줄보다 크다.** spotless가 파일 전체에 import 순서와 람다 줄바꿈을 걸었다. 실제 변경은 `startAutoMove`의 두 줄 순서와 주석 한 줄이다.

# 🙅 이번에 하지 않은 것

- **`tapCount` 상한 검증.** 치팅 방어는 범위 밖으로 뒀다. 사용자끼리 즐기는 게임이라 속도 상한 60이 지켜지는 것만 테스트로 못 박았다.
- **메시지 레이트 리밋.** 레이싱 전용이 아니라 WebSocket 공통 관심사라 별도로 뺀다.
- **이탈자 러너 정리(B06).** 경기 시간 상한 #1713과 같은 자리라 그쪽에 붙인다.
- **위치 메시지에 상태·완주 시각 싣기(B01·B04·B07).** 계약 변경이라 다음 묶음(2-B)이다.

https://claude.ai/code/session_012KbMUTQcovoS6KUiyt9FQG
