### PR TITLE
[fix] 랭킹 수집 때 사전에 걸리는 회원 닉네임도 교체한다

### DIFF
--- a/backend/user/src/main/java/coffeeshout/user/application/service/UserNicknameCleanupService.java
+++ b/backend/user/src/main/java/coffeeshout/user/application/service/UserNicknameCleanupService.java
@@ -59,18 +59,13 @@ public class UserNicknameCleanupService {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onProfanityWordBlocked(ProfanityWordBlockedEvent event) {
-        final Optional<UserNickname> blocked = toNickname(event.word());
-        if (blocked.isEmpty()) {
-            return;
-        }
-        final List<User> users = userRepository.findAllByNickname(blocked.get());
-
-        if (users.isEmpty()) {
-            return;
-        }
-
-        log.info("비속어 차단으로 닉네임 일괄 교체: word={}, userCount={}", event.word(), users.size());
-        replaceAll(users);
+        toNickname(event.word())
+                .map(userRepository::findAllByNickname)
+                .filter(users -> !users.isEmpty())
+                .ifPresent(users -> {
+                    log.info("비속어 차단으로 닉네임 일괄 교체: word={}, userCount={}", event.word(), users.size());
+                    replaceAll(users);
+                });
     }
 
     private void replaceAll(List<User> users) {

--- a/backend/user/src/main/java/coffeeshout/user/application/service/UserNicknameCleanupService.java
+++ b/backend/user/src/main/java/coffeeshout/user/application/service/UserNicknameCleanupService.java
@@ -1,13 +1,17 @@
 package coffeeshout.user.application.service;
 
 import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.global.nickname.NicknamesCollectedEvent;
+import coffeeshout.global.nickname.ProfanityChecker;
 import coffeeshout.global.nickname.ProfanityWordBlockedEvent;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.UserNickname;
 import coffeeshout.user.domain.repository.UserRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,29 +25,69 @@ public class UserNicknameCleanupService {
 
     private final UserRepository userRepository;
     private final NicknameDefaultGenerator nicknameDefaultGenerator;
+    private final ProfanityChecker profanityChecker;
+
+    /**
+     * 랭킹 수집 회차마다 사전에 걸리는 회원 프로필 닉네임을 생성 닉네임으로 교체한다 (#1777).
+     *
+     * <p>{@link #onProfanityWordBlocked}만으로는 부족하다. 그쪽은 차단된 단어와 <b>똑같은</b> 닉네임만 찾는데,
+     * AI 사후 감사는 닉네임 전체가 아니라 비속어 <b>조각</b>을 사전에 등록한다. "씨발이닷"이 FLAGGED면 "씨발"이
+     * 등록되고, 정작 그 회원의 닉네임은 남는다. 여기서는 사전 조회를 {@link ProfanityChecker}에 맡겨
+     * 조각 일치와 정규화(leet 치환·특수문자 제거)까지 같은 기준으로 판정한다.
+     *
+     * <p>차단 시점이 아니라 수집 시점에 도는 이유는 트라이 갱신이 Redis pub/sub이라 비동기이기 때문이다.
+     * 단어를 등록한 직후에는 이 인스턴스의 트라이에 그 단어가 아직 없을 수 있다.
+     */
+    @EventListener
+    @Transactional
+    public void onNicknamesCollected(NicknamesCollectedEvent event) {
+        final List<User> targets = event.nicknames().stream()
+                .filter(profanityChecker::contains)
+                .map(this::toNickname)
+                .flatMap(Optional::stream)
+                .flatMap(nickname -> userRepository.findAllByNickname(nickname).stream())
+                .toList();
+
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        log.info("랭킹 검열로 회원 닉네임 일괄 교체: userCount={}", targets.size());
+        replaceAll(targets);
+    }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onProfanityWordBlocked(ProfanityWordBlockedEvent event) {
-        final UserNickname blocked;
-        try {
-            blocked = new UserNickname(event.word());
-        } catch (BusinessException e) {
+        final Optional<UserNickname> blocked = toNickname(event.word());
+        if (blocked.isEmpty()) {
             return;
         }
-        final List<User> users = userRepository.findAllByNickname(blocked);
+        final List<User> users = userRepository.findAllByNickname(blocked.get());
 
         if (users.isEmpty()) {
             return;
         }
 
         log.info("비속어 차단으로 닉네임 일괄 교체: word={}, userCount={}", event.word(), users.size());
+        replaceAll(users);
+    }
 
+    private void replaceAll(List<User> users) {
         for (final User user : users) {
             final UserNickname newNickname = new UserNickname(nicknameDefaultGenerator.generate());
             user.changeNickname(newNickname);
             userRepository.save(user);
             log.debug("닉네임 교체 완료: userId={}, newNickname={}", user.getId(), newNickname.value());
+        }
+    }
+
+    /** 회원 닉네임이 될 수 없는 값(공백·길이 초과)은 교체 대상에서 뺀다. 예외를 그대로 올리면 같은 이벤트의 다른 리스너까지 함께 죽는다. */
+    private Optional<UserNickname> toNickname(String value) {
+        try {
+            return Optional.of(new UserNickname(value));
+        } catch (BusinessException e) {
+            return Optional.empty();
         }
     }
 }

--- a/backend/user/src/test/java/coffeeshout/user/application/service/UserNicknameCleanupServiceTest.java
+++ b/backend/user/src/test/java/coffeeshout/user/application/service/UserNicknameCleanupServiceTest.java
@@ -8,11 +8,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import coffeeshout.fixture.UserFixture;
+import coffeeshout.global.nickname.NicknamesCollectedEvent;
+import coffeeshout.global.nickname.ProfanityChecker;
 import coffeeshout.global.nickname.ProfanityWordBlockedEvent;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.UserNickname;
 import coffeeshout.user.domain.repository.UserRepository;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,6 +33,9 @@ class UserNicknameCleanupServiceTest {
 
     @Mock
     NicknameDefaultGenerator nicknameDefaultGenerator;
+
+    @Mock
+    ProfanityChecker profanityChecker;
 
     @InjectMocks
     UserNicknameCleanupService userNicknameCleanupService;
@@ -109,6 +115,82 @@ class UserNicknameCleanupServiceTest {
 
                 then(userRepository).should(never()).findAllByNickname(any());
                 then(userRepository).should(never()).save(any());
+            }
+        }
+    }
+
+    @Nested
+    class 랭킹_닉네임_수집_이벤트를_수신했을_때 {
+
+        @Nested
+        class 사전에_걸리는_닉네임이_없으면 {
+
+            @Test
+            void 저장소를_조회하지_않는다() {
+                userNicknameCleanupService.onNicknamesCollected(new NicknamesCollectedEvent(Set.of("용감한호랑이")));
+
+                then(userRepository).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        class 사전에_걸리는_닉네임이_있으면 {
+
+            @Test
+            void 회원_프로필_닉네임을_생성_닉네임으로_교체한다() {
+                final User 회원 = UserFixture.저장된_회원(1L, "씨발이닷");
+                given(profanityChecker.contains("씨발이닷")).willReturn(true);
+                given(userRepository.findAllByNickname(new UserNickname("씨발이닷")))
+                        .willReturn(List.of(회원));
+                given(nicknameDefaultGenerator.generate()).willReturn("빠른여우");
+
+                userNicknameCleanupService.onNicknamesCollected(new NicknamesCollectedEvent(Set.of("씨발이닷")));
+
+                assertThat(회원.getNickname().value()).isEqualTo("빠른여우");
+            }
+
+            @Test
+            void 교체한_회원을_저장한다() {
+                final User 회원 = UserFixture.저장된_회원(1L, "씨발이닷");
+                given(profanityChecker.contains("씨발이닷")).willReturn(true);
+                given(userRepository.findAllByNickname(new UserNickname("씨발이닷")))
+                        .willReturn(List.of(회원));
+                given(nicknameDefaultGenerator.generate()).willReturn("빠른여우");
+
+                userNicknameCleanupService.onNicknamesCollected(new NicknamesCollectedEvent(Set.of("씨발이닷")));
+
+                then(userRepository).should(times(1)).save(회원);
+            }
+
+            @Test
+            void 사전에_안_걸리는_닉네임은_조회하지_않는다() {
+                given(profanityChecker.contains("씨발이닷")).willReturn(true);
+                given(profanityChecker.contains("용감한호랑이")).willReturn(false);
+                given(userRepository.findAllByNickname(new UserNickname("씨발이닷")))
+                        .willReturn(List.of());
+
+                userNicknameCleanupService.onNicknamesCollected(new NicknamesCollectedEvent(Set.of("씨발이닷", "용감한호랑이")));
+
+                then(userRepository).should(never()).findAllByNickname(new UserNickname("용감한호랑이"));
+            }
+        }
+
+        @Nested
+        class 닉네임_길이를_넘는_이름이_섞여_있으면 {
+
+            @Test
+            void 그_이름만_건너뛰고_나머지를_교체한다() {
+                final User 회원 = UserFixture.저장된_회원(1L, "씨발이닷");
+                final String 길이초과이름 = "열한글자닉네임이에요이";
+                given(profanityChecker.contains(길이초과이름)).willReturn(true);
+                given(profanityChecker.contains("씨발이닷")).willReturn(true);
+                given(userRepository.findAllByNickname(new UserNickname("씨발이닷")))
+                        .willReturn(List.of(회원));
+                given(nicknameDefaultGenerator.generate()).willReturn("빠른여우");
+
+                userNicknameCleanupService.onNicknamesCollected(new NicknamesCollectedEvent(Set.of("씨발이닷", 길이초과이름)));
+
+                assertThat(회원.getNickname().value()).isEqualTo("빠른여우");
             }
         }
     }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1777

# 🚀 작업 내용

1. `NicknamesCollectedEvent`를 받는 리스너를 `UserNicknameCleanupService`에 추가해, 사전에 걸리는 회원 프로필 닉네임을 `NicknameDefaultGenerator`가 만든 이름으로 교체한다.
2. 두 리스너가 공유하는 교체 루프를 `replaceAll`로, 닉네임 변환 가드를 `toNickname`으로 뽑았다. 기존 `onProfanityWordBlocked`의 동작은 그대로다.
3. 회귀 테스트 4개를 `UserNicknameCleanupServiceTest`에 추가했다.

## 무엇이 깨져 있었나

이슈는 "user 모듈에 사후 감사 경로가 연결돼 있지 않다"고 적었는데, 실제로는 `ProfanityWordBlockedEvent`를 받는 `UserNicknameCleanupService`가 이미 있었다. **문제는 그 리스너가 차단된 단어와 똑같은 닉네임만 찾는다는 것이다.**

AI 사후 감사는 닉네임 전체가 아니라 비속어 조각을 등록한다(`ProfanityAuditBatchProcessor.resolveBlockWords`). "씨발이닷"이 FLAGGED면 사전에 들어가는 건 "씨발"이고, `findAllByNickname("씨발")`은 아무도 찾지 못한다. 정작 감사를 유발한 그 회원이 남는다.

여기에 하나 더 있다. 룰렛 당첨 랭킹은 `USER.nickname`을 직접 읽는다(`QueryDslDashboardStatisticsRepository.findTopWinnersBetween`). `PlayerNameRankingCleanupService`가 고치는 `PlayerEntity.playerName`은 미니게임 랭킹에만 쓰인다. 그래서 룰렛 랭킹은 표시조차 교체되지 않고 있었다.

## 설계 판단 — 어디에 둘 것인가

이슈가 제시한 두 안을 비교했다.

**① user 모듈에 리스너를 하나 더 붙인다 (채택)**

`NicknamesCollectedEvent`는 `:common`에 있고 발행처는 `:admin`이라, `:user`가 구독해도 의존 방향이 바뀌지 않는다. 회원 닉네임 교체 규칙(전역 중복 제약 없음, `NicknameDefaultGenerator`)이 user 모듈 안에 남는다. 리스너를 새 클래스로 만들지 않고 이미 같은 일을 하는 `UserNicknameCleanupService`에 넣어, 회원 닉네임 정리 책임을 한 클래스에 모았다.

**② 기존 `PlayerNameRankingCleanupService`를 확장한다 (반려)**

`:room`이 `:user`를 의존하므로 컴파일은 된다. 그래도 반려한 이유는 둘이다. 첫째, room 서비스가 user 애그리거트를 직접 고치면 회원 닉네임 불변식이 user 모듈 밖으로 샌다. 둘째, 두 교체 규칙이 다르다. 플레이어 이름은 `PlayerNameGenerator`가 방 안 중복을 피해 만들고, 회원 닉네임은 전역 제약이 없어 `NicknameDefaultGenerator`를 쓴다. 한 루프에 넣으면 방 단위 조회와 회원 단위 조회가 한 메서드에서 섞인다.

## 왜 차단 시점이 아니라 수집 시점인가

`ProfanityWordBlockedEvent` 쪽을 조각 일치로 고치는 안도 검토했다가 접었다. 트라이 갱신이 Redis pub/sub이라 비동기다(`ProfanityWordManagementService.add` → `TrieRefreshNotifier.publish`). 단어를 등록한 직후 `AFTER_COMMIT`에서 `ProfanityChecker.contains`를 불러도 그 인스턴스의 트라이에 방금 등록한 단어가 아직 없을 수 있다. 반면 랭킹 수집 스케줄러는 12시간 주기라 트라이가 이미 최신이다. room 쪽 리스너가 같은 이벤트에 붙어 있는 이유도 여기라고 본다.

기존 `onProfanityWordBlocked`는 그대로 남겼다. 조각이 아니라 닉네임 전체가 차단되는 경우(운영자 수동 차단, 유효 조각이 없어 전체를 폴백 차단하는 경우)에는 즉시 교체가 이득이다.

## 유니크 제약 확인

`app_user`에 닉네임 유니크 제약은 **없다**. `V14__add_user_and_oauth.sql`의 유니크 키는 `uk_app_user_user_code` 하나고, 이후 마이그레이션에서도 닉네임에 인덱스나 제약이 붙지 않았다. 생성 닉네임이 기존 닉네임과 겹쳐도 충돌하지 않으므로 별도 회피 로직을 두지 않았다.

## 검증

```
./gradlew spotlessCheck pmdMain pmdTest pmdTestFixtures   # BUILD SUCCESSFUL
./gradlew :user:test :room:test                            # BUILD SUCCESSFUL
```

회귀 테스트는 red를 먼저 확인했다. 리스너를 빈 메서드로 둔 상태에서 새 테스트 4개 중 4개가 실패했고, 구현 뒤 10개 모두 통과한다.

돌연변이 검증도 돌렸다(`.claude/rules/testing.md`).

| 망가뜨린 것 | 실패한 테스트 |
| --- | --- |
| `filter(profanityChecker::contains)` 무력화 | 2개 |
| `replaceAll(targets)` 호출 제거 | 3개 |

# 💬 리뷰 중점사항

- 리스너를 새 클래스로 빼지 않고 `UserNicknameCleanupService`에 넣은 선택이 괜찮은지 봐달라. 두 트리거가 한 클래스에 있는 게 읽기 불편하면 나눈다.
- `toNickname`이 `BusinessException`을 삼키고 건너뛴다. 랭킹 수집 닉네임에는 10자를 넘는 값이 들어올 일이 없지만, 예외가 그대로 올라가면 같은 이벤트를 구독하는 room 리스너까지 같이 죽어서 가드를 뒀다.
- 룰렛 랭킹이 `USER.nickname`을 읽는다는 사실은 이 PR에서 고치지 않았다. `PlayerNameRankingCleanupService`가 룰렛 랭킹 표시에는 영향을 주지 못한다는 뜻인데, 이번 수정으로 회원 닉네임 자체가 바뀌므로 결과적으로 해소된다. 별도로 정리할 값어치가 있는지 의견을 듣고 싶다.

https://claude.ai/code/session_018cviyWqATR2GREUeUPZALB
