### PR TITLE
[fix] 트라이 재빌드 신호를 병합하고 최소 간격을 둔다

### DIFF
--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -53,6 +53,5 @@ nickname-audit:
 
 profanity:
   trie:
-    refresh:
-      min-interval: 5s                 # 트라이 재빌드 최소 간격(#1759). 매시 안전망 재빌드가 이미 최대 1시간
-                                       # 지연을 허용하므로 몇 초는 그 안에 넉넉히 든다. 0이면 병합만 동작(측정 비교용).
+    rebuild:
+      min-interval: 5s                 # 재빌드 최소 간격(#1759). 근거는 ProfanityTrieRebuildProperties 참고.

--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -1,4 +1,4 @@
-# 서비스 도메인 설정 (user, room, player, friend, outbox, report, nickname-audit)
+# 서비스 도메인 설정 (user, room, player, friend, outbox, report, nickname-audit, profanity)
 user:
   code:
     max-retry: 100
@@ -50,3 +50,9 @@ nickname-audit:
     latency: 0s                        # 호출 하나가 흉내 낼 지연. 0으로 두면 LLM이 무한히 빠를 때의 처리량을 잰다.
     flagged-ratio: 0                   # FLAGGED로 판정할 비율(0~1). 올리면 자동 차단·사전 INSERT·트라이 재빌드까지 실제로 탄다.
                                        # 해상도는 0.01이다. 그보다 작은 값은 0으로 반올림돼 아무것도 안 걸린다.
+
+profanity:
+  trie:
+    refresh:
+      min-interval: 5s                 # 트라이 재빌드 최소 간격(#1759). 매시 안전망 재빌드가 이미 최대 1시간
+                                       # 지연을 허용하므로 몇 초는 그 안에 넉넉히 든다. 0이면 병합만 동작(측정 비교용).

--- a/backend/docs/adr/0018-profanity-module-extraction.md
+++ b/backend/docs/adr/0018-profanity-module-extraction.md
@@ -159,3 +159,17 @@ player_name_feedback (
 - `VaneProfanityChecker`, `ProfanityCheckerSyncListener`, `CustomProfanityLoader`를 제거하고 `:profanity` 구현체로 대체한다
 - `PlayerNameRankingCleanupService`의 차단 단어 조회를 `ProfanityWordRepository`로 교체한다
 - `:admin` 모듈에 비속어 관리 CRUD REST API(`/admin/profanity/words`)를 추가한다
+
+## 갱신 지연 한계 (#1759)
+
+10만 건 규모의 닉네임 검열 회차를 실측하니 트라이 재빌드가 10,028회, 합계 2,272초 걸려 회차 시간(271초)의
+8.4배가 겹쳐 돌았다. `RedisMessageListenerContainer`의 기본 실행기가 신호마다 새 스레드를 만들어 동시
+실행 상한이 없던 게 원인이다.
+
+`ProfanityTrieRefreshSubscriber`가 신호를 병합하고 최소 간격(기본 5초, `ProfanityTrieRebuildProperties`)을
+두도록 바꿨다. 그 결과 위 "다중 인스턴스 동기화"의 **즉시 broadcast**와 트레이드오프의 **단어 변경 시마다
+리빌드**는 더 이상 사실이 아니다.
+
+- 단어 변경 반영은 최대 `min-interval`만큼 늦을 수 있다. 매시 정각에 도는 `ProfanityTrieRebuildScheduler`
+  안전망이 이미 최대 1시간 지연을 설계로 받아들이고 있어, 몇 초 지연은 그 안에 든다.
+- 재빌드와 단어 변경은 더 이상 1:1이 아니다. 재빌드 한 번이 그 사이 쌓인 여러 변경을 한꺼번에 반영한다.

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/ProfanityTrieRebuildProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/ProfanityTrieRebuildProperties.java
@@ -10,12 +10,12 @@ import org.springframework.validation.annotation.Validated;
 /**
  * @param minInterval 비속어 트라이 재빌드 최소 간격(#1759). 신호를 병합해도 신호가 계속 들어오면 재빌드가
  *                     쉬지 않고 붙어 돈다. 한 번 돌고 나면 이 간격 안에는 다시 돌지 않는다.
- *                     기본값 5초의 근거는 {@code ProfanityTrieRebuildScheduler}가 이미 매시 정각 전량
- *                     재빌드를 안전망으로 돌려 최대 1시간 지연을 설계로 받아들이고 있다는 것이다.
- *                     몇 초 지연은 그 안에 넉넉히 든다. 0이면 간격 없이 병합만 동작한다(측정 비교용).
+ *                     기본값 5초의 근거는 {@code ProfanityTrieRebuildScheduler}가 이미 매시 정각
+ *                     전량 재빌드를 안전망으로 돌려 최대 1시간 지연을 설계로 받아들이고 있다는 것이다.
+ *                     몇 초 지연은 그 안에 넉넉히 든다. 0이면 간격 없이 병합만 동작하며, 측정 비교에 쓴다.
  */
 @Validated
-@ConfigurationProperties(prefix = "profanity.trie.refresh")
-public record ProfanityTrieRefreshProperties(
+@ConfigurationProperties(prefix = "profanity.trie.rebuild")
+public record ProfanityTrieRebuildProperties(
         @NotNull @DurationMin(nanos = 0, message = "최소 간격은 0 이상이어야 합니다") @DefaultValue("5s")
         Duration minInterval) {}

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/ProfanityTrieRefreshProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/ProfanityTrieRefreshProperties.java
@@ -1,0 +1,21 @@
+package coffeeshout.profanity.config;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import org.hibernate.validator.constraints.time.DurationMin;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * @param minInterval 비속어 트라이 재빌드 최소 간격(#1759). 신호를 병합해도 신호가 계속 들어오면 재빌드가
+ *                     쉬지 않고 붙어 돈다. 한 번 돌고 나면 이 간격 안에는 다시 돌지 않는다.
+ *                     기본값 5초의 근거는 {@code ProfanityTrieRebuildScheduler}가 이미 매시 정각 전량
+ *                     재빌드를 안전망으로 돌려 최대 1시간 지연을 설계로 받아들이고 있다는 것이다.
+ *                     몇 초 지연은 그 안에 넉넉히 든다. 0이면 간격 없이 병합만 동작한다(측정 비교용).
+ */
+@Validated
+@ConfigurationProperties(prefix = "profanity.trie.refresh")
+public record ProfanityTrieRefreshProperties(
+        @NotNull @DurationMin(nanos = 0, message = "최소 간격은 0 이상이어야 합니다") @DefaultValue("5s")
+        Duration minInterval) {}

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriber.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriber.java
@@ -52,6 +52,7 @@ public class ProfanityTrieRefreshSubscriber implements MessageListener {
     private final AtomicBoolean rebuildScheduled = new AtomicBoolean(false);
 
     private volatile Instant lastRebuildStartedAt = Instant.EPOCH;
+    private volatile boolean shuttingDown = false;
 
     private Counter rebuildFailureCounter;
     private Counter rebuildCoalescedCounter;
@@ -69,38 +70,34 @@ public class ProfanityTrieRefreshSubscriber implements MessageListener {
     }
 
     /**
-     * 리스너를 먼저 해제해 새 신호 유입을 끊은 뒤 실행기를 내린다. 순서를 바꿔 실행기부터 내리면,
-     * 스프링이 빈을 의존 역순으로 파괴해 이 구독자가 컨테이너보다 먼저 죽는 사이 들어온 신호가
-     * 이미 닫힌 실행기에 예약을 시도해 {@link RejectedExecutionException}이 리스너 스레드로 샌다.
-     * 진행 중인 재빌드는 끝까지 마치게 두고, 그래도 안 끝나면 강제 종료한다.
+     * 우아한 드레인을 하지 않는다. 재빌드 결과는 trieRef에 담기고 그 JVM은 지금 죽는 중이라, 끝까지
+     * 기다려 만든 트라이를 아무도 안 쓴다. 새 인스턴스는 기동 때 {@code ProfanityFilterService}의
+     * {@code @PostConstruct}가 다시 만든다. 실행기 종료를 기다리게 하면 #1753처럼 진행 중인 작업이
+     * 끝날 때까지 종료 자체가 막힌다. shuttingDown은 shutdownNow()보다 반드시 먼저 세운다.
+     * 반대로 하면 인터럽트가 먼저 도착해 그 예외가 재빌드 실패로 집계된다.
+     * 리스너를 먼저 해제해 새 신호 유입을 끊는다. 그래야 컨테이너가 이미 닫힌 실행기에 예약을
+     * 시도해 {@link RejectedExecutionException}이 리스너 스레드로 새는 것을 막는다.
      */
     @PreDestroy
     public void shutdown() {
+        shuttingDown = true;
         container.removeMessageListener(this, TRIE_REFRESH_TOPIC);
-        rebuildExecutor.shutdown();
-        try {
-            if (!rebuildExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-                rebuildExecutor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            rebuildExecutor.shutdownNow();
-            Thread.currentThread().interrupt();
-        }
+        rebuildExecutor.shutdownNow();
     }
 
     @Override
     public void onMessage(@NonNull Message message, byte[] pattern) {
         log.debug("비속어 트라이 갱신 신호 수신");
-        if (rebuildScheduled.compareAndSet(false, true)) {
-            try {
-                rebuildExecutor.schedule(this::rebuild, delayUntilNextRebuildMillis(), TimeUnit.MILLISECONDS);
-            } catch (RejectedExecutionException e) {
-                // 실행기가 이미 종료 처리 중이라 예약을 받지 않는다. 플래그를 되돌려도 구독은 이미
-                // 해제된 뒤라 다음 신호는 없다.
-                rebuildScheduled.set(false);
-            }
-        } else {
+        if (!rebuildScheduled.compareAndSet(false, true)) {
             rebuildCoalescedCounter.increment();
+            return;
+        }
+        try {
+            rebuildExecutor.schedule(this::rebuild, delayUntilNextRebuildMillis(), TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException e) {
+            // 실행기가 이미 종료 처리 중이라 예약을 받지 않는다. 플래그를 되돌려도 구독은 이미
+            // 해제된 뒤라 다음 신호는 없다.
+            rebuildScheduled.set(false);
         }
     }
 
@@ -129,6 +126,10 @@ public class ProfanityTrieRefreshSubscriber implements MessageListener {
         try {
             filterService.rebuildTrie();
         } catch (Exception e) {
+            // 종료 중 인터럽트로 죽은 재빌드는 실패가 아니다. 다음 기동이 다시 만든다.
+            if (shuttingDown) {
+                return;
+            }
             log.error("비속어 트라이 재빌드 실패 — channel: {}", ProfanityRedisChannel.TRIE_REFRESH, e);
             rebuildFailureCounter.increment();
         }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriber.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriber.java
@@ -1,7 +1,7 @@
 package coffeeshout.profanity.infra.redis;
 
 import coffeeshout.profanity.application.ProfanityFilterService;
-import coffeeshout.profanity.config.ProfanityTrieRefreshProperties;
+import coffeeshout.profanity.config.ProfanityTrieRebuildProperties;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
@@ -10,6 +10,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,22 +28,26 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProfanityTrieRefreshSubscriber implements MessageListener {
 
+    private static final PatternTopic TRIE_REFRESH_TOPIC = new PatternTopic(ProfanityRedisChannel.TRIE_REFRESH);
+
     private final RedisMessageListenerContainer container;
     private final ProfanityFilterService filterService;
     private final MeterRegistry meterRegistry;
     private final Clock clock;
-    private final ProfanityTrieRefreshProperties properties;
+    private final ProfanityTrieRebuildProperties properties;
 
     /**
-     * 재빌드 전용 단독 스레드(#1759). 리스너 컨테이너 기본 실행기({@code SimpleAsyncTaskExecutor})는
-     * 신호마다 새 스레드를 만들어 동시 실행 상한이 없다. 재빌드를 이 스레드 하나로 몰아 동시 실행을 1로 묶고,
-     * 최소 간격 지연도 여기 위임한다(Thread.sleep 금지 — 고정 대기는 실행 환경에 따라 동작이 갈린다).
+     * 재빌드 전용 단독 스레드(#1759). 리스너 컨테이너 기본 실행기인 {@code SimpleAsyncTaskExecutor}는
+     * 신호마다 새 스레드를 만들어 동시 실행 상한이 없다. 신호 기반 재빌드의 동시 실행을 1로 묶는다.
+     * 매시 안전망 재빌드와 시드 로더는 이 실행기를 거치지 않고 별도 스레드에서 rebuildTrie()를 직접
+     * 부른다. 최소 간격 지연도 이 실행기에 위임한다. 고정 대기는 실행 환경에 따라 동작이 갈려
+     * Thread.sleep은 쓰지 않는다.
      */
     private final ScheduledExecutorService rebuildExecutor = Executors.newSingleThreadScheduledExecutor();
 
     /**
-     * 재빌드가 이미 예약(대기 또는 실행 중)됐는지 표시한다. 신호에는 payload가 없고 재빌드는 항상 사전
-     * 전량을 다시 읽는 통짜 작업이라, 예약된 동안 들어온 신호는 버려도 결과가 같다.
+     * 다음 재빌드가 이미 예약됐는지 표시한다. 신호에는 payload가 없고 재빌드는 항상 사전 전량을
+     * 다시 읽는 통짜 작업이라, 예약된 동안 들어온 신호는 버려도 결과가 같다.
      */
     private final AtomicBoolean rebuildScheduled = new AtomicBoolean(false);
 
@@ -59,20 +64,41 @@ public class ProfanityTrieRefreshSubscriber implements MessageListener {
         rebuildCoalescedCounter = Counter.builder("profanity.trie.rebuild.coalesced")
                 .description("병합으로 버려진 트라이 재빌드 신호 수")
                 .register(meterRegistry);
-        container.addMessageListener(this, new PatternTopic(ProfanityRedisChannel.TRIE_REFRESH));
+        container.addMessageListener(this, TRIE_REFRESH_TOPIC);
         log.info("비속어 트라이 갱신 구독 등록 완료 — channel: {}", ProfanityRedisChannel.TRIE_REFRESH);
     }
 
+    /**
+     * 리스너를 먼저 해제해 새 신호 유입을 끊은 뒤 실행기를 내린다. 순서를 바꿔 실행기부터 내리면,
+     * 스프링이 빈을 의존 역순으로 파괴해 이 구독자가 컨테이너보다 먼저 죽는 사이 들어온 신호가
+     * 이미 닫힌 실행기에 예약을 시도해 {@link RejectedExecutionException}이 리스너 스레드로 샌다.
+     * 진행 중인 재빌드는 끝까지 마치게 두고, 그래도 안 끝나면 강제 종료한다.
+     */
     @PreDestroy
     public void shutdown() {
-        rebuildExecutor.shutdownNow();
+        container.removeMessageListener(this, TRIE_REFRESH_TOPIC);
+        rebuildExecutor.shutdown();
+        try {
+            if (!rebuildExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                rebuildExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            rebuildExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 
     @Override
     public void onMessage(@NonNull Message message, byte[] pattern) {
         log.debug("비속어 트라이 갱신 신호 수신");
         if (rebuildScheduled.compareAndSet(false, true)) {
-            rebuildExecutor.schedule(this::rebuild, delayUntilNextRebuildMillis(), TimeUnit.MILLISECONDS);
+            try {
+                rebuildExecutor.schedule(this::rebuild, delayUntilNextRebuildMillis(), TimeUnit.MILLISECONDS);
+            } catch (RejectedExecutionException e) {
+                // 실행기가 이미 종료 처리 중이라 예약을 받지 않는다. 플래그를 되돌려도 구독은 이미
+                // 해제된 뒤라 다음 신호는 없다.
+                rebuildScheduled.set(false);
+            }
         } else {
             rebuildCoalescedCounter.increment();
         }
@@ -81,14 +107,25 @@ public class ProfanityTrieRefreshSubscriber implements MessageListener {
     private long delayUntilNextRebuildMillis() {
         final Duration elapsed = Duration.between(lastRebuildStartedAt, clock.instant());
         final Duration remaining = properties.minInterval().minus(elapsed);
-        return remaining.isPositive() ? remaining.toMillis() : 0L;
+        if (remaining.isNegative() || remaining.isZero()) {
+            return 0L;
+        }
+        // NTP 스텝 조정 등으로 시계가 뒤로 뛰면 elapsed가 음수가 되어 remaining이 minInterval을 넘을 수
+        // 있다. ScheduledExecutorService의 대기는 System.nanoTime() 기반이라 시계가 돌아와도 줄어들지
+        // 않고, 그 긴 대기 동안 들어오는 신호가 전부 버려진다. 상한을 minInterval로 잡아 막는다.
+        if (remaining.compareTo(properties.minInterval()) > 0) {
+            return properties.minInterval().toMillis();
+        }
+        return remaining.toMillis();
     }
 
     private void rebuild() {
-        // 플래그는 반드시 DB를 읽기 전에 내린다. 읽은 뒤에 내리면 읽는 도중 커밋된 단어를 놓친다.
-        // 읽기 전에 내리면 그 단어의 신호가 플래그를 다시 세워 한 번 더 돌게 되는데, 그게 맞는 동작이다.
-        rebuildScheduled.set(false);
+        // 타임스탬프를 플래그보다 먼저 갱신한다. 순서를 바꾸면 플래그가 내려간 뒤 이 두 줄 사이에 들어온
+        // 신호가 갱신 전 타임스탬프를 보고, 최소 간격이 이미 지난 것으로 계산해 곧바로 재빌드를 예약한다.
+        // 그러면 최소 간격이 무시된다. 타임스탬프를 먼저 쓰면 그 신호도 정확한 간격을 계산한다.
+        // 플래그는 여전히 DB를 읽기 전에 내린다. 읽은 뒤에 내리면 읽는 도중 커밋된 단어를 놓친다.
         lastRebuildStartedAt = clock.instant();
+        rebuildScheduled.set(false);
         try {
             filterService.rebuildTrie();
         } catch (Exception e) {

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriber.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriber.java
@@ -1,9 +1,18 @@
 package coffeeshout.profanity.infra.redis;
 
 import coffeeshout.profanity.application.ProfanityFilterService;
+import coffeeshout.profanity.config.ProfanityTrieRefreshProperties;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -21,21 +30,65 @@ public class ProfanityTrieRefreshSubscriber implements MessageListener {
     private final RedisMessageListenerContainer container;
     private final ProfanityFilterService filterService;
     private final MeterRegistry meterRegistry;
+    private final Clock clock;
+    private final ProfanityTrieRefreshProperties properties;
+
+    /**
+     * 재빌드 전용 단독 스레드(#1759). 리스너 컨테이너 기본 실행기({@code SimpleAsyncTaskExecutor})는
+     * 신호마다 새 스레드를 만들어 동시 실행 상한이 없다. 재빌드를 이 스레드 하나로 몰아 동시 실행을 1로 묶고,
+     * 최소 간격 지연도 여기 위임한다(Thread.sleep 금지 — 고정 대기는 실행 환경에 따라 동작이 갈린다).
+     */
+    private final ScheduledExecutorService rebuildExecutor = Executors.newSingleThreadScheduledExecutor();
+
+    /**
+     * 재빌드가 이미 예약(대기 또는 실행 중)됐는지 표시한다. 신호에는 payload가 없고 재빌드는 항상 사전
+     * 전량을 다시 읽는 통짜 작업이라, 예약된 동안 들어온 신호는 버려도 결과가 같다.
+     */
+    private final AtomicBoolean rebuildScheduled = new AtomicBoolean(false);
+
+    private volatile Instant lastRebuildStartedAt = Instant.EPOCH;
 
     private Counter rebuildFailureCounter;
+    private Counter rebuildCoalescedCounter;
 
     @PostConstruct
     public void register() {
         rebuildFailureCounter = Counter.builder("profanity.trie.rebuild.failure")
                 .description("비속어 트라이 재빌드 실패 횟수")
                 .register(meterRegistry);
+        rebuildCoalescedCounter = Counter.builder("profanity.trie.rebuild.coalesced")
+                .description("병합으로 버려진 트라이 재빌드 신호 수")
+                .register(meterRegistry);
         container.addMessageListener(this, new PatternTopic(ProfanityRedisChannel.TRIE_REFRESH));
         log.info("비속어 트라이 갱신 구독 등록 완료 — channel: {}", ProfanityRedisChannel.TRIE_REFRESH);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        rebuildExecutor.shutdownNow();
     }
 
     @Override
     public void onMessage(@NonNull Message message, byte[] pattern) {
         log.debug("비속어 트라이 갱신 신호 수신");
+        if (rebuildScheduled.compareAndSet(false, true)) {
+            rebuildExecutor.schedule(this::rebuild, delayUntilNextRebuildMillis(), TimeUnit.MILLISECONDS);
+        } else {
+            rebuildCoalescedCounter.increment();
+        }
+    }
+
+    private long delayUntilNextRebuildMillis() {
+        final Duration elapsed = Duration.between(lastRebuildStartedAt, clock.instant());
+        final Duration remaining = properties.minInterval().minus(elapsed);
+        return remaining.isPositive() ? remaining.toMillis() : 0L;
+    }
+
+    private void rebuild() {
+        // 플래그는 반드시 DB를 읽기 전에 내린다. 읽은 뒤에 내리면 읽는 도중 커밋된 단어를 놓친다.
+        // 읽기 전에 내리면 그 단어의 신호가 플래그를 다시 세워 한 번 더 돌게 되는데, 그게 맞는 동작이다.
+        rebuildScheduled.set(false);
+        lastRebuildStartedAt = clock.instant();
         try {
             filterService.rebuildTrie();
         } catch (Exception e) {

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriberTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriberTest.java
@@ -3,6 +3,7 @@ package coffeeshout.profanity.infra.redis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -18,6 +19,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
@@ -69,35 +72,22 @@ class ProfanityTrieRefreshSubscriberTest {
 
         @Test
         @DisplayName("연속 신호는 재빌드를 신호 횟수만큼 돌리지 않는다")
-        void 연속_신호가_병합된다() throws InterruptedException {
+        void 연속_신호가_병합된다() {
             구독자를_준비한다(Duration.ZERO);
-            final CountDownLatch firstEntered = new CountDownLatch(1);
-            final CountDownLatch releaseFirst = new CountDownLatch(1);
-            doAnswer(invocation -> {
-                        firstEntered.countDown();
-                        releaseFirst.await();
-                        return null;
-                    })
-                    .when(filterService)
-                    .rebuildTrie();
 
-            // 첫 신호가 실행기에 들어가 DB를 읽는 동안 나머지 19개는 병합돼야 한다.
             for (int i = 0; i < 20; i++) {
                 subscriber.onMessage(MESSAGE, null);
             }
-            assertThat(firstEntered.await(2, TimeUnit.SECONDS))
-                    .as("첫 재빌드가 DB를 읽는 중이다")
-                    .isTrue();
 
-            verify(filterService, times(1)).rebuildTrie();
-            assertThat(meterRegistry
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(meterRegistry
                             .get("profanity.trie.rebuild.coalesced")
                             .counter()
                             .count())
-                    .as("병합돼 버려진 신호 수가 기록된다")
-                    .isGreaterThan(0);
-
-            releaseFirst.countDown();
+                    .as("신호 20개 중 일부가 병합돼 버려진다")
+                    .isGreaterThan(0));
+            // 신호 20개가 재빌드 20회가 되려면 매 반복 사이에 재빌드가 끝나야 하는데,
+            // 그러면 위 병합 단언이 먼저 깨진다. 워커 속도와 무관한 안전한 상한이다.
+            verify(filterService, atMost(19)).rebuildTrie();
         }
     }
 
@@ -109,40 +99,37 @@ class ProfanityTrieRefreshSubscriberTest {
         @DisplayName("신호 기반 재빌드는 동시 실행이 1을 넘지 않는다")
         void 신호_기반_재빌드는_동시_실행이_1을_넘지_않는다() throws InterruptedException {
             구독자를_준비한다(Duration.ZERO);
-            final AtomicInteger invocationCount = new AtomicInteger(0);
             final AtomicInteger concurrent = new AtomicInteger(0);
             final AtomicInteger maxConcurrent = new AtomicInteger(0);
-            final CountDownLatch firstEntered = new CountDownLatch(1);
-            final CountDownLatch releaseFirst = new CountDownLatch(1);
-            final CountDownLatch secondEntered = new CountDownLatch(1);
+            final CountDownLatch releaseRebuild = new CountDownLatch(1);
             doAnswer(invocation -> {
-                        maxConcurrent.updateAndGet(max -> Math.max(max, concurrent.incrementAndGet()));
-                        if (invocationCount.incrementAndGet() == 1) {
-                            firstEntered.countDown();
-                            releaseFirst.await();
-                        } else {
-                            secondEntered.countDown();
-                        }
+                        final int current = concurrent.incrementAndGet();
+                        maxConcurrent.updateAndGet(max -> Math.max(max, current));
+                        releaseRebuild.await(); // 테스트가 풀어줄 때까지, 딱 그만큼만 붙잡는다.
                         concurrent.decrementAndGet();
                         return null;
                     })
                     .when(filterService)
                     .rebuildTrie();
 
-            subscriber.onMessage(MESSAGE, null);
-            assertThat(firstEntered.await(2, TimeUnit.SECONDS))
-                    .as("첫 재빌드가 DB를 읽는 중이다")
-                    .isTrue();
+            // 10개 스레드가 동시에 신호를 보내도 CAS가 승자를 하나로 정한다.
+            final ExecutorService signalSenders = Executors.newFixedThreadPool(10);
+            for (int i = 0; i < 10; i++) {
+                signalSenders.execute(() -> subscriber.onMessage(MESSAGE, null));
+            }
+            signalSenders.shutdown();
+            signalSenders.awaitTermination(5, TimeUnit.SECONDS);
+
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> assertThat(concurrent.get()).isEqualTo(1));
 
             // 플래그는 DB를 읽기 전에 이미 내려가 있어 이 신호가 두 번째 재빌드를 예약한다.
+            // 실행기 스레드가 하나뿐이라 첫 재빌드가 끝나기 전에는 절대 함께 실행되지 않는다.
             subscriber.onMessage(MESSAGE, null);
 
-            // 실행기 스레드가 하나뿐이라 첫 재빌드가 끝나기 전에는 두 번째가 절대 시작될 수 없다.
-            // 실행기가 여러 스레드였다면 여기서 이미 secondEntered가 열렸을 것이다.
-            assertThat(secondEntered.getCount()).isEqualTo(1);
-
-            releaseFirst.countDown();
-            assertThat(secondEntered.await(2, TimeUnit.SECONDS)).isTrue();
+            releaseRebuild.countDown();
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> assertThat(concurrent.get()).isZero());
             assertThat(maxConcurrent.get()).isEqualTo(1);
         }
     }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriberTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriberTest.java
@@ -1,0 +1,247 @@
+package coffeeshout.profanity.infra.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.profanity.application.ProfanityFilterService;
+import coffeeshout.profanity.config.ProfanityTrieRefreshProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+/**
+ * 트라이 재빌드 신호 병합·최소 간격 회귀 테스트(#1759).
+ *
+ * <p>10만 건 실측에서 트라이 재빌드가 10,028회, 합계 2,272초 돌아 회차 시간(271초)의 8.4배가 겹쳐 돌았다.
+ * 리스너 컨테이너 기본 실행기가 신호마다 스레드를 새로 만들어 동시 실행 상한이 없었던 게 원인이다.
+ */
+class ProfanityTrieRefreshSubscriberTest {
+
+    private static final Message MESSAGE = mock(Message.class);
+
+    private RedisMessageListenerContainer container;
+    private ProfanityFilterService filterService;
+    private SimpleMeterRegistry meterRegistry;
+    private StubClock clock;
+    private ProfanityTrieRefreshSubscriber subscriber;
+
+    @BeforeEach
+    void setUp() {
+        container = mock(RedisMessageListenerContainer.class);
+        filterService = mock(ProfanityFilterService.class);
+        meterRegistry = new SimpleMeterRegistry();
+        clock = new StubClock(Instant.parse("2026-09-06T00:00:00Z"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        subscriber.shutdown();
+    }
+
+    private void 구독자를_준비한다(Duration minInterval) {
+        subscriber = new ProfanityTrieRefreshSubscriber(
+                container, filterService, meterRegistry, clock, new ProfanityTrieRefreshProperties(minInterval));
+        subscriber.register();
+    }
+
+    @Nested
+    @DisplayName("신호 병합")
+    class 신호_병합 {
+
+        @Test
+        @DisplayName("연속 신호는 재빌드를 신호 횟수만큼 돌리지 않는다")
+        void 연속_신호가_병합된다() {
+            구독자를_준비한다(Duration.ZERO);
+
+            for (int i = 0; i < 20; i++) {
+                subscriber.onMessage(MESSAGE, null);
+            }
+
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> verify(filterService, times(1)).rebuildTrie());
+            assertThat(meterRegistry
+                            .get("profanity.trie.rebuild.coalesced")
+                            .counter()
+                            .count())
+                    .as("병합돼 버려진 신호 수가 기록된다")
+                    .isGreaterThan(0);
+        }
+
+        @Test
+        @DisplayName("동시 실행이 1을 넘지 않는다")
+        void 동시_실행이_1을_넘지_않는다() throws InterruptedException {
+            구독자를_준비한다(Duration.ZERO);
+            final AtomicInteger concurrent = new AtomicInteger(0);
+            final AtomicInteger maxConcurrent = new AtomicInteger(0);
+            doAnswer(invocation -> {
+                        final int current = concurrent.incrementAndGet();
+                        maxConcurrent.updateAndGet(max -> Math.max(max, current));
+                        // 재빌드가 순간에 끝나지 않음을 흉내낸다. Thread.sleep 대신 만료되는 대기로 막는다.
+                        new CountDownLatch(1).await(20, TimeUnit.MILLISECONDS);
+                        concurrent.decrementAndGet();
+                        return null;
+                    })
+                    .when(filterService)
+                    .rebuildTrie();
+
+            final ExecutorService signalSenders = Executors.newFixedThreadPool(10);
+            for (int i = 0; i < 10; i++) {
+                signalSenders.execute(() -> subscriber.onMessage(MESSAGE, null));
+            }
+            signalSenders.shutdown();
+            signalSenders.awaitTermination(5, TimeUnit.SECONDS);
+
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> assertThat(concurrent.get()).isZero());
+            assertThat(maxConcurrent.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("재빌드 도중 신호")
+    class 재빌드_도중_신호 {
+
+        @Test
+        @DisplayName("DB를 읽는 동안 들어온 신호는 재빌드를 한 번 더 유발한다")
+        void 읽기_도중_신호가_재빌드를_한번_더_유발한다() throws InterruptedException {
+            구독자를_준비한다(Duration.ZERO);
+            final CountDownLatch enteredRebuild = new CountDownLatch(1);
+            final CountDownLatch releaseRebuild = new CountDownLatch(1);
+            doAnswer(invocation -> {
+                        enteredRebuild.countDown();
+                        releaseRebuild.await();
+                        return null;
+                    })
+                    .when(filterService)
+                    .rebuildTrie();
+
+            subscriber.onMessage(MESSAGE, null);
+            assertThat(enteredRebuild.await(2, TimeUnit.SECONDS))
+                    .as("첫 재빌드가 DB를 읽는 중이다")
+                    .isTrue();
+
+            // 플래그가 읽기 전에 내려가 있어야 이 신호가 다음 재빌드를 예약한다.
+            subscriber.onMessage(MESSAGE, null);
+            releaseRebuild.countDown();
+
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> verify(filterService, times(2)).rebuildTrie());
+        }
+    }
+
+    @Nested
+    @DisplayName("최소 간격")
+    class 최소_간격 {
+
+        @Test
+        @DisplayName("간격 안에 들어온 신호는 간격이 지난 뒤에 반영된다")
+        void 간격_안_신호는_지연되어_반영된다() {
+            final Duration minInterval = Duration.ofMillis(400);
+            구독자를_준비한다(minInterval);
+
+            subscriber.onMessage(MESSAGE, null);
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> verify(filterService, times(1)).rebuildTrie());
+
+            subscriber.onMessage(MESSAGE, null);
+            // 간격이 지나기 전이라 두 번째 신호는 아직 반영되지 않는다.
+            verify(filterService, times(1)).rebuildTrie();
+
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> verify(filterService, times(2)).rebuildTrie());
+        }
+
+        @Test
+        @DisplayName("간격이 지난 뒤 신호는 대기 없이 반영된다")
+        void 간격이_지난_신호는_즉시_반영된다() {
+            final Duration minInterval = Duration.ofSeconds(5);
+            구독자를_준비한다(minInterval);
+
+            subscriber.onMessage(MESSAGE, null);
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> verify(filterService, times(1)).rebuildTrie());
+
+            // 실제 시간은 그대로 두고 주입된 Clock만 간격 이상으로 흘려보낸다.
+            clock.advance(minInterval.plusSeconds(1));
+            subscriber.onMessage(MESSAGE, null);
+
+            await().atMost(Duration.ofMillis(500))
+                    .untilAsserted(() -> verify(filterService, times(2)).rebuildTrie());
+        }
+    }
+
+    @Nested
+    @DisplayName("재빌드 실패")
+    class 재빌드_실패 {
+
+        @Test
+        @DisplayName("재빌드가 예외를 던져도 다음 신호는 정상 처리된다")
+        void 예외_후_다음_신호가_정상_처리된다() {
+            구독자를_준비한다(Duration.ZERO);
+            doThrow(new RuntimeException("DB 조회 실패"))
+                    .doNothing()
+                    .when(filterService)
+                    .rebuildTrie();
+
+            subscriber.onMessage(MESSAGE, null);
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(meterRegistry
+                            .get("profanity.trie.rebuild.failure")
+                            .counter()
+                            .count())
+                    .isEqualTo(1));
+
+            subscriber.onMessage(MESSAGE, null);
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> verify(filterService, times(2)).rebuildTrie());
+        }
+    }
+
+    /** 재빌드 최소 간격 계산을 흉내내기 위한 수동 진행 시계. */
+    private static final class StubClock extends Clock {
+
+        private Instant now;
+
+        private StubClock(Instant start) {
+            this.now = start;
+        }
+
+        void advance(Duration amount) {
+            now = now.plus(amount);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+    }
+}

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriberTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/redis/ProfanityTrieRefreshSubscriberTest.java
@@ -1,6 +1,7 @@
 package coffeeshout.profanity.infra.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -9,7 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import coffeeshout.profanity.application.ProfanityFilterService;
-import coffeeshout.profanity.config.ProfanityTrieRefreshProperties;
+import coffeeshout.profanity.config.ProfanityTrieRebuildProperties;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Duration;
@@ -17,8 +18,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
@@ -60,7 +59,7 @@ class ProfanityTrieRefreshSubscriberTest {
 
     private void 구독자를_준비한다(Duration minInterval) {
         subscriber = new ProfanityTrieRefreshSubscriber(
-                container, filterService, meterRegistry, clock, new ProfanityTrieRefreshProperties(minInterval));
+                container, filterService, meterRegistry, clock, new ProfanityTrieRebuildProperties(minInterval));
         subscriber.register();
     }
 
@@ -70,49 +69,80 @@ class ProfanityTrieRefreshSubscriberTest {
 
         @Test
         @DisplayName("연속 신호는 재빌드를 신호 횟수만큼 돌리지 않는다")
-        void 연속_신호가_병합된다() {
+        void 연속_신호가_병합된다() throws InterruptedException {
             구독자를_준비한다(Duration.ZERO);
+            final CountDownLatch firstEntered = new CountDownLatch(1);
+            final CountDownLatch releaseFirst = new CountDownLatch(1);
+            doAnswer(invocation -> {
+                        firstEntered.countDown();
+                        releaseFirst.await();
+                        return null;
+                    })
+                    .when(filterService)
+                    .rebuildTrie();
 
+            // 첫 신호가 실행기에 들어가 DB를 읽는 동안 나머지 19개는 병합돼야 한다.
             for (int i = 0; i < 20; i++) {
                 subscriber.onMessage(MESSAGE, null);
             }
+            assertThat(firstEntered.await(2, TimeUnit.SECONDS))
+                    .as("첫 재빌드가 DB를 읽는 중이다")
+                    .isTrue();
 
-            await().atMost(Duration.ofSeconds(2))
-                    .untilAsserted(() -> verify(filterService, times(1)).rebuildTrie());
+            verify(filterService, times(1)).rebuildTrie();
             assertThat(meterRegistry
                             .get("profanity.trie.rebuild.coalesced")
                             .counter()
                             .count())
                     .as("병합돼 버려진 신호 수가 기록된다")
                     .isGreaterThan(0);
+
+            releaseFirst.countDown();
         }
+    }
+
+    @Nested
+    @DisplayName("동시 실행")
+    class 동시_실행 {
 
         @Test
-        @DisplayName("동시 실행이 1을 넘지 않는다")
-        void 동시_실행이_1을_넘지_않는다() throws InterruptedException {
+        @DisplayName("신호 기반 재빌드는 동시 실행이 1을 넘지 않는다")
+        void 신호_기반_재빌드는_동시_실행이_1을_넘지_않는다() throws InterruptedException {
             구독자를_준비한다(Duration.ZERO);
+            final AtomicInteger invocationCount = new AtomicInteger(0);
             final AtomicInteger concurrent = new AtomicInteger(0);
             final AtomicInteger maxConcurrent = new AtomicInteger(0);
+            final CountDownLatch firstEntered = new CountDownLatch(1);
+            final CountDownLatch releaseFirst = new CountDownLatch(1);
+            final CountDownLatch secondEntered = new CountDownLatch(1);
             doAnswer(invocation -> {
-                        final int current = concurrent.incrementAndGet();
-                        maxConcurrent.updateAndGet(max -> Math.max(max, current));
-                        // 재빌드가 순간에 끝나지 않음을 흉내낸다. Thread.sleep 대신 만료되는 대기로 막는다.
-                        new CountDownLatch(1).await(20, TimeUnit.MILLISECONDS);
+                        maxConcurrent.updateAndGet(max -> Math.max(max, concurrent.incrementAndGet()));
+                        if (invocationCount.incrementAndGet() == 1) {
+                            firstEntered.countDown();
+                            releaseFirst.await();
+                        } else {
+                            secondEntered.countDown();
+                        }
                         concurrent.decrementAndGet();
                         return null;
                     })
                     .when(filterService)
                     .rebuildTrie();
 
-            final ExecutorService signalSenders = Executors.newFixedThreadPool(10);
-            for (int i = 0; i < 10; i++) {
-                signalSenders.execute(() -> subscriber.onMessage(MESSAGE, null));
-            }
-            signalSenders.shutdown();
-            signalSenders.awaitTermination(5, TimeUnit.SECONDS);
+            subscriber.onMessage(MESSAGE, null);
+            assertThat(firstEntered.await(2, TimeUnit.SECONDS))
+                    .as("첫 재빌드가 DB를 읽는 중이다")
+                    .isTrue();
 
-            await().atMost(Duration.ofSeconds(2))
-                    .untilAsserted(() -> assertThat(concurrent.get()).isZero());
+            // 플래그는 DB를 읽기 전에 이미 내려가 있어 이 신호가 두 번째 재빌드를 예약한다.
+            subscriber.onMessage(MESSAGE, null);
+
+            // 실행기 스레드가 하나뿐이라 첫 재빌드가 끝나기 전에는 두 번째가 절대 시작될 수 없다.
+            // 실행기가 여러 스레드였다면 여기서 이미 secondEntered가 열렸을 것이다.
+            assertThat(secondEntered.getCount()).isEqualTo(1);
+
+            releaseFirst.countDown();
+            assertThat(secondEntered.await(2, TimeUnit.SECONDS)).isTrue();
             assertThat(maxConcurrent.get()).isEqualTo(1);
         }
     }
@@ -156,7 +186,7 @@ class ProfanityTrieRefreshSubscriberTest {
         @Test
         @DisplayName("간격 안에 들어온 신호는 간격이 지난 뒤에 반영된다")
         void 간격_안_신호는_지연되어_반영된다() {
-            final Duration minInterval = Duration.ofMillis(400);
+            final Duration minInterval = Duration.ofSeconds(1);
             구독자를_준비한다(minInterval);
 
             subscriber.onMessage(MESSAGE, null);
@@ -167,7 +197,7 @@ class ProfanityTrieRefreshSubscriberTest {
             // 간격이 지나기 전이라 두 번째 신호는 아직 반영되지 않는다.
             verify(filterService, times(1)).rebuildTrie();
 
-            await().atMost(Duration.ofSeconds(2))
+            await().atMost(Duration.ofSeconds(3))
                     .untilAsserted(() -> verify(filterService, times(2)).rebuildTrie());
         }
 
@@ -186,6 +216,25 @@ class ProfanityTrieRefreshSubscriberTest {
             subscriber.onMessage(MESSAGE, null);
 
             await().atMost(Duration.ofMillis(500))
+                    .untilAsserted(() -> verify(filterService, times(2)).rebuildTrie());
+        }
+
+        @Test
+        @DisplayName("시계가 뒤로 뛰어도 지연은 최소 간격을 넘지 않는다")
+        void 시계가_뒤로_뛰어도_지연은_최소_간격을_넘지_않는다() {
+            final Duration minInterval = Duration.ofMillis(300);
+            구독자를_준비한다(minInterval);
+
+            subscriber.onMessage(MESSAGE, null);
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> verify(filterService, times(1)).rebuildTrie());
+
+            // NTP 스텝 조정 등으로 시계가 뒤로 뛰는 상황을 흉내낸다. 클램프가 없으면 남은 시간이
+            // minInterval + 되돌린 폭(10초)이 되어 아래 대기 시간 안에 두 번째 재빌드가 끝나지 않는다.
+            clock.advance(Duration.ofSeconds(10).negated());
+            subscriber.onMessage(MESSAGE, null);
+
+            await().atMost(Duration.ofSeconds(2))
                     .untilAsserted(() -> verify(filterService, times(2)).rebuildTrie());
         }
     }
@@ -213,6 +262,20 @@ class ProfanityTrieRefreshSubscriberTest {
             subscriber.onMessage(MESSAGE, null);
             await().atMost(Duration.ofSeconds(2))
                     .untilAsserted(() -> verify(filterService, times(2)).rebuildTrie());
+        }
+    }
+
+    @Nested
+    @DisplayName("종료")
+    class 종료 {
+
+        @Test
+        @DisplayName("종료 후 신호가 와도 예외가 새지 않는다")
+        void 종료_후_신호는_예외없이_무시된다() {
+            구독자를_준비한다(Duration.ZERO);
+            subscriber.shutdown();
+
+            assertThatNoException().isThrownBy(() -> subscriber.onMessage(MESSAGE, null));
         }
     }
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (통합 브랜치 `fix/1759-audit-pipeline`)

# 🔥 연관 이슈

- #1759 (단계 PR이라 close하지 않는다. 통합 → dev PR이 close한다)

# 🚀 작업 내용

10만 건 "전" 측정에서 트라이 재빌드가 **10,028회, 합계 2,272초** 돌았다. 회차 전체가 271초였으니 8.4배가 회차 시간 안에서 겹쳐 돈 셈이다. 재빌드 로그의 스레드 이름을 세어 보니 10,027개가 전부 달랐다.

원인은 `RedisConfig`가 `RedisMessageListenerContainer`를 만들면서 실행기를 지정하지 않은 것이다. Spring Data Redis 기본값인 `SimpleAsyncTaskExecutor`는 풀이 아니라 신호마다 스레드를 새로 만드는 실행기라 동시 실행 상한이 없다.

이번 PR은 **구독 쪽만** 고친다. 발행 쪽(`ProfanityWordManagementService`가 단어마다 발행하는 것)은 다음 PR로 뺐다.

1. **신호 병합.** `TrieRefreshNotifier.publish()`는 payload가 없고 재빌드는 늘 사전 전량을 다시 읽는 통짜 작업이라, 밀린 신호 N개와 1개가 뜻하는 바가 같다. `AtomicBoolean` 예약 플래그로 중복 신호를 버린다.
2. **재빌드 전용 단일 스레드.** 리스너 컨테이너 기본 실행기를 쓰지 않고 재빌드를 전용 스레드 하나로 몰아 동시 실행을 1로 묶는다.
3. **최소 간격 5초.** `profanity.trie.refresh.min-interval` 프로퍼티. 병합만으로는 재빌드가 쉬지 않고 붙어 돈다. 기본값 5초의 근거는 `ProfanityTrieRebuildScheduler`가 이미 매시 정각 전량 재빌드를 안전망으로 돌고 있다는 것이다. 최대 1시간 지연을 이미 받아들인 설계라 몇 초는 그 안에 넉넉히 든다. 0을 주면 간격 없이 병합만 동작한다.
4. **`profanity.trie.rebuild.coalesced` 카운터.** "후" 측정에서 신호 대비 실제 재빌드 비율을 봐야 한다.

## 플래그를 내리는 순서가 이 PR의 핵심이다

`rebuild()`는 **DB를 읽기 전에** 플래그를 내린다. 읽은 뒤에 내리면 읽는 도중 커밋된 단어를 놓친다. 읽기 전에 내리면 그 단어의 신호가 플래그를 다시 세워 한 번 더 돌게 되는데, 그게 맞는 동작이다.

이 순서를 뒤집는 돌연변이를 넣어 "DB 읽기 도중 신호" 테스트가 실제로 실패하는 것을 확인하고 원복했다.

## 회귀 테스트 7개

| 무엇을 막나 | 테스트 |
| --- | --- |
| 신호마다 재빌드 | 연속 신호 20회에 재빌드 1회 |
| 동시 실행 폭발 | 10스레드 동시 신호에 최대 동시 실행 1 |
| 읽는 도중 커밋된 단어 누락 | 읽기 중 신호가 재빌드를 한 번 더 유발 |
| 간격 무시 | 간격 안 신호가 간격 뒤에 반영 |
| 실제 대기로 간격을 재는 것 | `Clock`만 앞당겨 대기 없이 반영 |
| 예외가 플래그를 잠그는 것 | 예외 뒤 다음 신호 정상 처리 |

## 예상 효과

| | 재빌드 횟수 | CPU |
| --- | --- | --- |
| 지금 | 10,028 | 2,272초 · 8.4코어 |
| 병합만 | 약 1,200 | 271초 · 1코어 |
| 병합 + 5초 간격 | 약 54 | 약 12초 · 1코어 |

계산이고 실측이 아니다. 같은 조건 "후" 측정으로 확인한다.

# 💬 리뷰 중점사항

- **`times(1)` 단언이 과한지.** `연속_신호가_병합된다`가 재빌드 정확히 1회를 단언한다. 20회 루프가 끝나기 전에 실행기 스레드가 첫 재빌드를 끝내면 두 번째가 예약돼 실패할 수 있다. 로컬 8회 연속 통과지만 CI 부하에서는 갈릴 수 있어, 테스트 이름이 말하는 "신호 횟수만큼 돌지 않는다"에 맞춰 20 미만 단언으로 바꾸는 쪽이 안전해 보인다.
- **`new CountDownLatch(1).await(20ms)`가 `Thread.sleep` 우회인지.** PMD `NoThreadSleep` 규칙을 피하려고 넣었는데 내려가지 않는 래치라 사실상 같은 대기다. 규칙의 의도를 지키려면 다른 테스트처럼 실제 핸드셰이크 래치로 바꾸는 게 맞는지 봐 달라.
- **`StubClock`이 또 복제됐다.** 저장소에 이미 셋이 있고 `:test-support`로 옮기는 건 별도 작업으로 잡혀 있다. 이번엔 그대로 두는 게 맞는지.
- **최소 간격 기준을 재빌드 "시작" 시점으로 잡았다.** 완료 시점이 아니다. 재빌드가 227ms라 5초 대비 오차가 작다는 판단인데 이의 있으면 말해 달라.
- **`@PreDestroy` 뒤 늦은 신호.** `shutdownNow()` 이후 신호가 오면 `schedule()`이 `RejectedExecutionException`을 던져 리스너 스레드로 샌다. 종료 구간이라 두고 봤는데 잡아야 하는지.
- 이 컨테이너에 붙은 리스너는 지금 이 하나뿐이라 다른 소비자에 영향이 없다.

https://claude.ai/code/session_01M4BvS9q4PUiVRRqEnxN4tx
