### PR TITLE
[chore] 검열 파이프라인 측정 도구 (스텁 지연·구간 타이머·적재)

### DIFF
--- a/backend/app/src/main/resources/application-dev.yml
+++ b/backend/app/src/main/resources/application-dev.yml
@@ -19,6 +19,10 @@ room:
   qr:
     prefix: "https://dev.zzol.site/join/"
 
+nickname-audit:
+  # dev 는 flash-lite 를 쓴다. Gemini 요청 한도는 모델별로 세므로 prod 의 flash 와 쿼터가 갈린다.
+  model: gemini-3.5-flash-lite
+
 websocket:
   docs:
     server-url: "https://api.dev.zzol.site/ws"

--- a/backend/app/src/main/resources/application-local.yml
+++ b/backend/app/src/main/resources/application-local.yml
@@ -54,6 +54,9 @@ outbox:
   relay:
     delay: 5000  # 로컬에서는 5초마다 폴링 (기본값 500ms)
 
+nickname-audit:
+  cron: "0 */5 * * * *"  # 로컬에서 12시간을 기다리지 않고 회차를 돌려보려고 5분으로 당긴다
+
 logging:
   level:
     coffeeshout: DEBUG

--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -43,3 +43,6 @@ nickname-audit:
   max-attempts: 3                      # 한 행이 검열 호출 실패를 견디는 횟수. 닿으면 DEAD_LETTER가 되어 스캔에서 빠진다.
   request-timeout: 120s                # Gemini HTTP 타임아웃. 없으면 응답 없는 호출이 스케줄러 스레드를 무기한 점유한다.
                                        # batch-size 를 올리면 응답 생성 시간도 늘어나므로 함께 올린다.
+  stub:                                # local/test 프로파일의 NoOpNicknameAuditor 동작. 아래 기본값이면 지연 0에 전부 CLEAN.
+    latency: 0s                        # 호출 하나가 흉내 낼 지연. 0으로 두면 LLM이 무한히 빠를 때의 처리량을 잰다.
+    flagged-ratio: 0                    # FLAGGED로 판정할 비율(0~1). 올리면 자동 차단·사전 INSERT·트라이 재빌드까지 실제로 탄다.

--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -43,6 +43,7 @@ nickname-audit:
   max-attempts: 3                      # 한 행이 검열 호출 실패를 견디는 횟수. 닿으면 DEAD_LETTER가 되어 스캔에서 빠진다.
   request-timeout: 120s                # Gemini HTTP 타임아웃. 없으면 응답 없는 호출이 스케줄러 스레드를 무기한 점유한다.
                                        # batch-size 를 올리면 응답 생성 시간도 늘어나므로 함께 올린다.
+  cron: "0 0 0/12 * * *"               # 검열 회차 주기. local 은 application-local.yml 에서 5분으로 당겨 쓴다.
   stub:                                # local/test 프로파일의 NoOpNicknameAuditor 동작. 아래 기본값이면 지연 0에 전부 CLEAN.
     latency: 0s                        # 호출 하나가 흉내 낼 지연. 0으로 두면 LLM이 무한히 빠를 때의 처리량을 잰다.
     flagged-ratio: 0                    # FLAGGED로 판정할 비율(0~1). 올리면 자동 차단·사전 INSERT·트라이 재빌드까지 실제로 탄다.

--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -48,4 +48,5 @@ nickname-audit:
     count: 0                           # local 에서 넣을 측정용 미검열 닉네임 수. 0 이면 안 넣는다.
   stub:                                # local/test 프로파일의 NoOpNicknameAuditor 동작. 아래 기본값이면 지연 0에 전부 CLEAN.
     latency: 0s                        # 호출 하나가 흉내 낼 지연. 0으로 두면 LLM이 무한히 빠를 때의 처리량을 잰다.
-    flagged-ratio: 0                    # FLAGGED로 판정할 비율(0~1). 올리면 자동 차단·사전 INSERT·트라이 재빌드까지 실제로 탄다.
+    flagged-ratio: 0                   # FLAGGED로 판정할 비율(0~1). 올리면 자동 차단·사전 INSERT·트라이 재빌드까지 실제로 탄다.
+                                       # 해상도는 0.01이다. 그보다 작은 값은 0으로 반올림돼 아무것도 안 걸린다.

--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -44,6 +44,8 @@ nickname-audit:
   request-timeout: 120s                # Gemini HTTP 타임아웃. 없으면 응답 없는 호출이 스케줄러 스레드를 무기한 점유한다.
                                        # batch-size 를 올리면 응답 생성 시간도 늘어나므로 함께 올린다.
   cron: "0 0 0/12 * * *"               # 검열 회차 주기. local 은 application-local.yml 에서 5분으로 당겨 쓴다.
+  seed:
+    count: 0                           # local 에서 넣을 측정용 미검열 닉네임 수. 0 이면 안 넣는다.
   stub:                                # local/test 프로파일의 NoOpNicknameAuditor 동작. 아래 기본값이면 지연 0에 전부 CLEAN.
     latency: 0s                        # 호출 하나가 흉내 낼 지연. 0으로 두면 LLM이 무한히 빠를 때의 처리량을 잰다.
     flagged-ratio: 0                    # FLAGGED로 판정할 비율(0~1). 올리면 자동 차단·사전 INSERT·트라이 재빌드까지 실제로 탄다.

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
@@ -40,7 +40,7 @@ public class ProfanityAuditBatchProcessor {
      * <p>{@code settle}은 {@code block}을 안에 포함한다. 자동 차단이 승격 저장 트랜잭션 안에서 돌기 때문이다.
      * 합이 회차 전체 시간과 맞아떨어지지 않는 건 그래서다.
      */
-    public static final String PHASE_TIMER = "nickname.audit.phase";
+    static final String PHASE_TIMER = "nickname.audit.phase";
 
     static final String PHASE_TIMER_DESCRIPTION = "닉네임 검열 회차의 구간별 소요 시간 (settle은 block을 포함한다)";
 

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
@@ -119,7 +119,9 @@ public class ProfanityAuditBatchProcessor {
             return settled == null ? 0 : settled;
         } catch (RuntimeException e) {
             log.warn("배치 저장 실패 {}건 — 같은 판정으로 건별 저장을 다시 시도한다", batch.size(), e);
-            return settlePhaseTimer.record(() -> settleIndividually(batch, resultMap));
+            // 여기서 다시 재지 않는다. 위 record는 예외로 빠져나가도 실패한 트랜잭션 시간을 이미 기록했다.
+            // 폴백까지 같은 타이머로 감싸면 그 배치의 settle이 두 번 세어져 병목을 잘못 지목하게 된다.
+            return settleIndividually(batch, resultMap);
         }
     }
 

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
@@ -15,6 +15,7 @@ import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.domain.audit.NicknameAuditor;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +34,16 @@ import org.springframework.transaction.support.TransactionTemplate;
 @RequiredArgsConstructor
 public class ProfanityAuditBatchProcessor {
 
+    /**
+     * 회차 구간별 소요 시간. phase 태그로 나눈다. LLM 없이 회차를 돌려 어디가 느린지 볼 때 이게 근거가 된다.
+     *
+     * <p>{@code settle}은 {@code block}을 안에 포함한다. 자동 차단이 승격 저장 트랜잭션 안에서 돌기 때문이다.
+     * 합이 회차 전체 시간과 맞아떨어지지 않는 건 그래서다.
+     */
+    public static final String PHASE_TIMER = "nickname.audit.phase";
+
+    static final String PHASE_TIMER_DESCRIPTION = "닉네임 검열 회차의 구간별 소요 시간 (settle은 block을 포함한다)";
+
     /** 배치 내용이 원인이라 다시 불러도 같은 결과가 나오는 실패. 이것만 시도 횟수에 센다. */
     private static final Set<ErrorCode> DETERMINISTIC_AUDIT_FAILURES = Set.of(
             NicknameAuditErrorCode.AI_RESPONSE_PARSE_FAILED,
@@ -50,6 +61,9 @@ public class ProfanityAuditBatchProcessor {
 
     private Counter batchSkippedCounter;
     private Counter deadLetteredCounter;
+    private Timer auditPhaseTimer;
+    private Timer settlePhaseTimer;
+    private Timer blockPhaseTimer;
 
     @PostConstruct
     void initMetrics() {
@@ -59,6 +73,16 @@ public class ProfanityAuditBatchProcessor {
         deadLetteredCounter = Counter.builder("nickname.audit.dead.lettered")
                 .description("시도 횟수 상한에 닿아 DEAD_LETTER로 내려간 행 수")
                 .register(meterRegistry);
+        auditPhaseTimer = phaseTimer("audit");
+        settlePhaseTimer = phaseTimer("settle");
+        blockPhaseTimer = phaseTimer("block");
+    }
+
+    private Timer phaseTimer(String phase) {
+        return Timer.builder(PHASE_TIMER)
+                .description(PHASE_TIMER_DESCRIPTION)
+                .tag("phase", phase)
+                .register(meterRegistry);
     }
 
     public int process(List<NicknameAudit> batch) {
@@ -67,7 +91,7 @@ public class ProfanityAuditBatchProcessor {
 
         final List<NicknameAuditResult> results;
         try {
-            results = nicknameAuditor.audit(nicknames);
+            results = auditPhaseTimer.record(() -> nicknameAuditor.audit(nicknames));
         } catch (RuntimeException e) {
             // 파싱 실패·빈 응답은 InfrastructureException이고 resilience4j ignore 목록이라
             // (resilience4j.yml의 geminiAudit.ignore-exceptions) 재시도 없이 여기까지 올라온다.
@@ -90,11 +114,12 @@ public class ProfanityAuditBatchProcessor {
                 .collect(Collectors.toMap(NicknameAuditResult::nickname, Function.identity(), (a, b) -> a));
 
         try {
-            final Integer settled = transactionTemplate.execute(status -> settle(batch, nicknames, resultMap));
+            final Integer settled = settlePhaseTimer.record(
+                    () -> transactionTemplate.execute(status -> settle(batch, nicknames, resultMap)));
             return settled == null ? 0 : settled;
         } catch (RuntimeException e) {
             log.warn("배치 저장 실패 {}건 — 같은 판정으로 건별 저장을 다시 시도한다", batch.size(), e);
-            return settleIndividually(batch, resultMap);
+            return settlePhaseTimer.record(() -> settleIndividually(batch, resultMap));
         }
     }
 
@@ -236,6 +261,10 @@ public class ProfanityAuditBatchProcessor {
     }
 
     private void autoBlock(NicknameAuditResult result) {
+        blockPhaseTimer.record(() -> blockWords(result));
+    }
+
+    private void blockWords(NicknameAuditResult result) {
         resolveBlockWords(result).forEach(word -> {
             final Language language = Language.detect(textNormalizer.normalize(word));
             if (profanityWordManagementService.add(word, language, WordSource.AI_FLAGGED)) {

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
@@ -8,10 +8,14 @@ import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,12 +50,21 @@ public class ProfanityAuditService {
     private final MeterRegistry meterRegistry;
     private final Clock clock;
 
+    /** 회차 끝 로그에 찍는 구간. 회차 시작과 끝의 타이머 누적값 차이로 이번 회차 몫만 뽑는다. */
+    private static final List<String> PHASES = List.of("fetch", "audit", "settle", "block");
+
     private final AtomicLong unauditedQueueDepth = new AtomicLong(0);
+
+    private Timer fetchPhaseTimer;
 
     @PostConstruct
     void initMetrics() {
         Gauge.builder("nickname.audit.unaudited.queue", unauditedQueueDepth, AtomicLong::get)
                 .description("스케줄러 실행 시점의 UNAUDITED 닉네임 적체량")
+                .register(meterRegistry);
+        fetchPhaseTimer = Timer.builder(ProfanityAuditBatchProcessor.PHASE_TIMER)
+                .description(ProfanityAuditBatchProcessor.PHASE_TIMER_DESCRIPTION)
+                .tag("phase", "fetch")
                 .register(meterRegistry);
     }
 
@@ -120,6 +133,7 @@ public class ProfanityAuditService {
         unauditedQueueDepth.set(initialQueueSize);
         log.info("닉네임 검열 시작: UNAUDITED 적체량 {}건", initialQueueSize);
 
+        final Map<String, Long> phaseBefore = phaseTotalMillis();
         final Instant deadline = clock.instant().plus(properties.maxRunDuration());
         int page = 0;
         List<NicknameAudit> batch = readPage(page);
@@ -161,12 +175,34 @@ public class ProfanityAuditService {
             batch = readPage(page);
         }
 
-        log.info("닉네임 검열 완료: 총 {}건 처리", processedTotal);
+        log.info("닉네임 검열 완료: 총 {}건 처리, 구간별 소요(ms) {}", processedTotal, phaseElapsedMillis(phaseBefore));
     }
 
     private List<NicknameAudit> readPage(int page) {
-        final Pageable pageable = PageRequest.of(
-                page, properties.batchSize(), Sort.by("createdAt").ascending());
-        return auditRepository.findByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED, pageable);
+        return fetchPhaseTimer.record(() -> {
+            final Pageable pageable = PageRequest.of(
+                    page, properties.batchSize(), Sort.by("createdAt").ascending());
+            return auditRepository.findByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED, pageable);
+        });
+    }
+
+    private Map<String, Long> phaseTotalMillis() {
+        final Map<String, Long> totals = new LinkedHashMap<>();
+        PHASES.forEach(phase -> totals.put(phase, totalMillis(phase)));
+        return totals;
+    }
+
+    private Map<String, Long> phaseElapsedMillis(Map<String, Long> before) {
+        final Map<String, Long> elapsed = new LinkedHashMap<>();
+        before.forEach((phase, millis) -> elapsed.put(phase, totalMillis(phase) - millis));
+        return elapsed;
+    }
+
+    private long totalMillis(String phase) {
+        final Timer timer = meterRegistry
+                .find(ProfanityAuditBatchProcessor.PHASE_TIMER)
+                .tag("phase", phase)
+                .timer();
+        return timer == null ? 0L : (long) timer.totalTime(TimeUnit.MILLISECONDS);
     }
 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
@@ -12,10 +12,7 @@ import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,9 +46,6 @@ public class ProfanityAuditService {
     private final NicknameAuditProperties properties;
     private final MeterRegistry meterRegistry;
     private final Clock clock;
-
-    /** 회차 끝 로그에 찍는 구간. 회차 시작과 끝의 타이머 누적값 차이로 이번 회차 몫만 뽑는다. */
-    private static final List<String> PHASES = List.of("fetch", "audit", "settle", "block");
 
     private final AtomicLong unauditedQueueDepth = new AtomicLong(0);
 
@@ -131,7 +125,6 @@ public class ProfanityAuditService {
     public void auditPending() {
         recordQueueDepth();
 
-        final Map<String, Long> phaseBefore = phaseTotalMillis();
         final Instant deadline = clock.instant().plus(properties.maxRunDuration());
         int page = 0;
         List<NicknameAudit> batch = readPage(page);
@@ -173,7 +166,7 @@ public class ProfanityAuditService {
             batch = readPage(page);
         }
 
-        log.info("닉네임 검열 완료: 총 {}건 처리, 구간별 소요(ms) {}", processedTotal, phaseElapsedMillis(phaseBefore));
+        log.info("닉네임 검열 완료: 총 {}건 처리", processedTotal);
     }
 
     private void recordQueueDepth() {
@@ -188,25 +181,5 @@ public class ProfanityAuditService {
                     page, properties.batchSize(), Sort.by("createdAt").ascending());
             return auditRepository.findByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED, pageable);
         });
-    }
-
-    private Map<String, Long> phaseTotalMillis() {
-        final Map<String, Long> totals = new LinkedHashMap<>();
-        PHASES.forEach(phase -> totals.put(phase, totalMillis(phase)));
-        return totals;
-    }
-
-    private Map<String, Long> phaseElapsedMillis(Map<String, Long> before) {
-        final Map<String, Long> elapsed = new LinkedHashMap<>();
-        before.forEach((phase, millis) -> elapsed.put(phase, totalMillis(phase) - millis));
-        return elapsed;
-    }
-
-    private long totalMillis(String phase) {
-        final Timer timer = meterRegistry
-                .find(ProfanityAuditBatchProcessor.PHASE_TIMER)
-                .tag("phase", phase)
-                .timer();
-        return timer == null ? 0L : (long) timer.totalTime(TimeUnit.MILLISECONDS);
     }
 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
@@ -129,9 +129,7 @@ public class ProfanityAuditService {
             leaseTime = LOCK_LEASE_MILLIS,
             doneTtl = LOCK_DONE_TTL_MILLIS)
     public void auditPending() {
-        final long initialQueueSize = auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED);
-        unauditedQueueDepth.set(initialQueueSize);
-        log.info("닉네임 검열 시작: UNAUDITED 적체량 {}건", initialQueueSize);
+        recordQueueDepth();
 
         final Map<String, Long> phaseBefore = phaseTotalMillis();
         final Instant deadline = clock.instant().plus(properties.maxRunDuration());
@@ -176,6 +174,12 @@ public class ProfanityAuditService {
         }
 
         log.info("닉네임 검열 완료: 총 {}건 처리, 구간별 소요(ms) {}", processedTotal, phaseElapsedMillis(phaseBefore));
+    }
+
+    private void recordQueueDepth() {
+        final long initialQueueSize = auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED);
+        unauditedQueueDepth.set(initialQueueSize);
+        log.info("닉네임 검열 시작: UNAUDITED 적체량 {}건", initialQueueSize);
     }
 
     private List<NicknameAudit> readPage(int page) {

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityFilterService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityFilterService.java
@@ -4,6 +4,8 @@ import coffeeshout.global.nickname.ProfanityChecker;
 import coffeeshout.profanity.domain.ProfanityWord;
 import coffeeshout.profanity.domain.ProfanityWordRepository;
 import coffeeshout.profanity.domain.TextNormalizer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -17,13 +19,20 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProfanityFilterService implements ProfanityChecker {
 
-    private final AtomicReference<Trie> trieRef = new AtomicReference<>(Trie.builder().build());
+    private final AtomicReference<Trie> trieRef =
+            new AtomicReference<>(Trie.builder().build());
 
     private final ProfanityWordRepository wordRepository;
     private final TextNormalizer textNormalizer;
+    private final MeterRegistry meterRegistry;
+
+    private Timer rebuildTimer;
 
     @PostConstruct
     public void init() {
+        rebuildTimer = Timer.builder("profanity.trie.rebuild.duration")
+                .description("비속어 트라이 재구성 소요 시간. FLAGGED 한 건마다 구독자에서 한 번씩 돈다.")
+                .register(meterRegistry);
         rebuildTrie();
     }
 
@@ -37,6 +46,10 @@ public class ProfanityFilterService implements ProfanityChecker {
     }
 
     public void rebuildTrie() {
+        rebuildTimer.record(this::buildAndSwapTrie);
+    }
+
+    private void buildAndSwapTrie() {
         final List<ProfanityWord> words = wordRepository.findAllActive();
         final Trie.TrieBuilder builder = Trie.builder().ignoreOverlaps().ignoreCase();
         words.forEach(w -> builder.addKeyword(textNormalizer.normalize(w.word())));

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -21,6 +21,9 @@ import org.springframework.validation.annotation.Validated;
  *                       {@code ProfanityAuditService.LOCK_LEASE_MILLIS}보다 반드시 짧아야 한다.
  * @param maxAttempts    한 행이 검열 호출 실패를 견디는 횟수. 여기 닿으면 DEAD_LETTER가 되어 UNAUDITED 스캔에서
  *                       빠진다. 늘리면 되풀이 실패하는 행 하나가 회차마다 Gemini 호출을 그만큼 더 태운다.
+ * @param cron           검열 회차 주기. {@code @Scheduled}는 컴파일 상수만 받으므로 어노테이션에는 이 프로퍼티를
+ *                       가리키는 문자열을 쓴다. 값을 여기 두는 이유는 local에서 12시간을 기다리지 않고 회차를
+ *                       돌려보기 위해서다.
  * @param stub           local·test 프로파일에서 Gemini 대신 도는 {@code NoOpNicknameAuditor}의 동작.
  *                       기본값이 지연 0에 전부 CLEAN이라 값을 주지 않으면 지금까지와 똑같이 움직인다.
  */
@@ -41,6 +44,8 @@ public record NicknameAuditProperties(
         Duration maxRunDuration,
 
         @DefaultValue("3") @Positive int maxAttempts,
+
+        @NotBlank String cron,
 
         @DefaultValue @Valid @NotNull Stub stub) {
 

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.validation.annotation.Validated;
 
 /**
@@ -26,6 +27,8 @@ import org.springframework.validation.annotation.Validated;
  * @param cron           검열 회차 주기. {@code @Scheduled}는 컴파일 상수만 받으므로 어노테이션에는 이 프로퍼티를
  *                       가리키는 문자열을 쓴다. 값을 여기 두는 이유는 local에서 12시간을 기다리지 않고 회차를
  *                       돌려보기 위해서다. 형식은 컴팩트 생성자가 실제로 파싱해 검증한다.
+ *                       주기를 {@code ProfanityAuditService.LOCK_DONE_TTL_MILLIS}(60초)보다 짧게 잡으면 안 된다.
+ *                       완료 마킹이 아직 살아 있어 다음 회차가 락에 막혀 말없이 사라진다. local의 5분은 안전하다.
  * @param seed           local 프로파일에서 미검열 닉네임을 몇 건 적재할지. 측정용이라 기본값은 0이다.
  * @param stub           local·test 프로파일에서 Gemini 대신 도는 {@code NoOpNicknameAuditor}의 동작.
  *                       기본값이 지연 0에 전부 CLEAN이라 값을 주지 않으면 지금까지와 똑같이 움직인다.
@@ -53,6 +56,14 @@ public record NicknameAuditProperties(
         @DefaultValue @Valid @NotNull Seed seed,
 
         @DefaultValue @Valid @NotNull Stub stub) {
+
+    public NicknameAuditProperties {
+        // @NotBlank는 공백 여부만 본다. 형식이 틀린 cron을 여기서 막지 않으면 바인딩은 통과하고
+        // 스케줄러 후처리기가 기동을 실패시킨다. 그 시점 예외에는 어느 프로퍼티가 문제인지 안 나온다.
+        if (cron != null && !cron.isBlank()) {
+            CronExpression.parse(cron);
+        }
+    }
 
     /**
      * local 전용 적재 설정.

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -25,7 +25,7 @@ import org.springframework.validation.annotation.Validated;
  *                       빠진다. 늘리면 되풀이 실패하는 행 하나가 회차마다 Gemini 호출을 그만큼 더 태운다.
  * @param cron           검열 회차 주기. {@code @Scheduled}는 컴파일 상수만 받으므로 어노테이션에는 이 프로퍼티를
  *                       가리키는 문자열을 쓴다. 값을 여기 두는 이유는 local에서 12시간을 기다리지 않고 회차를
- *                       돌려보기 위해서다.
+ *                       돌려보기 위해서다. 형식은 컴팩트 생성자가 실제로 파싱해 검증한다.
  * @param seed           local 프로파일에서 미검열 닉네임을 몇 건 적재할지. 측정용이라 기본값은 0이다.
  * @param stub           local·test 프로파일에서 Gemini 대신 도는 {@code NoOpNicknameAuditor}의 동작.
  *                       기본값이 지연 0에 전부 CLEAN이라 값을 주지 않으면 지금까지와 똑같이 움직인다.
@@ -71,6 +71,7 @@ public record NicknameAuditProperties(
      * @param latency      호출 하나가 흉내 낼 지연. 0이면 LLM이 무한히 빠를 때의 처리량을 잰다.
      * @param flaggedRatio FLAGGED로 판정할 닉네임 비율. 0보다 크면 자동 차단과 사전 INSERT, 트라이 재빌드까지
      *                     실제로 탄다. 어떤 닉네임이 걸릴지는 닉네임 해시로 정해 같은 입력에 같은 결과가 나온다.
+     *                     해상도는 0.01이다. 그보다 작은 값은 반올림되어 0이 되고 아무것도 FLAGGED가 되지 않는다.
      */
     public record Stub(
             @DefaultValue("0s") @NotNull Duration latency,

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -1,5 +1,6 @@
 package coffeeshout.profanity.config;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -20,6 +21,8 @@ import org.springframework.validation.annotation.Validated;
  *                       {@code ProfanityAuditService.LOCK_LEASE_MILLIS}보다 반드시 짧아야 한다.
  * @param maxAttempts    한 행이 검열 호출 실패를 견디는 횟수. 여기 닿으면 DEAD_LETTER가 되어 UNAUDITED 스캔에서
  *                       빠진다. 늘리면 되풀이 실패하는 행 하나가 회차마다 Gemini 호출을 그만큼 더 태운다.
+ * @param stub           local·test 프로파일에서 Gemini 대신 도는 {@code NoOpNicknameAuditor}의 동작.
+ *                       기본값이 지연 0에 전부 CLEAN이라 값을 주지 않으면 지금까지와 똑같이 움직인다.
  */
 @Validated
 @ConfigurationProperties(prefix = "nickname-audit")
@@ -37,4 +40,20 @@ public record NicknameAuditProperties(
         @DefaultValue("10m") @NotNull @DurationMin(minutes = 1)
         Duration maxRunDuration,
 
-        @DefaultValue("3") @Positive int maxAttempts) {}
+        @DefaultValue("3") @Positive int maxAttempts,
+
+        @DefaultValue @Valid @NotNull Stub stub) {
+
+    /**
+     * 스텁 검열기의 동작. LLM을 빼고 파이프라인 내부 병목만 재려고 둔다.
+     *
+     * @param latency      호출 하나가 흉내 낼 지연. 0이면 LLM이 무한히 빠를 때의 처리량을 잰다.
+     * @param flaggedRatio FLAGGED로 판정할 닉네임 비율. 0보다 크면 자동 차단과 사전 INSERT, 트라이 재빌드까지
+     *                     실제로 탄다. 어떤 닉네임이 걸릴지는 닉네임 해시로 정해 같은 입력에 같은 결과가 나온다.
+     */
+    public record Stub(
+            @DefaultValue("0s") @NotNull Duration latency,
+
+            @DefaultValue("0") @DecimalMin("0.0") @DecimalMax("1.0")
+            double flaggedRatio) {}
+}

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -3,9 +3,11 @@ package coffeeshout.profanity.config;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.time.Duration;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -24,6 +26,7 @@ import org.springframework.validation.annotation.Validated;
  * @param cron           검열 회차 주기. {@code @Scheduled}는 컴파일 상수만 받으므로 어노테이션에는 이 프로퍼티를
  *                       가리키는 문자열을 쓴다. 값을 여기 두는 이유는 local에서 12시간을 기다리지 않고 회차를
  *                       돌려보기 위해서다.
+ * @param seed           local 프로파일에서 미검열 닉네임을 몇 건 적재할지. 측정용이라 기본값은 0이다.
  * @param stub           local·test 프로파일에서 Gemini 대신 도는 {@code NoOpNicknameAuditor}의 동작.
  *                       기본값이 지연 0에 전부 CLEAN이라 값을 주지 않으면 지금까지와 똑같이 움직인다.
  */
@@ -47,7 +50,20 @@ public record NicknameAuditProperties(
 
         @NotBlank String cron,
 
+        @DefaultValue @Valid @NotNull Seed seed,
+
         @DefaultValue @Valid @NotNull Stub stub) {
+
+    /**
+     * local 전용 적재 설정.
+     *
+     * @param count 합성 UNAUDITED 닉네임을 몇 건 넣을지. 0이면 아무것도 안 넣어 지금까지와 같다.
+     *              상한은 닉네임 칼럼이 10자라서 정했다. 접두사 두 자에 음절 두 자를 붙이고 나면 일련번호에
+     *              여섯 자리가 남는다.
+     */
+    public record Seed(
+            @DefaultValue("0") @PositiveOrZero @Max(1_000_000)
+            int count) {}
 
     /**
      * 스텁 검열기의 동작. LLM을 빼고 파이프라인 내부 병목만 재려고 둔다.

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
@@ -6,7 +6,7 @@ import coffeeshout.profanity.domain.audit.AiConfidence;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import java.sql.Timestamp;
-import java.time.Instant;
+import java.time.Clock;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +25,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
 
     /**
-     * 합성 닉네임에 섞을 음절 범위. 스텁 검열기가 닉네임에서 한글 두 글자를 잘라 차단 조각으로 쓰는데, 음절
-     * 가짓수가 적으면 사전 INSERT가 초반 몇백 건 뒤로 전부 중복이 되어 자동 차단과 트라이 재빌드가 멈춘다.
-     * 완성형 한글 전체를 쓰면 음절 두 자리 조합이 1억 가지라 적재 상한까지 겹치지 않는다.
+     * 합성 닉네임의 접두사. 한글이 아니어야 한다.
+     *
+     * <p>스텁 검열기는 닉네임의 한글 구간에서 두 글자를 잘라 차단 조각으로 쓴다. 접두사가 한글이면 구간이 네
+     * 글자로 늘어 자르는 자리가 셋이 되고, 그중 하나는 언제나 접두사 그 자체다. 시드의 3분의 1이 같은 조각을
+     * 내면 사전 INSERT가 중복으로 걸러져 자동 차단과 트라이 재빌드가 그만큼 안 돈다. block 구간이 실제보다
+     * 싸게 측정된다. 접두사를 한글 밖에 두면 구간이 음절 두 자와 정확히 겹쳐 조각이 전부 달라진다.
+     */
+    private static final String SEED_PREFIX = "zz";
+
+    /**
+     * 합성 닉네임에 섞을 음절 범위. 음절 가짓수가 적으면 사전 INSERT가 초반 몇백 건 뒤로 전부 중복이 되어
+     * 자동 차단과 트라이 재빌드가 멈춘다. 완성형 한글 전체를 쓰면 두 자리 조합이 1억 가지라 적재 상한까지
+     * 겹치지 않는다.
      */
     private static final char FIRST_SYLLABLE = '가';
 
@@ -44,6 +54,7 @@ public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
     private final NicknameAuditRepository auditRepository;
     private final NicknameAuditProperties properties;
     private final JdbcTemplate jdbcTemplate;
+    private final Clock clock;
 
     @Override
     @Transactional
@@ -68,7 +79,7 @@ public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
             return;
         }
 
-        final Timestamp now = Timestamp.from(Instant.now());
+        final Timestamp now = Timestamp.from(clock.instant());
         jdbcTemplate.batchUpdate(SEED_INSERT, IntStream.range(0, count).boxed().toList(), SEED_CHUNK, (ps, index) -> {
             ps.setString(1, seedNickname(index));
             ps.setString(2, NicknameAuditStatus.UNAUDITED.name());
@@ -93,7 +104,7 @@ public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
     private String seedNickname(int index) {
         final char first = (char) (FIRST_SYLLABLE + index % SYLLABLE_COUNT);
         final char second = (char) (FIRST_SYLLABLE + index / SYLLABLE_COUNT % SYLLABLE_COUNT);
-        return "측정" + first + second + index;
+        return SEED_PREFIX + first + second + index;
     }
 
     private void seedSamples() {

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
@@ -7,8 +7,8 @@ import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -25,16 +25,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
 
     /**
-     * 합성 닉네임에 섞을 음절. 스텁 검열기가 닉네임에서 한글 두 글자를 잘라 차단 조각으로 쓰는데, 모든 닉네임이
-     * 같은 조각을 내면 사전 INSERT가 첫 건 뒤로 전부 중복이 되어 자동 차단과 트라이 재빌드가 안 돈다.
+     * 합성 닉네임에 섞을 음절 범위. 스텁 검열기가 닉네임에서 한글 두 글자를 잘라 차단 조각으로 쓰는데, 음절
+     * 가짓수가 적으면 사전 INSERT가 초반 몇백 건 뒤로 전부 중복이 되어 자동 차단과 트라이 재빌드가 멈춘다.
+     * 완성형 한글 전체를 쓰면 음절 두 자리 조합이 1억 가지라 적재 상한까지 겹치지 않는다.
      */
-    private static final String SYLLABLES = "가나다라마바사아자차카타파하거너더러머버";
+    private static final char FIRST_SYLLABLE = '가';
+
+    private static final int SYLLABLE_COUNT = 11_172;
 
     private static final String SEED_INSERT =
             "INSERT INTO player_name_audit (player_name, status, attempt_count, created_at) VALUES (?, ?, 0, ?)";
 
     /** 한 번에 보낼 행 수. 10만 건을 한 문장으로 보내면 패킷 상한에 걸린다. */
     private static final int SEED_CHUNK = 1_000;
+
+    private static final String SEED_EXISTS = "SELECT COUNT(*) FROM player_name_audit WHERE player_name = ?";
 
     private final NicknameAuditRepository auditRepository;
     private final NicknameAuditProperties properties;
@@ -58,30 +63,36 @@ public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
         if (count == 0) {
             return;
         }
-        if (auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED) > 0) {
-            log.info("[LocalInit] 미검열 닉네임이 이미 있습니다. 측정용 적재를 건너뜁니다.");
+        if (alreadySeeded()) {
+            log.info("[LocalInit] 측정용 닉네임이 이미 있습니다. 적재를 건너뜁니다.");
             return;
         }
 
         final Timestamp now = Timestamp.from(Instant.now());
-        List<Object[]> chunk = new ArrayList<>(SEED_CHUNK);
-        for (int i = 0; i < count; i++) {
-            chunk.add(new Object[] {seedNickname(i), NicknameAuditStatus.UNAUDITED.name(), now});
-            if (chunk.size() == SEED_CHUNK) {
-                jdbcTemplate.batchUpdate(SEED_INSERT, chunk);
-                chunk = new ArrayList<>(SEED_CHUNK);
-            }
-        }
-        if (!chunk.isEmpty()) {
-            jdbcTemplate.batchUpdate(SEED_INSERT, chunk);
-        }
+        jdbcTemplate.batchUpdate(SEED_INSERT, IntStream.range(0, count).boxed().toList(), SEED_CHUNK, (ps, index) -> {
+            ps.setString(1, seedNickname(index));
+            ps.setString(2, NicknameAuditStatus.UNAUDITED.name());
+            ps.setTimestamp(3, now);
+        });
         log.info("[LocalInit] 측정용 미검열 닉네임 {}건 적재 완료", count);
+    }
+
+    /**
+     * 상태를 보지 않고 첫 시드 이름이 있는지로 판단한다.
+     *
+     * <p>UNAUDITED 건수로 막으면 회차를 한 번 끝낸 뒤에 0이 되어, 앱을 다시 띄울 때마다 같은 이름이 또 들어간다.
+     * 그 행들은 다음 회차에서 판정 대신 중복 재등록으로 지워지므로 두 번째 측정이 검열 경로가 아니라 삭제
+     * 경로를 재게 된다.
+     */
+    private boolean alreadySeeded() {
+        final Integer existing = jdbcTemplate.queryForObject(SEED_EXISTS, Integer.class, seedNickname(0));
+        return existing != null && existing > 0;
     }
 
     /** 접두사 두 자에 음절 두 자를 붙이고 일련번호로 끝낸다. 닉네임 칼럼이 10자라 번호는 여섯 자리까지다. */
     private String seedNickname(int index) {
-        final char first = SYLLABLES.charAt(index % SYLLABLES.length());
-        final char second = SYLLABLES.charAt(index / SYLLABLES.length() % SYLLABLES.length());
+        final char first = (char) (FIRST_SYLLABLE + index % SYLLABLE_COUNT);
+        final char second = (char) (FIRST_SYLLABLE + index / SYLLABLE_COUNT % SYLLABLE_COUNT);
         return "측정" + first + second + index;
     }
 

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
@@ -1,15 +1,20 @@
 package coffeeshout.profanity.infra;
 
 import coffeeshout.profanity.application.port.NicknameAuditRepository;
+import coffeeshout.profanity.config.NicknameAuditProperties;
 import coffeeshout.profanity.domain.audit.AiConfidence;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,11 +24,68 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
 
+    /**
+     * 합성 닉네임에 섞을 음절. 스텁 검열기가 닉네임에서 한글 두 글자를 잘라 차단 조각으로 쓰는데, 모든 닉네임이
+     * 같은 조각을 내면 사전 INSERT가 첫 건 뒤로 전부 중복이 되어 자동 차단과 트라이 재빌드가 안 돈다.
+     */
+    private static final String SYLLABLES = "가나다라마바사아자차카타파하거너더러머버";
+
+    private static final String SEED_INSERT =
+            "INSERT INTO player_name_audit (player_name, status, attempt_count, created_at) VALUES (?, ?, 0, ?)";
+
+    /** 한 번에 보낼 행 수. 10만 건을 한 문장으로 보내면 패킷 상한에 걸린다. */
+    private static final int SEED_CHUNK = 1_000;
+
     private final NicknameAuditRepository auditRepository;
+    private final NicknameAuditProperties properties;
+    private final JdbcTemplate jdbcTemplate;
 
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
+        seedUnaudited();
+        seedSamples();
+    }
+
+    /**
+     * 측정용 미검열 닉네임을 적재한다. 건수는 {@code nickname-audit.seed.count}가 정하고 기본값은 0이다.
+     *
+     * <p>행마다 저장하면 10만 건에 몇 분이 걸려 JDBC 배치로 넣는다. 일련번호가 이름을 유일하게 만들어
+     * 유니크 제약에 걸리지 않는다.
+     */
+    private void seedUnaudited() {
+        final int count = properties.seed().count();
+        if (count == 0) {
+            return;
+        }
+        if (auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED) > 0) {
+            log.info("[LocalInit] 미검열 닉네임이 이미 있습니다. 측정용 적재를 건너뜁니다.");
+            return;
+        }
+
+        final Timestamp now = Timestamp.from(Instant.now());
+        List<Object[]> chunk = new ArrayList<>(SEED_CHUNK);
+        for (int i = 0; i < count; i++) {
+            chunk.add(new Object[] {seedNickname(i), NicknameAuditStatus.UNAUDITED.name(), now});
+            if (chunk.size() == SEED_CHUNK) {
+                jdbcTemplate.batchUpdate(SEED_INSERT, chunk);
+                chunk = new ArrayList<>(SEED_CHUNK);
+            }
+        }
+        if (!chunk.isEmpty()) {
+            jdbcTemplate.batchUpdate(SEED_INSERT, chunk);
+        }
+        log.info("[LocalInit] 측정용 미검열 닉네임 {}건 적재 완료", count);
+    }
+
+    /** 접두사 두 자에 음절 두 자를 붙이고 일련번호로 끝낸다. 닉네임 칼럼이 10자라 번호는 여섯 자리까지다. */
+    private String seedNickname(int index) {
+        final char first = SYLLABLES.charAt(index % SYLLABLES.length());
+        final char second = SYLLABLES.charAt(index / SYLLABLES.length() % SYLLABLES.length());
+        return "측정" + first + second + index;
+    }
+
+    private void seedSamples() {
         if (auditRepository.countByStatus(NicknameAuditStatus.FLAGGED) > 0
                 || auditRepository.countByStatus(NicknameAuditStatus.PENDING) > 0) {
             log.info("[LocalInit] 닉네임 검열 데이터가 이미 존재합니다. 초기 데이터 삽입을 건너뜁니다.");
@@ -31,75 +93,72 @@ public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
         }
 
         final List<NicknameAudit> flaggedData = List.of(
-                flagged("씨b알",       0.97, "비속어 우회 (특수문자 삽입)"),
-                flagged("ㅅㅂ놈아",    0.95, "초성 비속어"),
-                flagged("개새끼야",    0.99, "직접적 욕설"),
-                flagged("존나빠름",    0.91, "비속어 포함"),
-                flagged("미친병X",     0.88, "비속어 우회 (특수문자 삽입)"),
+                flagged("씨b알", 0.97, "비속어 우회 (특수문자 삽입)"),
+                flagged("ㅅㅂ놈아", 0.95, "초성 비속어"),
+                flagged("개새끼야", 0.99, "직접적 욕설"),
+                flagged("존나빠름", 0.91, "비속어 포함"),
+                flagged("미친병X", 0.88, "비속어 우회 (특수문자 삽입)"),
                 flagged("쓰레기같은놈", 0.98, "직접적 모욕 표현"),
-                flagged("ㄱㅅㄲ",      0.96, "초성 비속어"),
-                flagged("닥쳐이새X",   0.94, "욕설 + 특수문자 우회"),
-                flagged("병신같애",    0.92, "모욕적 표현"),
-                flagged("꺼져씨X",     0.93, "비속어 우회"),
-                flagged("좆같네",      0.97, "직접적 성적 비속어"),
-                flagged("ㅈ같은인생",  0.89, "초성+비속어 혼용"),
-                flagged("개돼지들아",  0.91, "집단 모욕 표현"),
-                flagged("뒤져라고",    0.95, "생명 위협 표현"),
-                flagged("창X년",       0.90, "성적 모욕 우회 표현"),
-                flagged("찐따냐",      0.93, "장애 비하 표현"),
-                flagged("미친놈들아",  0.88, "직접적 욕설"),
-                flagged("씹새끼들",    0.99, "직접적 복합 욕설"),
-                flagged("거지같은X",   0.87, "모욕 + 특수문자 우회"),
-                flagged("ㅂㅅ집합",    0.92, "초성 비속어 집합 표현"),
-                flagged("개쓰레기야",  0.96, "동물 비유 + 모욕"),
-                flagged("죽어버려",    0.94, "생명 위협"),
-                flagged("재수없는놈",  0.86, "모욕적 표현"),
-                flagged("X발놈아",     0.91, "특수문자 우회 욕설"),
-                flagged("멍청이새X",   0.89, "복합 모욕 표현"),
-                flagged("돼지같은년",  0.90, "동물 비유 + 성차별 표현"),
-                flagged("ㅁㅊ새끼",    0.95, "초성 비속어"),
-                flagged("인간쓰레기",  0.93, "극단적 모욕 표현"),
-                flagged("꼴통들아",    0.87, "모욕적 집합 표현"),
-                flagged("바보새X야",   0.88, "복합 모욕 우회 표현")
-        );
+                flagged("ㄱㅅㄲ", 0.96, "초성 비속어"),
+                flagged("닥쳐이새X", 0.94, "욕설 + 특수문자 우회"),
+                flagged("병신같애", 0.92, "모욕적 표현"),
+                flagged("꺼져씨X", 0.93, "비속어 우회"),
+                flagged("좆같네", 0.97, "직접적 성적 비속어"),
+                flagged("ㅈ같은인생", 0.89, "초성+비속어 혼용"),
+                flagged("개돼지들아", 0.91, "집단 모욕 표현"),
+                flagged("뒤져라고", 0.95, "생명 위협 표현"),
+                flagged("창X년", 0.90, "성적 모욕 우회 표현"),
+                flagged("찐따냐", 0.93, "장애 비하 표현"),
+                flagged("미친놈들아", 0.88, "직접적 욕설"),
+                flagged("씹새끼들", 0.99, "직접적 복합 욕설"),
+                flagged("거지같은X", 0.87, "모욕 + 특수문자 우회"),
+                flagged("ㅂㅅ집합", 0.92, "초성 비속어 집합 표현"),
+                flagged("개쓰레기야", 0.96, "동물 비유 + 모욕"),
+                flagged("죽어버려", 0.94, "생명 위협"),
+                flagged("재수없는놈", 0.86, "모욕적 표현"),
+                flagged("X발놈아", 0.91, "특수문자 우회 욕설"),
+                flagged("멍청이새X", 0.89, "복합 모욕 표현"),
+                flagged("돼지같은년", 0.90, "동물 비유 + 성차별 표현"),
+                flagged("ㅁㅊ새끼", 0.95, "초성 비속어"),
+                flagged("인간쓰레기", 0.93, "극단적 모욕 표현"),
+                flagged("꼴통들아", 0.87, "모욕적 집합 표현"),
+                flagged("바보새X야", 0.88, "복합 모욕 우회 표현"));
 
         final List<NicknameAudit> pendingData = List.of(
-                pending("열받네",      0.62, "감탄사로도 쓰이나 문맥 의존적"),
-                pending("빡친호랑이",  0.71, "비속어 경계 표현"),
-                pending("킹받는곰",    0.68, "신조어, 판단 불명확"),
-                pending("뒤진다고",    0.75, "위협적 표현 가능성"),
-                pending("X같은여우",   0.80, "특수문자 치환 의심"),
-                pending("짜증유발자",  0.58, "감정 표현, 직접 욕설 아님"),
-                pending("현타오는곰",  0.45, "신조어, 비속어 여부 불명확"),
-                pending("빡세게살자",  0.52, "경계 표현, 문맥 의존적"),
-                pending("열폭하는중",  0.67, "분노 표현, 판단 필요"),
+                pending("열받네", 0.62, "감탄사로도 쓰이나 문맥 의존적"),
+                pending("빡친호랑이", 0.71, "비속어 경계 표현"),
+                pending("킹받는곰", 0.68, "신조어, 판단 불명확"),
+                pending("뒤진다고", 0.75, "위협적 표현 가능성"),
+                pending("X같은여우", 0.80, "특수문자 치환 의심"),
+                pending("짜증유발자", 0.58, "감정 표현, 직접 욕설 아님"),
+                pending("현타오는곰", 0.45, "신조어, 비속어 여부 불명확"),
+                pending("빡세게살자", 0.52, "경계 표현, 문맥 의존적"),
+                pending("열폭하는중", 0.67, "분노 표현, 판단 필요"),
                 pending("화났어요주의", 0.49, "경고성 표현, 직접 욕설 없음"),
-                pending("돌아이같은",  0.73, "경계 모욕 표현"),
-                pending("반쯤미친듯",  0.70, "과장 표현, 문맥 의존"),
-                pending("못살겠다야",  0.55, "극단 표현이나 일상어 가능성"),
-                pending("답답한세상",  0.42, "사회 불만, 직접 비하 없음"),
-                pending("갑갑한인생",  0.48, "감정 표현, 저위험"),
-                pending("킹받는오리",  0.66, "신조어 혼용"),
-                pending("빡세구리",    0.61, "신조어, 비속어 경계"),
-                pending("뿔난코끼리",  0.44, "은유적 표현"),
-                pending("화염방사기",  0.53, "공격적 이미지 연상 가능"),
-                pending("독한마음곰",  0.59, "경계 표현"),
+                pending("돌아이같은", 0.73, "경계 모욕 표현"),
+                pending("반쯤미친듯", 0.70, "과장 표현, 문맥 의존"),
+                pending("못살겠다야", 0.55, "극단 표현이나 일상어 가능성"),
+                pending("답답한세상", 0.42, "사회 불만, 직접 비하 없음"),
+                pending("갑갑한인생", 0.48, "감정 표현, 저위험"),
+                pending("킹받는오리", 0.66, "신조어 혼용"),
+                pending("빡세구리", 0.61, "신조어, 비속어 경계"),
+                pending("뿔난코끼리", 0.44, "은유적 표현"),
+                pending("화염방사기", 0.53, "공격적 이미지 연상 가능"),
+                pending("독한마음곰", 0.59, "경계 표현"),
                 pending("눈에띄는악당", 0.64, "부정적 정체성 표현"),
-                pending("악당지망생",  0.57, "부정적이나 유희적 표현 가능"),
-                pending("세상원망중",  0.69, "부정적 감정, 판단 필요"),
+                pending("악당지망생", 0.57, "부정적이나 유희적 표현 가능"),
+                pending("세상원망중", 0.69, "부정적 감정, 판단 필요"),
                 pending("뒤통수전문가", 0.72, "부정적 의미, 직접 욕설 아님"),
-                pending("나쁜짓만함",  0.76, "자기 비하인지 타인 비하인지 불명확"),
-                pending("짜증덩어리",  0.63, "모욕적 표현 가능성"),
-                pending("폭발직전곰",  0.50, "감정 표현, 위험도 낮음"),
-                pending("욱하는성격",  0.47, "성격 표현, 직접 비하 없음"),
+                pending("나쁜짓만함", 0.76, "자기 비하인지 타인 비하인지 불명확"),
+                pending("짜증덩어리", 0.63, "모욕적 표현 가능성"),
+                pending("폭발직전곰", 0.50, "감정 표현, 위험도 낮음"),
+                pending("욱하는성격", 0.47, "성격 표현, 직접 비하 없음"),
                 pending("화병난거북이", 0.54, "과장된 감정 표현"),
-                pending("비관론자야",  0.46, "부정적 관점 표현, 저위험")
-        );
+                pending("비관론자야", 0.46, "부정적 관점 표현, 저위험"));
 
         auditRepository.saveAll(flaggedData);
         auditRepository.saveAll(pendingData);
-        log.info("[LocalInit] 닉네임 검열 샘플 데이터 삽입 완료 — FLAGGED {}건, PENDING {}건",
-                flaggedData.size(), pendingData.size());
+        log.info("[LocalInit] 닉네임 검열 샘플 데이터 삽입 완료 — FLAGGED {}건, PENDING {}건", flaggedData.size(), pendingData.size());
     }
 
     private NicknameAudit flagged(String nickname, double confidence, String reason) {

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
@@ -7,6 +7,7 @@ import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -84,12 +85,15 @@ public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
         }
 
         final Timestamp now = Timestamp.from(clock.instant());
+        final long startedAt = System.nanoTime();
         jdbcTemplate.batchUpdate(SEED_INSERT, IntStream.range(0, count).boxed().toList(), SEED_CHUNK, (ps, index) -> {
             ps.setString(1, seedNickname(index));
             ps.setString(2, NicknameAuditStatus.UNAUDITED.name());
             ps.setTimestamp(3, now);
         });
-        log.info("[LocalInit] 측정용 미검열 닉네임 {}건 적재 완료", count);
+        final long elapsedMillis =
+                Duration.ofNanos(System.nanoTime() - startedAt).toMillis();
+        log.info("[LocalInit] 측정용 미검열 닉네임 {}건 적재 완료 ({}ms)", count, elapsedMillis);
     }
 
     /**

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializer.java
@@ -16,7 +16,6 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -57,7 +56,6 @@ public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
     private final Clock clock;
 
     @Override
-    @Transactional
     public void run(ApplicationArguments args) {
         seedUnaudited();
         seedSamples();
@@ -68,6 +66,12 @@ public class LocalNicknameAuditDataInitializer implements ApplicationRunner {
      *
      * <p>행마다 저장하면 10만 건에 몇 분이 걸려 JDBC 배치로 넣는다. 일련번호가 이름을 유일하게 만들어
      * 유니크 제약에 걸리지 않는다.
+     *
+     * <p><b>트랜잭션을 걸지 않는다.</b> 10만 건을 하나로 묶으면 그동안 undo 로그가 계속 자라고 락도 함께
+     * 길어진다. 트랜잭션 밖에서는 커넥션이 autocommit이라 {@link #SEED_CHUNK}마다 커밋된다. 적재 도중 죽으면
+     * 앞쪽 청크는 남고 뒤쪽은 안 들어온 상태가 되는데, 그때는 {@code player_name_audit}에서 접두사
+     * {@value #SEED_PREFIX}로 시작하는 행을 지우고 다시 띄운다. {@link #alreadySeeded()}가 첫 이름만 보므로
+     * 지우지 않고 다시 띄우면 적재를 통째로 건너뛴다.
      */
     private void seedUnaudited() {
         final int count = properties.seed().count();

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/NicknameAuditScheduler.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/NicknameAuditScheduler.java
@@ -9,7 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * 12시간 주기 닉네임 AI 검열 트리거.
+ * 닉네임 AI 검열 트리거. 주기는 {@code nickname-audit.cron}이 정한다(운영 기본 12시간).
  *
  * <p>검열 작업을 직접 실행하지 않고 전용 실행기로 넘긴다. 프로덕션에서 모든 {@code @Scheduled}가
  * 단일 스레드를 공유하는데(그 안에 500ms 주기 Outbox 릴레이가 있다), 검열 회차는 적체량에 비례해
@@ -31,7 +31,8 @@ public class NicknameAuditScheduler {
     @Qualifier("nicknameAuditExecutor")
     private final Executor auditExecutor;
 
-    @Scheduled(cron = "0 0 0/12 * * *")
+    // @Scheduled는 컴파일 상수만 받는다. 값 자체는 NicknameAuditProperties#cron이 검증한다.
+    @Scheduled(cron = "${nickname-audit.cron}")
     public void auditPendingNicknames() {
         log.info("닉네임 AI 검열 스케줄러 시작 — 실행기로 넘긴다");
         auditExecutor.execute(this::runAudit);

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/NicknameAuditScheduler.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/NicknameAuditScheduler.java
@@ -31,7 +31,7 @@ public class NicknameAuditScheduler {
     @Qualifier("nicknameAuditExecutor")
     private final Executor auditExecutor;
 
-    // @Scheduled는 컴파일 상수만 받는다. 값 자체는 NicknameAuditProperties#cron이 검증한다.
+    // @Scheduled는 컴파일 상수만 받는다. 값의 형식은 NicknameAuditProperties의 컴팩트 생성자가 파싱해 검증한다.
     @Scheduled(cron = "${nickname-audit.cron}")
     public void auditPendingNicknames() {
         log.info("닉네임 AI 검열 스케줄러 시작 — 실행기로 넘긴다");

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/NoOpNicknameAuditor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/NoOpNicknameAuditor.java
@@ -82,6 +82,9 @@ public class NoOpNicknameAuditor implements NicknameAuditor {
         return List.of(run.substring(start, start + 2));
     }
 
+    // 스텁이 HTTP 호출 시간을 흉내 내는 자리라 호출 스레드를 실제로 붙잡아야 한다. 스케줄러로 미루면
+    // 회차가 기다리지 않고 지나가 지연을 준 의미가 없어진다.
+    @SuppressWarnings("PMD.NoThreadSleep")
     private void sleepStubLatency() {
         if (latency.isZero() || latency.isNegative()) {
             return;

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/NoOpNicknameAuditor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/NoOpNicknameAuditor.java
@@ -2,27 +2,96 @@ package coffeeshout.profanity.infra;
 
 import static java.util.Objects.requireNonNull;
 
+import coffeeshout.global.exception.custom.InfrastructureException;
+import coffeeshout.profanity.config.NicknameAuditProperties;
 import coffeeshout.profanity.domain.audit.AiConfidence;
+import coffeeshout.profanity.domain.audit.NicknameAuditErrorCode;
 import coffeeshout.profanity.domain.audit.NicknameAuditResult;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.domain.audit.NicknameAuditor;
+import java.time.Duration;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+/**
+ * local·test 프로파일에서 Gemini 대신 도는 스텁 검열기.
+ *
+ * <p>{@code nickname-audit.stub}으로 지연과 FLAGGED 비율을 주면 LLM 없이 파이프라인 내부 병목을 잴 수 있다.
+ * 지연 0에 FLAGGED 비율을 0보다 크게 두면 자동 차단과 트라이 재빌드까지 실제로 타면서 LLM 시간만 빠진다.
+ *
+ * <p>판정은 닉네임 해시로 정해 같은 입력에 같은 FLAGGED 집합이 나온다. 회차를 여러 번 돌려 비교하려면
+ * 결정론이 필요하다.
+ */
 @Slf4j
 @Component
 @Profile("local | test")
 public class NoOpNicknameAuditor implements NicknameAuditor {
 
+    /** 차단 조각으로 쓸 한글 구간. 정규화한 닉네임의 부분 문자열이어야 도메인이 조각으로 채택한다. */
+    private static final Pattern HANGUL_RUN = Pattern.compile("[가-힣]{2,}");
+
+    private static final int RATIO_BUCKETS = 100;
+
+    private final Duration latency;
+    private final double flaggedRatio;
+
+    public NoOpNicknameAuditor(NicknameAuditProperties properties) {
+        this.latency = properties.stub().latency();
+        this.flaggedRatio = properties.stub().flaggedRatio();
+    }
+
     @Override
     public List<NicknameAuditResult> audit(List<String> nicknames) {
+        requireNonNull(nicknames, "nicknames은 null일 수 없습니다.");
         log.debug("NoOpNicknameAuditor: Gemini 호출 생략 (local/test 프로파일), nicknames={}", nicknames);
 
-        requireNonNull(nicknames, "nicknames은 null일 수 없습니다.");
-        return nicknames.stream()
-                .map(nickname -> new NicknameAuditResult(nickname, NicknameAuditStatus.CLEAN, AiConfidence.UNKNOWN, "no-op"))
-                .toList();
+        sleepStubLatency();
+        return nicknames.stream().map(this::judge).toList();
+    }
+
+    private NicknameAuditResult judge(String nickname) {
+        if (!isFlagged(nickname)) {
+            return new NicknameAuditResult(nickname, NicknameAuditStatus.CLEAN, AiConfidence.UNKNOWN, "no-op");
+        }
+        return new NicknameAuditResult(
+                nickname, NicknameAuditStatus.FLAGGED, AiConfidence.of(1.0), "no-op stub", blockTerms(nickname));
+    }
+
+    private boolean isFlagged(String nickname) {
+        if (flaggedRatio <= 0) {
+            return false;
+        }
+        return Math.floorMod(nickname.hashCode(), RATIO_BUCKETS) < Math.round(flaggedRatio * RATIO_BUCKETS);
+    }
+
+    /**
+     * 닉네임에서 한글 두 글자를 잘라 차단 조각으로 쓴다. 조각을 비워두면 자동 차단이 닉네임 전체를 사전에 넣어
+     * 측정하려는 경로가 실제와 달라진다. 자르는 위치도 해시로 정해 닉네임마다 다른 단어가 사전에 들어간다.
+     */
+    private List<String> blockTerms(String nickname) {
+        final Matcher matcher = HANGUL_RUN.matcher(nickname);
+        if (!matcher.find()) {
+            return List.of();
+        }
+        final String run = matcher.group();
+        final int start = Math.floorMod(nickname.hashCode(), run.length() - 1);
+        return List.of(run.substring(start, start + 2));
+    }
+
+    private void sleepStubLatency() {
+        if (latency.isZero() || latency.isNegative()) {
+            return;
+        }
+        try {
+            Thread.sleep(latency);
+        } catch (InterruptedException e) {
+            // 실행기의 shutdownNow가 보낸 인터럽트다. 플래그를 되살려야 드레인 루프가 회차를 멈춘다.
+            Thread.currentThread().interrupt();
+            throw new InfrastructureException(NicknameAuditErrorCode.AI_CALL_FAILED, "스텁 지연 대기가 중단됐습니다.", e);
+        }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -608,6 +609,38 @@ class ProfanityAuditBatchProcessorTest {
             willThrow(new DataIntegrityViolationException("uq_player_name_audit_name_status 충돌"))
                     .given(auditRepository)
                     .saveAll(any());
+        }
+    }
+
+    /**
+     * 구간별 타이머가 없으면 회차가 느릴 때 어디가 느린지 추측으로 답하게 된다.
+     * {@code settle}은 자동 차단을 트랜잭션 안에서 돌리므로 {@code block}을 안에 포함한다.
+     */
+    @Nested
+    class 구간_타이머 {
+
+        @Test
+        void FLAGGED_배치를_처리하면_audit_settle_block_구간이_모두_기록된다() {
+            final NicknameAudit entity = new NicknameAudit("욕설닉네임");
+            given(nicknameAuditor.audit(List.of("욕설닉네임")))
+                    .willReturn(List.of(new NicknameAuditResult(
+                            "욕설닉네임", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "직접 욕설")));
+
+            processor.process(List.of(entity));
+
+            final SoftAssertions softly = new SoftAssertions();
+            List.of("audit", "settle", "block").forEach(phase -> softly.assertThat(구간_호출수(phase))
+                    .as("%s 구간이 안 잡히면 회차 로그가 그 구간을 0으로 보고한다.", phase)
+                    .isPositive());
+            softly.assertAll();
+        }
+
+        private long 구간_호출수(String phase) {
+            return meterRegistry
+                    .get(ProfanityAuditBatchProcessor.PHASE_TIMER)
+                    .tag("phase", phase)
+                    .timer()
+                    .count();
         }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
@@ -24,6 +24,7 @@ import coffeeshout.profanity.domain.audit.NicknameAuditErrorCode;
 import coffeeshout.profanity.domain.audit.NicknameAuditResult;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.domain.audit.NicknameAuditor;
+import coffeeshout.profanity.fixture.NicknameAuditPropertiesFixture;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Arrays;
@@ -76,16 +77,8 @@ class ProfanityAuditBatchProcessorTest {
             protected void doRollback(DefaultTransactionStatus status) {}
         });
 
-        final NicknameAuditProperties properties = new NicknameAuditProperties(
-                "test-key",
-                "gemini-test",
-                0.85,
-                10,
-                20,
-                2,
-                Duration.ofSeconds(120),
-                Duration.ofMinutes(10),
-                MAX_ATTEMPTS);
+        final NicknameAuditProperties properties =
+                NicknameAuditPropertiesFixture.회차(10, Duration.ofMinutes(10), MAX_ATTEMPTS);
         meterRegistry = new SimpleMeterRegistry();
         processor = new ProfanityAuditBatchProcessor(
                 auditRepository,

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -13,6 +13,7 @@ import coffeeshout.profanity.application.port.NicknameAuditRepository;
 import coffeeshout.profanity.config.NicknameAuditProperties;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import coffeeshout.profanity.fixture.NicknameAuditPropertiesFixture;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Duration;
@@ -40,8 +41,7 @@ class ProfanityAuditServiceTest {
         batchProcessor = mock(ProfanityAuditBatchProcessor.class);
         profanityWordManagementService = mock(ProfanityWordManagementService.class);
 
-        final NicknameAuditProperties properties = new NicknameAuditProperties(
-                "api-key", "gemini-2.0-flash", 0.8, 10, 5, 2, Duration.ofSeconds(120), Duration.ofMinutes(10), 3);
+        final NicknameAuditProperties properties = NicknameAuditPropertiesFixture.회차(10, Duration.ofMinutes(10), 3);
         service = new ProfanityAuditService(
                 auditRepository,
                 batchProcessor,
@@ -228,16 +228,8 @@ class ProfanityAuditServiceTest {
         }
 
         private ProfanityAuditService productionSizedService(Clock clock) {
-            final NicknameAuditProperties production = new NicknameAuditProperties(
-                    "api-key",
-                    "gemini-3.5-flash",
-                    0.85,
-                    PRODUCTION_BATCH_SIZE,
-                    20,
-                    2,
-                    Duration.ofSeconds(120),
-                    Duration.ofSeconds(MAX_RUN_SECONDS),
-                    3);
+            final NicknameAuditProperties production =
+                    NicknameAuditPropertiesFixture.회차(PRODUCTION_BATCH_SIZE, Duration.ofSeconds(MAX_RUN_SECONDS), 3);
             final ProfanityAuditService target = new ProfanityAuditService(
                     auditRepository,
                     batchProcessor,

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -33,6 +33,7 @@ class ProfanityAuditServiceTest {
     private NicknameAuditRepository auditRepository;
     private ProfanityAuditBatchProcessor batchProcessor;
     private ProfanityWordManagementService profanityWordManagementService;
+    private SimpleMeterRegistry meterRegistry;
     private ProfanityAuditService service;
 
     @BeforeEach
@@ -42,12 +43,13 @@ class ProfanityAuditServiceTest {
         profanityWordManagementService = mock(ProfanityWordManagementService.class);
 
         final NicknameAuditProperties properties = NicknameAuditPropertiesFixture.회차(10, Duration.ofMinutes(10), 3);
+        meterRegistry = new SimpleMeterRegistry();
         service = new ProfanityAuditService(
                 auditRepository,
                 batchProcessor,
                 profanityWordManagementService,
                 properties,
-                new SimpleMeterRegistry(),
+                meterRegistry,
                 Clock.systemDefaultZone());
         service.initMetrics();
     }
@@ -88,6 +90,24 @@ class ProfanityAuditServiceTest {
 
     @Nested
     class auditPending_배치_검열 {
+
+        @Test
+        void 회차를_돌면_fetch_구간이_기록된다() {
+            given(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED))
+                    .willReturn(0L);
+            given(auditRepository.findByStatusAndAuditedAtIsNull(any(NicknameAuditStatus.class), any(Pageable.class)))
+                    .willReturn(List.of());
+
+            service.auditPending();
+
+            assertThat(meterRegistry
+                            .get(ProfanityAuditBatchProcessor.PHASE_TIMER)
+                            .tag("phase", "fetch")
+                            .timer()
+                            .count())
+                    .as("페이지 조회가 안 잡히면 회차 로그가 fetch를 0으로 보고한다.")
+                    .isPositive();
+        }
 
         @Test
         void UNAUDITED_닉네임이_없으면_배치_처리를_하지_않는다() {

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityFilterServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityFilterServiceTest.java
@@ -8,8 +8,9 @@ import coffeeshout.fixture.ProfanityWordFixture;
 import coffeeshout.profanity.domain.Language;
 import coffeeshout.profanity.domain.ProfanityWord;
 import coffeeshout.profanity.domain.ProfanityWordRepository;
-import coffeeshout.profanity.domain.WordSource;
 import coffeeshout.profanity.domain.TextNormalizer;
+import coffeeshout.profanity.domain.WordSource;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -18,17 +19,17 @@ import org.junit.jupiter.api.Test;
 class ProfanityFilterServiceTest {
 
     private ProfanityWordRepository wordRepository;
+    private SimpleMeterRegistry meterRegistry;
     private ProfanityFilterService service;
 
     @BeforeEach
     void setUp() {
         wordRepository = mock(ProfanityWordRepository.class);
-        service = new ProfanityFilterService(wordRepository, new TextNormalizer());
+        meterRegistry = new SimpleMeterRegistry();
+        service = new ProfanityFilterService(wordRepository, new TextNormalizer(), meterRegistry);
 
-        given(wordRepository.findAllActive()).willReturn(List.of(
-                ProfanityWordFixture.한국어_수동_욕설(),
-                ProfanityWordFixture.영어_LDNOOBW_욕설()
-        ));
+        given(wordRepository.findAllActive())
+                .willReturn(List.of(ProfanityWordFixture.한국어_수동_욕설(), ProfanityWordFixture.영어_LDNOOBW_욕설()));
         service.init();
     }
 
@@ -90,9 +91,8 @@ class ProfanityFilterServiceTest {
 
         @Test
         void 트라이_재구성_후_새로운_단어를_감지한다() {
-            given(wordRepository.findAllActive()).willReturn(List.of(
-                    new ProfanityWord("신규욕설", Language.KOREAN, WordSource.MANUAL, true)
-            ));
+            given(wordRepository.findAllActive())
+                    .willReturn(List.of(new ProfanityWord("신규욕설", Language.KOREAN, WordSource.MANUAL, true)));
             service.rebuildTrie();
 
             assertThat(service.contains("이건 신규욕설이야")).isTrue();
@@ -104,6 +104,26 @@ class ProfanityFilterServiceTest {
             service.rebuildTrie();
 
             assertThat(service.contains("욕설")).isFalse();
+        }
+    }
+
+    /**
+     * FLAGGED 한 건마다 pub/sub이 나가고 구독자가 여기서 트라이를 통째로 다시 만든다.
+     * 재빌드 시간을 안 재면 이게 병목인지 아닌지를 추측으로 답하게 된다.
+     */
+    @Nested
+    class rebuildTrie_재구성_시간 {
+
+        @Test
+        void 재구성마다_소요_시간이_기록된다() {
+            service.rebuildTrie();
+
+            assertThat(meterRegistry
+                            .get("profanity.trie.rebuild.duration")
+                            .timer()
+                            .count())
+                    .as("init 1회에 방금 호출 1회를 더해 2회다.")
+                    .isEqualTo(2L);
         }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditConfigTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditConfigTest.java
@@ -2,6 +2,7 @@ package coffeeshout.profanity.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import coffeeshout.profanity.fixture.NicknameAuditPropertiesFixture;
 import com.google.genai.types.HttpOptions;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -17,17 +18,12 @@ class NicknameAuditConfigTest {
 
     @Test
     void 요청_타임아웃이_밀리초로_변환되어_설정된다() {
-        final NicknameAuditProperties properties = propertiesWithTimeout(Duration.ofSeconds(90));
+        final NicknameAuditProperties properties = NicknameAuditPropertiesFixture.요청_타임아웃(Duration.ofSeconds(90));
 
         final HttpOptions httpOptions = NicknameAuditConfig.httpOptions(properties);
 
         assertThat(httpOptions.timeout())
                 .as("HttpOptions.timeout 은 밀리초 단위다. 초 단위 값을 그대로 넣으면 90ms 가 되어 모든 호출이 즉시 끊긴다.")
                 .contains(90_000);
-    }
-
-    private NicknameAuditProperties propertiesWithTimeout(Duration timeout) {
-        return new NicknameAuditProperties(
-                "api-key", "gemini-3.5-flash", 0.85, 100, 20, 2, timeout, Duration.ofMinutes(10), 3);
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditPropertiesTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditPropertiesTest.java
@@ -1,0 +1,34 @@
+package coffeeshout.profanity.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coffeeshout.profanity.fixture.NicknameAuditPropertiesFixture;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * cron 형식을 바인딩 시점에 잡는지 검증한다.
+ *
+ * <p>{@code @NotBlank}는 공백 여부만 본다. 형식이 틀린 값을 여기서 막지 못하면 바인딩은 통과하고
+ * 스케줄러 후처리기가 기동을 실패시킨다. 그 시점 예외에는 어느 프로퍼티가 원인인지 나오지 않는다.
+ */
+class NicknameAuditPropertiesTest {
+
+    @Nested
+    class cron_형식_검증 {
+
+        @Test
+        void 필드가_모자란_cron은_바인딩에서_거부된다() {
+            assertThatThrownBy(() -> NicknameAuditPropertiesFixture.주기("*/5 * * * *"))
+                    .as("필드 5개짜리 표준 crontab 표기다. Spring은 6개를 요구한다.")
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void 여섯_필드_cron은_그대로_통과한다() {
+            assertThat(NicknameAuditPropertiesFixture.주기("0 */5 * * * *").cron())
+                    .isEqualTo("0 */5 * * * *");
+        }
+    }
+}

--- a/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
@@ -1,6 +1,7 @@
 package coffeeshout.profanity.fixture;
 
 import coffeeshout.profanity.config.NicknameAuditProperties;
+import coffeeshout.profanity.config.NicknameAuditProperties.Seed;
 import coffeeshout.profanity.config.NicknameAuditProperties.Stub;
 import java.time.Duration;
 
@@ -35,6 +36,10 @@ public final class NicknameAuditPropertiesFixture {
         return of("api-key", 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, new Stub(latency, flaggedRatio));
     }
 
+    public static NicknameAuditProperties 적재(int seedCount) {
+        return of("api-key", 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐, new Seed(seedCount));
+    }
+
     private static NicknameAuditProperties of(
             String geminiApiKey,
             int batchSize,
@@ -42,6 +47,17 @@ public final class NicknameAuditPropertiesFixture {
             Duration maxRunDuration,
             int maxAttempts,
             Stub stub) {
+        return of(geminiApiKey, batchSize, requestTimeout, maxRunDuration, maxAttempts, stub, new Seed(0));
+    }
+
+    private static NicknameAuditProperties of(
+            String geminiApiKey,
+            int batchSize,
+            Duration requestTimeout,
+            Duration maxRunDuration,
+            int maxAttempts,
+            Stub stub,
+            Seed seed) {
         return new NicknameAuditProperties(
                 geminiApiKey,
                 모델,
@@ -53,6 +69,7 @@ public final class NicknameAuditPropertiesFixture {
                 maxRunDuration,
                 maxAttempts,
                 "0 0 0/12 * * *",
+                seed,
                 stub);
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
@@ -43,6 +43,16 @@ public final class NicknameAuditPropertiesFixture {
             int maxAttempts,
             Stub stub) {
         return new NicknameAuditProperties(
-                geminiApiKey, 모델, 0.85, batchSize, 20, 2, requestTimeout, maxRunDuration, maxAttempts, stub);
+                geminiApiKey,
+                모델,
+                0.85,
+                batchSize,
+                20,
+                2,
+                requestTimeout,
+                maxRunDuration,
+                maxAttempts,
+                "0 0 0/12 * * *",
+                stub);
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
@@ -21,33 +21,23 @@ public final class NicknameAuditPropertiesFixture {
     private NicknameAuditPropertiesFixture() {}
 
     public static NicknameAuditProperties API_키(String geminiApiKey) {
-        return of(geminiApiKey, 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐);
+        return of(geminiApiKey, 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐, new Seed(0));
     }
 
     public static NicknameAuditProperties 요청_타임아웃(Duration requestTimeout) {
-        return of("api-key", 배치_크기, requestTimeout, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐);
+        return of("api-key", 배치_크기, requestTimeout, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐, new Seed(0));
     }
 
     public static NicknameAuditProperties 회차(int batchSize, Duration maxRunDuration, int maxAttempts) {
-        return of("api-key", batchSize, 요청_타임아웃_기본, maxRunDuration, maxAttempts, 스텁_꺼짐);
+        return of("api-key", batchSize, 요청_타임아웃_기본, maxRunDuration, maxAttempts, 스텁_꺼짐, new Seed(0));
     }
 
     public static NicknameAuditProperties 스텁(Duration latency, double flaggedRatio) {
-        return of("api-key", 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, new Stub(latency, flaggedRatio));
+        return of("api-key", 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, new Stub(latency, flaggedRatio), new Seed(0));
     }
 
     public static NicknameAuditProperties 적재(int seedCount) {
         return of("api-key", 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐, new Seed(seedCount));
-    }
-
-    private static NicknameAuditProperties of(
-            String geminiApiKey,
-            int batchSize,
-            Duration requestTimeout,
-            Duration maxRunDuration,
-            int maxAttempts,
-            Stub stub) {
-        return of(geminiApiKey, batchSize, requestTimeout, maxRunDuration, maxAttempts, stub, new Seed(0));
     }
 
     private static NicknameAuditProperties of(

--- a/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
@@ -1,0 +1,48 @@
+package coffeeshout.profanity.fixture;
+
+import coffeeshout.profanity.config.NicknameAuditProperties;
+import coffeeshout.profanity.config.NicknameAuditProperties.Stub;
+import java.time.Duration;
+
+/**
+ * {@link NicknameAuditProperties}는 생성자 바인딩 record라 필드를 하나 늘릴 때마다 모든 호출부가 깨진다.
+ * 조립을 여기 모아 테스트가 자기가 검증할 값만 넘기게 한다.
+ */
+public final class NicknameAuditPropertiesFixture {
+
+    private static final String 모델 = "gemini-3.5-flash";
+    private static final int 배치_크기 = 100;
+    private static final Duration 요청_타임아웃_기본 = Duration.ofSeconds(120);
+    private static final Duration 회차_예산_기본 = Duration.ofMinutes(10);
+    private static final int 시도_상한_기본 = 3;
+    private static final Stub 스텁_꺼짐 = new Stub(Duration.ZERO, 0);
+
+    private NicknameAuditPropertiesFixture() {}
+
+    public static NicknameAuditProperties API_키(String geminiApiKey) {
+        return of(geminiApiKey, 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐);
+    }
+
+    public static NicknameAuditProperties 요청_타임아웃(Duration requestTimeout) {
+        return of("api-key", 배치_크기, requestTimeout, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐);
+    }
+
+    public static NicknameAuditProperties 회차(int batchSize, Duration maxRunDuration, int maxAttempts) {
+        return of("api-key", batchSize, 요청_타임아웃_기본, maxRunDuration, maxAttempts, 스텁_꺼짐);
+    }
+
+    public static NicknameAuditProperties 스텁(Duration latency, double flaggedRatio) {
+        return of("api-key", 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, new Stub(latency, flaggedRatio));
+    }
+
+    private static NicknameAuditProperties of(
+            String geminiApiKey,
+            int batchSize,
+            Duration requestTimeout,
+            Duration maxRunDuration,
+            int maxAttempts,
+            Stub stub) {
+        return new NicknameAuditProperties(
+                geminiApiKey, 모델, 0.85, batchSize, 20, 2, requestTimeout, maxRunDuration, maxAttempts, stub);
+    }
+}

--- a/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/fixture/NicknameAuditPropertiesFixture.java
@@ -36,6 +36,11 @@ public final class NicknameAuditPropertiesFixture {
         return of("api-key", 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, new Stub(latency, flaggedRatio), new Seed(0));
     }
 
+    public static NicknameAuditProperties 주기(String cron) {
+        return new NicknameAuditProperties(
+                "api-key", 모델, 0.85, 배치_크기, 20, 2, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, cron, new Seed(0), 스텁_꺼짐);
+    }
+
     public static NicknameAuditProperties 적재(int seedCount) {
         return of("api-key", 배치_크기, 요청_타임아웃_기본, 회차_예산_기본, 시도_상한_기본, 스텁_꺼짐, new Seed(seedCount));
     }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorConnectivityTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorConnectivityTest.java
@@ -10,10 +10,10 @@ import coffeeshout.profanity.application.port.NicknameFeedbackRepository;
 import coffeeshout.profanity.config.NicknameAuditProperties;
 import coffeeshout.profanity.domain.audit.NicknameAuditResult;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import coffeeshout.profanity.fixture.NicknameAuditPropertiesFixture;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.genai.Client;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -24,8 +24,7 @@ import org.springframework.data.domain.PageRequest;
 class GeminiNicknameAuditorConnectivityTest {
 
     private static final String API_KEY = System.getenv("GEMINI_API_KEY");
-    private static final NicknameAuditProperties PROPERTIES = new NicknameAuditProperties(
-            API_KEY, "gemini-3.5-flash", 0.85, 100, 20, 2, Duration.ofSeconds(120), Duration.ofMinutes(10), 3);
+    private static final NicknameAuditProperties PROPERTIES = NicknameAuditPropertiesFixture.API_키(API_KEY);
 
     private GeminiNicknameAuditor auditor;
 

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializerTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializerTest.java
@@ -6,6 +6,7 @@ import coffeeshout.profanity.application.port.NicknameAuditRepository;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.fixture.NicknameAuditPropertiesFixture;
 import coffeeshout.support.ServiceTest;
+import java.time.Clock;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +29,7 @@ class LocalNicknameAuditDataInitializerTest extends ServiceTest {
 
     private LocalNicknameAuditDataInitializer 초기화기(int seedCount) {
         return new LocalNicknameAuditDataInitializer(
-                auditRepository, NicknameAuditPropertiesFixture.적재(seedCount), jdbcTemplate);
+                auditRepository, NicknameAuditPropertiesFixture.적재(seedCount), jdbcTemplate, Clock.systemUTC());
     }
 
     private long 미검열_건수() {
@@ -57,7 +58,7 @@ class LocalNicknameAuditDataInitializerTest extends ServiceTest {
         void 회차가_끝나_승격된_뒤에도_같은_이름을_다시_넣지_않는다() {
             초기화기(적재_건수).run(null);
             jdbcTemplate.update(
-                    "UPDATE player_name_audit SET status = 'CLEAN', audited_at = NOW() WHERE player_name LIKE '측정%'");
+                    "UPDATE player_name_audit SET status = 'CLEAN', audited_at = NOW() WHERE player_name LIKE 'zz%'");
 
             초기화기(적재_건수).run(null);
 

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializerTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializerTest.java
@@ -1,0 +1,63 @@
+package coffeeshout.profanity.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.profanity.application.port.NicknameAuditRepository;
+import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import coffeeshout.profanity.fixture.NicknameAuditPropertiesFixture;
+import coffeeshout.support.ServiceTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * 측정용 미검열 닉네임 적재. 10만 건을 넣고 회차를 돌려 파이프라인 처리량을 재는 것이 목적이라
+ * 건수가 프로퍼티대로 들어가고 다시 띄워도 안 늘어나야 한다.
+ */
+class LocalNicknameAuditDataInitializerTest extends ServiceTest {
+
+    /** 청크 경계(1000)를 두 번 넘고 마지막 청크가 덜 차는 값. 나머지를 빠뜨리면 여기서 걸린다. */
+    private static final int 적재_건수 = 2_500;
+
+    @Autowired
+    private NicknameAuditRepository auditRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private LocalNicknameAuditDataInitializer 초기화기(int seedCount) {
+        return new LocalNicknameAuditDataInitializer(
+                auditRepository, NicknameAuditPropertiesFixture.적재(seedCount), jdbcTemplate);
+    }
+
+    private long 미검열_건수() {
+        return auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED);
+    }
+
+    @Nested
+    class seed_count_적재 {
+
+        @Test
+        void 설정한_건수만큼_미검열_닉네임이_들어간다() {
+            초기화기(적재_건수).run(null);
+
+            assertThat(미검열_건수()).isEqualTo(적재_건수);
+        }
+
+        @Test
+        void 두_번_돌려도_건수가_늘지_않는다() {
+            초기화기(적재_건수).run(null);
+            초기화기(적재_건수).run(null);
+
+            assertThat(미검열_건수()).as("앱을 다시 띄울 때마다 적체가 불어나면 회차 간 측정값을 비교할 수 없다.").isEqualTo(적재_건수);
+        }
+
+        @Test
+        void 기본값_0이면_아무것도_넣지_않는다() {
+            초기화기(0).run(null);
+
+            assertThat(미검열_건수()).isZero();
+        }
+    }
+}

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializerTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/LocalNicknameAuditDataInitializerTest.java
@@ -54,6 +54,20 @@ class LocalNicknameAuditDataInitializerTest extends ServiceTest {
         }
 
         @Test
+        void 회차가_끝나_승격된_뒤에도_같은_이름을_다시_넣지_않는다() {
+            초기화기(적재_건수).run(null);
+            jdbcTemplate.update(
+                    "UPDATE player_name_audit SET status = 'CLEAN', audited_at = NOW() WHERE player_name LIKE '측정%'");
+
+            초기화기(적재_건수).run(null);
+
+            assertThat(미검열_건수())
+                    .as("UNAUDITED 건수로만 막으면 회차를 한 번 끝낸 뒤 같은 이름이 다시 들어간다."
+                            + " 그 행들은 다음 회차에서 판정 대신 중복 재등록으로 지워져 측정이 삭제 경로를 잰다.")
+                    .isZero();
+        }
+
+        @Test
         void 기본값_0이면_아무것도_넣지_않는다() {
             초기화기(0).run(null);
 

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/NicknameAuditSchedulerTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/NicknameAuditSchedulerTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.Scheduled;
 
 /**
  * 12시간 주기 검열 스케줄러의 구조적 결함 두 가지를 고정한다. 둘 다 실사용자 트래픽 없이 재현된다.
@@ -106,6 +107,27 @@ class NicknameAuditSchedulerTest {
             assertThat(auditPendingLock().doneTtl())
                     .as("완료 마킹이 cron 주기(12시간)보다 오래 남으면 다음 회차가 조용히 건너뛰어진다.")
                     .isLessThan(TimeUnit.HOURS.toMillis(12));
+        }
+    }
+
+    /**
+     * 결함 3 — cron 이 코드에 박혀 있으면 local 에서 회차를 돌려볼 수 없다.
+     *
+     * <p>12시간 주기를 그대로 두면 파이프라인을 한 번 재려고 12시간을 기다리거나 코드를 고쳐야 한다.
+     * {@code @Scheduled} 는 컴파일 상수만 받으므로 어노테이션에는 프로퍼티를 가리키는 문자열을 둔다.
+     */
+    @Nested
+    class 회차_주기_설정 {
+
+        @Test
+        void cron은_프로퍼티에서_읽어야_한다() throws NoSuchMethodException {
+            final Scheduled scheduled = NicknameAuditScheduler.class
+                    .getDeclaredMethod("auditPendingNicknames")
+                    .getAnnotation(Scheduled.class);
+
+            assertThat(scheduled.cron())
+                    .as("리터럴이면 local 에서 주기를 당기려고 프로덕션 코드를 고쳐야 한다.")
+                    .isEqualTo("${nickname-audit.cron}");
         }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/NoOpNicknameAuditorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/NoOpNicknameAuditorTest.java
@@ -3,26 +3,47 @@ package coffeeshout.profanity.infra;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import coffeeshout.profanity.domain.audit.NicknameAuditResult;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import coffeeshout.profanity.fixture.NicknameAuditPropertiesFixture;
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class NoOpNicknameAuditorTest {
 
+    private static final List<String> 닉네임들 =
+            IntStream.range(0, 200).mapToObj(i -> "측정닉%03d".formatted(i)).toList();
+
     private NoOpNicknameAuditor auditor;
 
     @BeforeEach
     void setUp() {
-        auditor = new NoOpNicknameAuditor();
+        auditor = 스텁(Duration.ZERO, 0);
+    }
+
+    private NoOpNicknameAuditor 스텁(Duration latency, double flaggedRatio) {
+        return new NoOpNicknameAuditor(NicknameAuditPropertiesFixture.스텁(latency, flaggedRatio));
+    }
+
+    private Set<String> flagged된_닉네임(List<NicknameAuditResult> results) {
+        return results.stream()
+                .filter(result -> result.status() == NicknameAuditStatus.FLAGGED)
+                .map(NicknameAuditResult::nickname)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Nested
     class audit_검열 {
 
         @Test
-        void 모든_닉네임을_CLEAN으로_반환한다() {
+        void 기본값에서는_모든_닉네임을_CLEAN으로_반환한다() {
             final var results = auditor.audit(List.of("용감한호랑이", "씨발", "닉네임"));
 
             assertThat(results).allMatch(r -> r.status() == NicknameAuditStatus.CLEAN);
@@ -37,13 +58,66 @@ class NoOpNicknameAuditorTest {
 
         @Test
         void null_입력은_예외가_발생한다() {
-            assertThatThrownBy(() -> auditor.audit(null))
-                    .isInstanceOf(NullPointerException.class);
+            assertThatThrownBy(() -> auditor.audit(null)).isInstanceOf(NullPointerException.class);
         }
 
         @Test
         void 빈_리스트는_빈_결과를_반환한다() {
             assertThat(auditor.audit(List.of())).isEmpty();
+        }
+    }
+
+    @Nested
+    class flagged_비율_판정 {
+
+        @Test
+        void 비율이_0이면_전부_CLEAN이다() {
+            final var results = 스텁(Duration.ZERO, 0).audit(닉네임들);
+
+            assertThat(results).allMatch(r -> r.status() == NicknameAuditStatus.CLEAN);
+        }
+
+        @Test
+        void 비율이_1이면_전부_FLAGGED이고_차단_조각을_담는다() {
+            final var results = 스텁(Duration.ZERO, 1).audit(닉네임들);
+
+            final SoftAssertions softly = new SoftAssertions();
+            softly.assertThat(results).allMatch(r -> r.status() == NicknameAuditStatus.FLAGGED);
+            softly.assertThat(results)
+                    .as("조각이 비면 자동 차단이 닉네임 전체를 사전에 넣어 측정 경로가 실제와 달라진다.")
+                    .allMatch(r -> r.profanityTerms().size() == 1);
+            softly.assertThat(results)
+                    .as("조각은 닉네임의 부분 문자열이어야 도메인이 차단 대상으로 채택한다.")
+                    .allMatch(r -> r.nickname().contains(r.profanityTerms().getFirst()));
+            softly.assertAll();
+        }
+
+        @Test
+        void 같은_입력이면_FLAGGED_집합이_회차마다_같다() {
+            final Set<String> 첫_회차 = flagged된_닉네임(스텁(Duration.ZERO, 0.5).audit(닉네임들));
+            final Set<String> 두번째_회차 = flagged된_닉네임(스텁(Duration.ZERO, 0.5).audit(닉네임들));
+
+            final SoftAssertions softly = new SoftAssertions();
+            softly.assertThat(첫_회차).as("판정이 난수면 회차마다 결과가 달라져 측정값을 비교할 수 없다.").isEqualTo(두번째_회차);
+            softly.assertThat(첫_회차)
+                    .as("비율 0.5가 전부 CLEAN이나 전부 FLAGGED로 쏠리면 위 비교가 아무것도 재지 못한다.")
+                    .hasSizeBetween(1, 닉네임들.size() - 1);
+            softly.assertAll();
+        }
+    }
+
+    @Nested
+    class latency_지연 {
+
+        private static final Duration 지연 = Duration.ofMillis(50);
+
+        @Test
+        void 호출마다_설정한_지연만큼_기다린다() {
+            final long 시작 = System.nanoTime();
+
+            스텁(지연, 0).audit(닉네임들);
+
+            assertThat(Duration.ofNanos(System.nanoTime() - 시작)).isGreaterThanOrEqualTo(지연);
         }
     }
 }

--- a/backend/profanity/src/test/resources/application-test.yml
+++ b/backend/profanity/src/test/resources/application-test.yml
@@ -9,3 +9,4 @@ nickname-audit:
   batch-size: 10
   feedback-injection-threshold: 20
   min-term-length: 2
+  cron: "0 0 0/12 * * *"   # @Scheduled 플레이스홀더는 @DefaultValue 를 못 본다. 값이 없으면 컨텍스트가 안 뜬다.

--- a/backend/profanity/src/test/resources/application-test.yml
+++ b/backend/profanity/src/test/resources/application-test.yml
@@ -9,4 +9,3 @@ nickname-audit:
   batch-size: 10
   feedback-injection-threshold: 20
   min-term-length: 2
-  cron: "0 0 0/12 * * *"   # @Scheduled 플레이스홀더는 @DefaultValue 를 못 본다. 값이 없으면 컨텍스트가 안 뜬다.

--- a/backend/test-support/src/main/resources/application-test-base.yml
+++ b/backend/test-support/src/main/resources/application-test-base.yml
@@ -177,6 +177,11 @@ outbox:
   relay:
     delay: 500
 
+# @Scheduled 의 cron 플레이스홀더는 @ConfigurationProperties 의 @DefaultValue 를 못 본다. 값이 없으면
+# profanity 빈을 스캔하는 모든 모듈 테스트에서 컨텍스트가 안 뜬다. 운영값은 config/service.yml 에 있다.
+nickname-audit:
+  cron: "0 0 0/12 * * *"
+
 report:
   rate-limit:
     rate: 5


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (통합 브랜치 `fix/1759-audit-pipeline`)

# 🔥 연관 이슈

- #1759 (측정 도구)

# 🚀 작업 내용

## 무엇이 달라지는가

이 PR이 merge되면 로컬에서 LLM 없이 닉네임 검열 파이프라인의 처리량을 잴 수 있다. 미검열 닉네임을 원하는 만큼 적재하고, 스텁 검열기에 지연 0을 주고 회차를 돌리면 "AI가 무한히 빠를 때 우리 코드가 분당 몇 건을 처리하는가"가 나온다. 구간별 타이머가 그중 어디가 느린지도 같이 보여준다.

동작은 바뀌지 않는다. 새 프로퍼티의 기본값이 전부 지금 값이라 아무것도 설정하지 않으면 지금까지와 똑같이 움직인다.

## 왜 바꿨는가

검열 회차가 느린 원인을 지금은 지목할 수 없다. 계측이 Gemini 호출 시간 하나뿐이라 회차가 오래 걸릴 때 그게 LLM 때문인지 우리 코드 때문인지 구분이 안 된다. 그 상태로 배치 크기나 thinking 설정을 건드리면 개선했는지 아닌지도 확인할 수 없다.

측정을 막는 것이 세 가지 있었다. 스텁 검열기가 무조건 즉시 CLEAN을 돌려줘 자동 차단 경로가 아예 안 돌았다. 회차 주기 12시간이 코드에 박혀 있어 한 번 돌려보려면 12시간을 기다려야 했다. 로컬 초기화기가 판정이 끝난 샘플 60건만 넣고 미검열은 한 건도 안 넣어 잴 대상이 없었다.

## 변경 목록

1. **스텁 검열기에 지연과 FLAGGED 비율을 붙였다.** `nickname-audit.stub.latency`로 호출 지연을, `nickname-audit.stub.flagged-ratio`로 FLAGGED 비율을 준다. 비율을 0보다 크게 두면 자동 차단과 사전 INSERT, pub/sub, 트라이 재빌드까지 실제로 탄다. 기본값은 지연 0에 비율 0이라 켜지 않으면 전부 CLEAN이다. `NoOpNicknameAuditor`

2. **판정을 닉네임 해시로 정해 결정론을 지켰다.** 난수를 쓰면 회차마다 FLAGGED 집합이 달라져 측정값을 비교할 수 없다. 차단 조각도 닉네임의 한글 두 글자를 해시 위치에서 잘라 채운다. 조각을 비우면 자동 차단이 닉네임 전체를 사전에 넣어 측정 경로가 실제와 달라진다. `NoOpNicknameAuditor`

3. **회차를 네 구간으로 나눠 잰다.** `nickname.audit.phase` 타이머에 phase 태그를 붙였다. `fetch`는 페이지 조회, `audit`은 판정 호출, `settle`은 승격 저장 트랜잭션, `block`은 자동 차단과 이벤트 발행이다. 값은 `/actuator/prometheus`로 읽는다. `ProfanityAuditService`, `ProfanityAuditBatchProcessor`

4. **구독자 쪽 트라이 재빌드도 따로 잰다.** FLAGGED 한 건마다 pub/sub이 나가고 구독자가 트라이를 통째로 다시 만드는데(#1759의 6번), 그 비용을 지금은 아무도 모른다. `profanity.trie.rebuild.duration` `ProfanityFilterService`

5. **회차 주기를 프로퍼티로 뺐다.** 운영 기본값은 12시간 그대로고 local만 5분으로 당긴다. `NicknameAuditScheduler`

6. **로컬 적재 건수를 열었다.** `nickname-audit.seed.count`만큼 합성 미검열 닉네임을 넣는다. 기본값 0이라 값을 주지 않으면 아무것도 안 넣는다. 10만 건도 넣어야 해서 1000행씩 JDBC 배치로 보낸다. `LocalNicknameAuditDataInitializer`

7. **dev 검열 모델을 flash-lite로 내렸다.** Gemini 요청 한도는 모델별로 세므로 dev에서 회차를 돌려도 운영 쿼터를 깎지 않는다. 이 PR에서 유일하게 동작이 바뀌는 항목이라 아래 리뷰 중점사항에 따로 적었다.

9. **시드 적재 시간을 로그에 남긴다.** 완료 로그에 걸린 시간을 함께 적는다. 10만 건이 몇 초인지 알아야 자바 적재를 SQL 스크립트로 옮길지 판단할 수 있다. 아래 측정 결과를 보면 옮길 이유가 없다. `LocalNicknameAuditDataInitializer`

8. **시드 적재를 한 트랜잭션에 담지 않는다.** `seed.count`를 열면서 최대 100만 건의 INSERT가 `run()`의 트랜잭션 하나에 들어가게 됐다. 10만 건을 적재해 측정할 참이라 undo 로그가 그만큼 자라고 락도 적재가 끝날 때까지 유지된다. 트랜잭션을 걷어내 1000건마다 커밋한다. `LocalNicknameAuditDataInitializer`

## 측정 결과

1000건을 적재하고 스텁 지연 0, FLAGGED 비율 0.1로 회차를 한 번 돌렸다.

| 항목 | 값 |
| --- | --- |
| 적재 | 1,000건 |
| 회차 전체 | 891 ms |
| fetch | 56 ms (11회) |
| audit | 1 ms (10회) |
| settle | 790 ms (10회) |
| block | 126 ms (101회) |
| 트라이 재빌드 | 484 ms (102회) |
| 판정 결과 | FLAGGED 101건, CLEAN 899건 |

`settle`이 `block`을 안에 포함한다. 자동 차단이 승격 저장 트랜잭션 안에서 돌기 때문이다.

읽히는 것 두 가지를 적어둔다. 첫째, LLM 시간을 0으로 놓아도 1000건에 0.89초가 든다. 분당 약 6만 7천 건이 우리 코드의 상한이다. 둘째, 그 시간의 대부분이 `settle`이다. 개선을 시작할 자리가 여기라는 뜻이다. 트라이 재빌드는 FLAGGED 101건 전부가 새 단어라 101번 돌았다. 이슈 #1759의 6번이 지적한 단어당 재빌드가 여기서 눈에 보인다.

## 적재 성능

10만 건 적재가 오래 걸리면 측정 회차를 반복할 때마다 기다려야 해서, 자바 적재를 SQL 스크립트로 옮길지 검토했다. 로컬 MySQL에 같은 JDBC 배치를 두 설정으로 돌려 쟀다.

| `rewriteBatchedStatements` | 10만 건 적재 |
| --- | --- |
| true (지금 설정) | 1,790 ms |
| false | 142,577 ms |

80배 차이다. `config/database.yml`이 Hikari `data-source-properties`로 이 값을 이미 켜 두고 있고 그 파일은 모든 프로필에 import되므로, 로컬도 지금 설정 그대로 1.8초다. 드라이버가 청크마다 다중 행 INSERT 한 문장으로 다시 쓰기 때문이고, 이건 SQL 스크립트로 직접 쓰는 것과 같은 형태다. **자바 적재를 SQL로 옮길 이유가 없다.**

옮기지 않는 이유가 하나 더 있다. 시드 닉네임 모양과 스텁이 차단 조각을 뽑는 규칙이 서로 맞아야 하는데, 지금은 둘이 같은 언어 안에 있고 테스트가 덮는다. 이번 리뷰가 잡은 접두사 버그가 정확히 그 결합에서 났다. 시드를 SQL로 옮기면 그 결합이 자바와 SQL에 걸쳐 있게 된다.

측정에 쓴 임시 테스트는 커밋하지 않았다.

## 검증

`./gradlew test` 전체 통과. `./gradlew spotlessCheck pmdMain pmdTest pmdTestFixtures` 통과. base가 `dev`가 아니라 CI가 돌지 않으므로 로컬 결과를 적는다.

새로 추가한 테스트는 다음과 같다. 모두 대상 코드를 일부러 망가뜨려 실패하는 것을 확인했다.

- `NoOpNicknameAuditorTest` — 비율 0이면 전부 CLEAN, 비율 1이면 전부 FLAGGED에 조각 있음, 같은 입력이면 FLAGGED 집합이 회차마다 같음, 설정한 지연만큼 기다림
- `ProfanityAuditBatchProcessorTest` — FLAGGED 배치를 처리하면 audit·settle·block 구간이 모두 기록됨
- `ProfanityAuditServiceTest` — 회차를 돌면 fetch 구간이 기록됨
- `ProfanityFilterServiceTest` — 재구성마다 소요 시간이 기록됨
- `NicknameAuditSchedulerTest` — cron을 프로퍼티에서 읽음
- `NicknameAuditPropertiesTest` — 필드가 모자란 cron이 바인딩에서 거부됨
- `LocalNicknameAuditDataInitializerTest` — 설정한 건수만큼 들어가고, 두 번 돌려도 안 늘고, 회차가 끝나 승격된 뒤에도 다시 안 넣고, 0이면 아무것도 안 넣음

# 💬 리뷰 중점사항

**로컬 앱으로 못 띄우고 Testcontainers로 쟀다.** 포트 8080을 다른 워크트리(`feat-1749`)에서 띄운 백엔드가 잡고 있었다. 남의 프로세스를 죽이지 않으려고 `IntegrationTestSupport` 기반의 임시 테스트로 같은 경로를 돌려 위 수치를 얻었다. 실제 MySQL과 Redis를 쓰고 pub/sub과 트라이 재빌드까지 실제로 타므로 로컬 실행과 경로는 같다. 임시 테스트는 커밋하지 않았다. 포트가 비면 `seed.count`와 `stub` 값을 주고 로컬에서 그대로 재현된다.

**스텁 FLAGGED가 로컬 사전을 오염시킨다.** 비율을 0보다 크게 주고 회차를 돌리면 합성 닉네임에서 자른 조각이 `profanity_word`에 `AI_FLAGGED`로 들어간다. 로컬 전용이고 `ddl-auto: create`라 백엔드를 다시 띄우면 스키마가 새로 만들어져 사라진다. 남은 것을 지우려면 `DELETE FROM profanity_word WHERE source = 'AI_FLAGGED'`를 쓴다. 측정 회차를 여러 번 비교할 때는 사이에 이걸 돌려야 두 번째 회차의 `block` 시간이 첫 회차보다 짧게 나오는 것을 피한다.

**적재 기본값을 0으로 뒀다.** 원래 요청은 "지금 건수"를 기본값으로 두는 것이었는데, 초기화기가 넣던 미검열 닉네임이 실제로는 0건이었다. 샘플 데이터 60건은 FLAGGED와 PENDING이라 회차 대상이 아니다. 그래서 0이 곧 지금 값이다.

**cron 기본값이 두 곳에 있다.** 운영값은 `config/service.yml`, 모듈 테스트값은 `application-test-base.yml`이다. `@Scheduled`의 플레이스홀더는 `@ConfigurationProperties`의 `@DefaultValue`를 보지 않아서 값이 없으면 profanity 빈을 스캔하는 모든 모듈 테스트가 컨텍스트부터 실패한다. 한 곳으로 줄이려면 어노테이션에 `${nickname-audit.cron:0 0 0/12 * * *}`처럼 기본값을 박아야 하는데, 그러면 기본값이 코드로 다시 들어간다. 지금 배치가 나은지 봐주면 좋겠다.

**리뷰 반영으로 측정 신뢰도 결함 넷을 고쳤다.** 재적재 가드가 UNAUDITED 건수만 봐서 두 번째 회차가 삭제 경로를 재던 것, 차단 조각이 421가지로 막히던 것, 시드 접두사가 한글이라 조각의 3분의 1이 한 단어로 몰리던 것, 벌크 저장 실패 시 settle이 두 번 세어지던 것이다. 접두사를 고친 뒤 트라이 재빌드가 70회에서 101회로 늘어 FLAGGED 전부가 새 단어가 됐다. 반려한 항목과 사유는 리뷰 답글에 있다.

**`settle`이 `block`을 포함한다.** 자동 차단이 승격 트랜잭션 안에서 돌아 구간 합이 회차 전체와 맞지 않는다. 분리하려면 자동 차단을 트랜잭션 밖으로 빼야 하는데 그건 동작 변경이라 이 PR 범위 밖으로 뒀다.

**dev 모델 교체가 이 PR에서 유일하게 동작을 바꾼다.** 나머지는 새 프로퍼티의 기본값이 전부 지금 값이라 설정하지 않으면 지금까지와 똑같이 움직인다. `application-dev.yml`의 모델 교체만 다르다. dev가 flash-lite로 판정하면 prod의 flash와 FLAGGED 결과가 갈릴 수 있다. 쿼터를 나누려는 의도된 선택이라 되돌리지 않았고, "동작은 바뀌지 않는다"는 이 PR의 전제에서 여기만 예외라는 것을 밝혀둔다.

**시드 적재가 중간에 죽으면 앞쪽 청크만 남는다.** 트랜잭션을 걷어낸 대가다. `alreadySeeded()`가 첫 이름만 보므로 그 상태로 다시 띄우면 적재를 통째로 건너뛴다. 접두사 `zz`로 시작하는 행을 지우고 다시 띄우면 된다. 로컬 전용이라 완전한 재개는 넣지 않았고 동작만 javadoc에 적었다.

**dev 모델 id를 문서로 확인했다.** Gemini API 문서의 모델 페이지에서 `gemini-3.5-flash-lite`를 확인했다. 실제 호출로는 검증하지 않았다.

# 🙅 이번에 하지 않은 것

성능은 고치지 않았다. 배치 크기, thinking 설정, 트라이 refresh 배치당 1회, 벌크 UPDATE, 키 기반 빈 선택, API 키 분리는 전부 범위 밖이다. 무엇을 고칠지는 이 도구로 잰 뒤에 정한다.

10만 건 측정도 이 PR 뒤에 따로 한다. 여기서는 도구가 동작하는 것만 1000건으로 확인했다.

https://claude.ai/code/session_01M4BvS9q4PUiVRRqEnxN4tx


