### PR TITLE
[chore] 닉네임 검열 큐 적체 알림 규칙 추가

### DIFF
--- a/backend/docker/monitoring/conf/rules/alerts-app.yml
+++ b/backend/docker/monitoring/conf/rules/alerts-app.yml
@@ -9,6 +9,7 @@
 #   ip_block_request_blocked_total      차단된 요청 카운터
 #   login_start_total / login_success_total  라벨: provider, job — LoginMetricService(앱 코드) 신설
 #     (예외: LoginSuccessDroppedToZero는 기존 메트릭으로 잡히지 않아 전용 카운터를 도입했다)
+#   nickname_audit_unaudited_queue      닉네임 AI 검열 회차 시작 시점의 미검열 적체량 (ProfanityAuditService)
 #
 # ⚠️ 임계값은 전부 베이스라인 미측정 상태의 보수적 추정치다(ADR-0026 트레이드오프).
 #    배포 전 Prometheus API로 정상 범위를 재고, 초기엔 오탐을 줄이는 방향(높게)으로 둔다.
@@ -107,3 +108,35 @@ groups:
         annotations:
           summary: "{{ $labels.provider }} 로그인 성공 0 ({{ $labels.job }}) — 시도는 계속됨"
           description: "최근 로그인 시도는 있으나 성공이 없다. redirect_uri(스킴/호스트)·provider 콘솔 등록·시크릿을 점검. 여러 provider 동시 발생 시 프록시/baseUrl 의심."
+
+      # 닉네임 AI 검열 큐 적체 — 등록은 제한이 없고 처리만 상한에 묶여 있어, 유입이 처리량을 넘으면
+      # 큐가 단조 증가한다. 게이지는 12시간 주기 회차가 시작할 때만 갱신돼 회차 사이 값이 그대로
+      # 유지되므로 for가 짧아도 놓치지 않는다.
+      # blue/green 두 인스턴스 중 분산 락을 잡은 쪽만 게이지를 갱신하고 나머지는 0에 머물러
+      # max()로 활성 인스턴스 값을 고른다(OutboxDeadLetterHigh와 같은 이유).
+      # 앱 재기동 직후에는 게이지가 0으로 시작해 다음 회차까지 최대 12시간 알림이 해제된 상태가 된다.
+      # 임계 1만 — 하루 처리량 상한이 그 언저리다. 무료 티어 RPD 500에 배치 100이면 5만 건이지만,
+      # 회차 예산 10분에 레이트리미터가 13초당 1회만 허용해 회차당 약 4600건, 하루 두 회차로 약
+      # 9200건이 실제 상한이다. 1만 건이 남아 있으면 하루 안에 큐를 못 비운다.
+      # ⚠️ prod 적체 베이스라인 미측정. 실측 후 재조정한다.
+      - alert: NicknameAuditQueueBacklogHigh
+        expr: max by (job) (nickname_audit_unaudited_queue{job="prod-app"}) > 10000
+        for: 10m
+        labels:
+          severity: warning
+          incident_group: nickname-audit-backlog
+        annotations:
+          summary: "닉네임 검열 큐 적체 (> 1만, {{ $labels.job }})"
+          description: "미검열 닉네임이 {{ $value }}건. 하루 처리량을 넘어 큐가 줄지 않는 상태. 검열 회차 로그와 Gemini 쿼터를 확인."
+
+      # 임계 5만 — 무료 티어 하루 요청 상한(RPD 500 × 배치 100)이라, 쿼터를 다 써도 하루에 비울 수 없는 양이다.
+      # 위 warning과 같은 인시던트라 incident_group으로 묶어 LLM 분석을 한 번만 쓴다(#1598).
+      - alert: NicknameAuditQueueBacklogCritical
+        expr: max by (job) (nickname_audit_unaudited_queue{job="prod-app"}) > 50000
+        for: 10m
+        labels:
+          severity: critical
+          incident_group: nickname-audit-backlog
+        annotations:
+          summary: "닉네임 검열 큐 적체 심각 (> 5만, {{ $labels.job }})"
+          description: "미검열 닉네임이 {{ $value }}건. 하루 쿼터를 전부 써도 비우지 못하는 양. 회차 예산·배치 크기 상향 또는 쿼터 증설을 검토."

--- a/backend/docker/monitoring/conf/rules/alerts-app.yml
+++ b/backend/docker/monitoring/conf/rules/alerts-app.yml
@@ -110,33 +110,39 @@ groups:
           description: "최근 로그인 시도는 있으나 성공이 없다. redirect_uri(스킴/호스트)·provider 콘솔 등록·시크릿을 점검. 여러 provider 동시 발생 시 프록시/baseUrl 의심."
 
       # 닉네임 AI 검열 큐 적체 — 등록은 제한이 없고 처리만 상한에 묶여 있어, 유입이 처리량을 넘으면
-      # 큐가 단조 증가한다. 게이지는 12시간 주기 회차가 시작할 때만 갱신돼 회차 사이 값이 그대로
-      # 유지되므로 for가 짧아도 놓치지 않는다.
+      # 큐가 단조 증가한다.
       # blue/green 두 인스턴스 중 분산 락을 잡은 쪽만 게이지를 갱신하고 나머지는 0에 머물러
       # max()로 활성 인스턴스 값을 고른다(OutboxDeadLetterHigh와 같은 이유).
+      #
+      # for: 13h는 오타가 아니다. 잡으려는 신호가 적체량이 아니라 "회차가 지나도 안 빠진다"는
+      # 사실이라서다. 하루 처리 상한은 9200건이라(회차 예산 10분 ÷ 레이트리미터 13초/콜 = 회차당
+      # 약 4600건, cron 12시간 주기로 하루 두 회차) 100건은 한 회차에 다 빠지는 양이다. 게이지가
+      # 회차 시작 때만 갱신돼 회차 사이 12시간 동안 값이 고정되므로, 13시간을 버티면 회차가 통째로
+      # 지나고도 큐가 그대로라는 뜻이 된다. 정상이면 회차 직후 값이 0으로 떨어져 for를 못 채운다.
+      # for를 줄이면 이 판정이 사라지고 평소 적체량을 재는 룰이 된다.
+      #
+      # 임계 100·500은 현재 유입 수준(하루 약 10건) 기준이다. 정상이면 회차마다 비워져 두 자릿수를
+      # 넘지 않으므로, 100건은 열흘치, 500건은 쉰날치 유입이 안 빠지고 쌓인 양이다. 처리 상한
+      # 9200건에 맞춘 값이 아니라서 유입이 늘면 함께 올린다.
       # 앱 재기동 직후에는 게이지가 0으로 시작해 다음 회차까지 최대 12시간 알림이 해제된 상태가 된다.
-      # 임계 1만 — 하루 처리량 상한이 그 언저리다. 무료 티어 RPD 500에 배치 100이면 5만 건이지만,
-      # 회차 예산 10분에 레이트리미터가 13초당 1회만 허용해 회차당 약 4600건, 하루 두 회차로 약
-      # 9200건이 실제 상한이다. 1만 건이 남아 있으면 하루 안에 큐를 못 비운다.
-      # ⚠️ prod 적체 베이스라인 미측정. 실측 후 재조정한다.
       - alert: NicknameAuditQueueBacklogHigh
-        expr: max by (job) (nickname_audit_unaudited_queue{job="prod-app"}) > 10000
-        for: 10m
+        expr: max by (job) (nickname_audit_unaudited_queue{job="prod-app"}) > 100
+        for: 13h
         labels:
           severity: warning
           incident_group: nickname-audit-backlog
         annotations:
-          summary: "닉네임 검열 큐 적체 (> 1만, {{ $labels.job }})"
-          description: "미검열 닉네임이 {{ $value }}건. 하루 처리량을 넘어 큐가 줄지 않는 상태. 검열 회차 로그와 Gemini 쿼터를 확인."
+          summary: "닉네임 검열 큐 적체 (> 100, {{ $labels.job }})"
+          description: "미검열 닉네임 {{ $value }}건이 검열 회차를 하나 넘기고도 남아 있습니다. 회차가 아예 안 돌거나(스케줄러·분산 락) 배치마다 실패하는 상태. 검열 회차 로그와 Gemini 쿼터를 확인."
 
-      # 임계 5만 — 무료 티어 하루 요청 상한(RPD 500 × 배치 100)이라, 쿼터를 다 써도 하루에 비울 수 없는 양이다.
+      # 임계 500 — warning을 놓쳤거나 처리가 훨씬 오래 멎은 상태다.
       # 위 warning과 같은 인시던트라 incident_group으로 묶어 LLM 분석을 한 번만 쓴다(#1598).
       - alert: NicknameAuditQueueBacklogCritical
-        expr: max by (job) (nickname_audit_unaudited_queue{job="prod-app"}) > 50000
-        for: 10m
+        expr: max by (job) (nickname_audit_unaudited_queue{job="prod-app"}) > 500
+        for: 13h
         labels:
           severity: critical
           incident_group: nickname-audit-backlog
         annotations:
-          summary: "닉네임 검열 큐 적체 심각 (> 5만, {{ $labels.job }})"
-          description: "미검열 닉네임이 {{ $value }}건. 하루 쿼터를 전부 써도 비우지 못하는 양. 회차 예산·배치 크기 상향 또는 쿼터 증설을 검토."
+          summary: "닉네임 검열 큐 적체 심각 (> 500, {{ $labels.job }})"
+          description: "미검열 닉네임이 {{ $value }}건. 검열 회차가 오래 멎어 있었다는 뜻입니다. 스케줄러 실행 여부와 분산 락(lock:nickname-audit) 잔류를 확인."


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1775

# 🚀 작업 내용

1. `alerts-app.yml`의 `app-symptoms` 그룹에 닉네임 검열 큐 적체 알림 두 개를 추가했다. `nickname_audit_unaudited_queue` 게이지는 이미 노출되고 있었지만 임계값 규칙이 없어 큐가 늘어도 아무도 몰랐다. 등록은 제한이 없고 처리만 회차 예산과 API 쿼터에 묶여 있어, 유입이 처리량을 넘으면 적체가 단조 증가한다.

   | 알림 | severity | 임계 | `for` |
   | --- | --- | --- | --- |
   | `NicknameAuditQueueBacklogHigh` | warning | 100 | 13h |
   | `NicknameAuditQueueBacklogCritical` | critical | 500 | 13h |

2. **임계값은 현재 유입 수준(하루 약 10건)에 맞췄다.** 정상이면 회차마다 비워져 두 자릿수를 넘지 않으므로 100건은 열흘치, 500건은 쉰날치 유입이 안 빠지고 쌓인 양이다. 하루 처리 상한 9,200건(회차 예산 10분 ÷ 레이트리미터 13초당 1회 = 회차당 약 4,600건, cron 12시간 주기로 하루 두 회차)에 맞춘 값이 아니라서, 유입이 늘면 함께 올려야 한다.

3. **`for: 13h`는 오타가 아니다.** 잡으려는 신호가 적체량이 아니라 큐가 빠지지 않는다는 사실이다. 100건은 한 회차가 4,600건을 처리하므로 한 번에 다 빠지는 양이고, 그 자체로는 위험하지 않다. cron이 12시간 주기이므로 13시간을 버텼다는 것은 회차가 통째로 지나고도 큐가 그대로라는 뜻이 된다. 정상이면 회차 직후 값이 0으로 떨어져 `for`를 못 채우고 해제된다.

   게이지가 회차 시작 때만 갱신돼 회차 사이 12시간 동안 값이 고정되는 성질이 여기서 판정 근거가 된다. `for`를 줄이면 이 판정이 사라지고 평소 적체량을 재는 룰이 되므로, 나중에 값을 건드리려는 사람을 위해 주석에 이유를 적어뒀다.

4. 집계는 `max by (job)`으로 잡았다. blue/green 두 인스턴스 중 분산 락을 잡은 쪽만 게이지를 갱신하고 나머지는 0에 머문다. `OutboxDeadLetterHigh`가 같은 이유로 쓰는 패턴이다.

5. 두 알림에 `incident_group: nickname-audit-backlog`를 달았다. 같은 인시던트를 두 단계로 보는 것이라 zzol-bot LLM 분석이 한 번만 돌게 한다(#1598과 같은 처리).

6. `alertmanager.yml`은 건드리지 않았다. warning은 `slack-default`, critical은 `severity = "critical"` 매처로 `slack-critical`을 타고, 둘 다 `zzolbot-enrich`로 미러링된다. severity 라벨만 맞으면 기존 채널로 흘러가서 라우팅을 추가할 이유가 없다.

## 로컬 검증

`monitoring-rules-ci.yml`이 도는 검사 두 개를 그대로 돌렸다. 둘 다 통과했다.

```
$ promtool check rules backend/docker/monitoring/conf/rules/*.yml   # v2.49.1, CI와 동일 버전
Checking backend/docker/monitoring/conf/rules/alerts-app.yml
  SUCCESS: 7 rules found
... (6개 파일 전부 SUCCESS)

$ python3 .github/scripts/check-alert-job-scope.py \
    backend/docker/monitoring/conf/rules backend/docker/monitoring/conf/loki-rules
✅ 알림 룰 32개 job 스코프 검사 통과 (예외 2건)
```

# 💬 리뷰 중점사항

- **임계 100·500은 지금 트래픽에서만 뜻이 있다.** 하루 약 10건이라는 현재 유입을 기준으로 잡은 값이라, 유입이 늘면 정상 상태에서도 임계를 넘게 된다. 트래픽이 오르면 함께 올려야 한다는 점을 주석에 적어뒀지만 놓치기 쉬운 종류라 봐주면 좋겠다.
- **앱 재기동 직후 12시간 구멍이 있다.** 게이지는 회차가 시작할 때만 갱신되고 `AtomicLong`이 0에서 시작한다. 배포 직후에는 적체가 실제로 많아도 다음 회차(최대 12시간 뒤)까지 알림이 해제된 상태로 남는다. `for: 13h`와 겹치면 배포가 잦은 기간에는 알림이 아예 안 뜰 수도 있다. 고치려면 앱 코드(기동 시 1회 count 또는 별도 주기 갱신)를 손대야 해서 이 PR 범위 밖으로 뒀다. 후속 이슈로 뺄지 봐주면 좋겠다.

https://claude.ai/code/session_018cviyWqATR2GREUeUPZALB
